### PR TITLE
Explicitly convert lamda to std::function (Fix GCC 4.8.4 compillation)

### DIFF
--- a/src/ogdf/basic/extended_graph_alg.cpp
+++ b/src/ogdf/basic/extended_graph_alg.cpp
@@ -42,9 +42,10 @@ namespace ogdf {
 // Recursive call for testing C-connectivity.
 bool cConnectTest(ClusterGraph &C, const cluster act, NodeArray<bool> &mark, Graph &G)
 {
-	bool childOk = safeTestForEach(act->children, [&](cluster child) {
+	std::function<bool(cluster)> testFunc = [&](cluster child) {
 		return cConnectTest(C, child, mark, G);
-	});
+	};
+	bool childOk = safeTestForEach(act->children, testFunc);
 	if (!childOk) {
 		return false;
 	}
@@ -164,9 +165,10 @@ void recursiveConnect(
 	//for non-cc clusters, add edges to make them connected
 	//recursively search for connection nodes (simple version:
 	//use first node/first node of first child (recursive)
-	safeForEach(act->children, [&](cluster child) {
+	std::function<void(cluster)> connectFunc = [&](cluster child) {
 		recursiveConnect(CG, child, origCluster, oCcluster, origNode, G, newEdges);
-	});
+	};
+	safeForEach(act->children, connectFunc);
 
 	//We construct a copy of the current cluster
 	OGDF_ASSERT(act->cCount() == 0);
@@ -331,9 +333,10 @@ void recursiveCConnect(
 	//for non-cc clusters, add edges to make them connected
 	//recursively search for connection nodes (simple version:
 	//use first node/first node of first child (recursive)
-	safeForEach(act->children, [&](cluster child) {
+	std::function<void(cluster)> connectFunc = [&](cluster child) {
 		recursiveCConnect(CG, child, origCluster, oCcluster, origNode, G, fullCopy, copyNode, badNode, newEdges);
-	});
+	};
+	safeForEach(act->children, connectFunc);
 
 	//We construct a graph copy of the current cluster subgraph
 	OGDF_ASSERT(act->cCount() == 0);

--- a/src/ogdf/cluster/CconnectClusterPlanar.cpp
+++ b/src/ogdf/cluster/CconnectClusterPlanar.cpp
@@ -119,9 +119,10 @@ bool CconnectClusterPlanar::planarityTest(
 	Graph &G)
 {
 	// Test children first
-	if (!safeTestForEach(act->children, [&](cluster child) {
+	std::function<bool(cluster)> testFunc = [&](cluster child) {
 		return planarityTest(C, child, G);
-	})) {
+	};
+	if (!safeTestForEach(act->children, testFunc)) {
 		return false;
 	}
 

--- a/src/ogdf/cluster/CconnectClusterPlanarEmbed.cpp
+++ b/src/ogdf/cluster/CconnectClusterPlanarEmbed.cpp
@@ -1026,9 +1026,10 @@ bool CconnectClusterPlanarEmbed::planarityTest(
 	cluster origOfAct = m_clusterTableCopy2Orig[act];
 
 	// Test children first
-	if (!safeTestForEach(act->children, [&](cluster child) {
+	std::function<bool(cluster)> testFunc = [&](cluster child) {
 		return planarityTest(Ccopy, child, Gcopy);
-	})) {
+	};
+	if (!safeTestForEach(act->children, testFunc)) {
 		return false;
 	}
 

--- a/src/ogdf/cluster/ClusterPlanRep.cpp
+++ b/src/ogdf/cluster/ClusterPlanRep.cpp
@@ -220,9 +220,10 @@ void ClusterPlanRep::convertClusterGraph(cluster act,
 		isLeaf = true;
 	}
 	// Test children first
-	safeForEach(act->children, [&](cluster child) {
+	std::function<void(cluster)> convertFunc = [&](cluster child) {
 		convertClusterGraph(child, currentEdge, outEdge);
-	});
+	};
+	safeForEach(act->children, convertFunc);
 
 	//do not convert root cluster
 	if (isRoot) return;


### PR DESCRIPTION
Hi, I am compilling ogdf on Ubuntu 14.04 with GCC 4.8.4.

My compiller can't automatically convert lambda functions to std::function.
