### PR TITLE
Fix setting random seed for FMMMLayout

### DIFF
--- a/src/ogdf/energybased/FMMMLayout.cpp
+++ b/src/ogdf/energybased/FMMMLayout.cpp
@@ -1173,11 +1173,11 @@ void FMMMLayout::create_initial_placement(Graph& G, NodeArray<NodeAttributes>& A
 		create_initial_placement_uniform_grid(G, A);
 		break;
 	case FMMMOptions::InitialPlacementForces::RandomTime:
-		srand((unsigned int) time(nullptr));
+		setSeed((unsigned int) time(nullptr));
 		create_initial_placement_random(G, A);
 		break;
 	case FMMMOptions::InitialPlacementForces::RandomRandIterNr:
-		srand(randSeed());
+		setSeed(randSeed());
 		create_initial_placement_random(G, A);
 	}
 

--- a/src/ogdf/energybased/fmmm/Multilevel.cpp
+++ b/src/ogdf/energybased/fmmm/Multilevel.cpp
@@ -51,7 +51,7 @@ void Multilevel::create_multilevel_representations(
 	Array<EdgeArray<EdgeAttributes>*> &E_mult_ptr,
 	int & max_level)
 {
-	srand(rand_seed);
+	setSeed(rand_seed);
 	G_mult_ptr[0] = &G; //init graph at level 0 to the original undirected simple
 	A_mult_ptr[0] = &A; //and loopfree connected graph G/A/E
 	E_mult_ptr[0] = &E;

--- a/src/ogdf/energybased/fmmm/Set.cpp
+++ b/src/ogdf/energybased/fmmm/Set.cpp
@@ -51,7 +51,7 @@ Set::~Set()
 
 void Set::set_seed(int rand_seed)
 {
-	srand(rand_seed);
+	setSeed(rand_seed);
 }
 
 


### PR DESCRIPTION
FMMMLayout should produce same result for same random seed, but, it doesn't.
I've fixed it.

test code

```c++
#include <ogdf/basic/Graph.h>
#include <ogdf/basic/graph_generators.h>
#include <ogdf/energybased/FMMMLayout.h>

using namespace ogdf;

int main()
{
  Graph G;
  randomSimpleGraph(G, 10, 20);

  for (int i = 0; i < 10; ++i) {
    GraphAttributes GA(G, GraphAttributes::nodeGraphics |
        GraphAttributes::edgeGraphics |
        GraphAttributes::nodeLabel |
        GraphAttributes::nodeStyle |
        GraphAttributes::edgeType |
        GraphAttributes::edgeArrow |
        GraphAttributes::edgeStyle);

    FMMMLayout layout;
    layout.randSeed(42);
    layout.initialPlacementForces(FMMMOptions::InitialPlacementForces::RandomRandIterNr);
    layout.call(GA);

    auto v = G.firstNode();
    std::cout << GA.x(v) << ", " << GA.y(v) << std::endl;
  }

  return 0;
}
```

actual results

```
97, 68
66, 91
79, 91
69, 60
72, 58
78, 86
61, 67
74, 83
81, 82
89, 68
```

expected result

```
97, 68
97, 68
97, 68
97, 68
97, 68
97, 68
97, 68
97, 68
97, 68
97, 68
```