### PR TITLE
Use built-in type for 64-bit integer type provided by Microsoft compiler for coin

### DIFF
--- a/include/coin/config_coinutils_default.h
+++ b/include/coin/config_coinutils_default.h
@@ -16,22 +16,12 @@
 /* Release Version number of project */
 #define COINUTILS_VERSION_RELEASE 9999
 
-/*
-  Define to 64bit integer types. Note that MS does not provide __uint64.
-
-  Microsoft defines types in BaseTsd.h, part of the Windows SDK. Given
-  that this file only gets used in the Visual Studio environment, it
-  seems to me we'll be better off simply including it and using the
-  types MS defines. But since I have no idea of history here, I'll leave
-  all of this inside the guard for MSC_VER >= 1200. If you're reading this
-  and have been developing in MSVS long enough to know, fix it.  -- lh, 100915 --
-*/
-#if _MSC_VER >= 1200
-# include <BaseTsd.h>
-# define COIN_INT64_T INT64
-# define COIN_UINT64_T UINT64
+/* Use 64-bit integer type provided by Microsoft */
+#ifdef _MSC_VER
+# define COIN_INT64_T __int64
+# define COIN_UINT64_T unsigned __int64
   /* Define to integer type capturing pointer */
-# define COIN_INTPTR_T ULONG_PTR
+# define COIN_INTPTR_T intptr_t
 #else
 # define COIN_INT64_T long long
 # define COIN_UINT64_T unsigned long long


### PR DESCRIPTION
This patch allows coin to use built-in type for 64-bit integer provided by Microsoft Compiler. The original code includes directly the file **BaseTsd.h** which should not be included outside **Windows.h**.
For this reason, it prevents to compilation if **_WIN32_WINNT** is >= 0x0600 because of this part of code:

```c++
#if _WIN32_WINNT >= 0x0600 || (defined(__cplusplus) && defined(WINDOWS_ENABLE_CPLUSPLUS))
//...
#define MAXUINT     ((UINT)~((UINT)0))
#define MAXINT      ((INT)(MAXUINT >> 1))
//...
#endif
```
Both **UINT** and **INT** are not defined in this header.
