### PR TITLE
Fix for compilation with MingW32

### DIFF
--- a/src/ogdf/basic/System.cpp
+++ b/src/ogdf/basic/System.cpp
@@ -73,7 +73,7 @@
 
 static inline void cpuid(int CPUInfo[4], int infoType)
 {
-#if defined(OGDF_SYSTEM_WINDOWS)
+#if defined(OGDF_SYSTEM_WINDOWS) && !defined(__GNUC__)
 	__cpuid(CPUInfo, infoType);
 #else
 	uint32_t a = 0;


### PR DESCRIPTION
Compiling with MingW (5.3.0) caused an error by duplicate macro definition of **__cpuid** (included from **intrin.h** and **cpuid.h**)

*src\ogdf\basic\System.cpp:77:27: error: macro "__cpuid" requires 5 arguments, but only 2 given*