### PR TITLE
fix DOT parser cluster depth bug

### DIFF
--- a/src/ogdf/fileformats/DotParser.cpp
+++ b/src/ogdf/fileformats/DotParser.cpp
@@ -1172,7 +1172,7 @@ node Parser::requestNode(
 	// up. And this is achieved by the line below - if a node is requested on
 	// a level that is deeper than currently assigned one, then we reassign
 	// cluster.
-	if(C && data.rootCluster->depth() < C->clusterOf(v)->depth()) {
+	if(C && data.rootCluster->depth() > C->clusterOf(v)->depth()) {
 		C->reassignNode(v, data.rootCluster);
 	}
 

--- a/test/resources/fileformats/dot/valid/cluster
+++ b/test/resources/fileformats/dot/valid/cluster
@@ -1,0 +1,16 @@
+digraph G {
+	subgraph cluster_0 {
+		a0 -> a1 -> a2 -> a3;
+	}
+
+	subgraph cluster_1 {
+		b0 -> b1 -> b2 -> b3;
+	}
+	start -> a0;
+	start -> b0;
+	a1 -> b3;
+	b2 -> a3;
+	a3 -> a0;
+	a3 -> end;
+	b3 -> end;
+}

--- a/test/src/basic/fileformats.cpp
+++ b/test/src/basic/fileformats.cpp
@@ -679,16 +679,14 @@ void describeDOTwithClusters()
 {
 	describe("DOT with subgraphs as clusters", []() {
 		it("reads a cluster graph", []() {
-			const std::string filename = "fileformats/dot/valid/cluster";
-
-			const ResourceFile* file = ResourceFile::get(filename);
+			const ResourceFile* file = ResourceFile::get(
+				"fileformats/dot/valid/cluster");
 			std::stringstream is{file->data()};
 
 			Graph G;
 			ClusterGraph CG(G);
-			ClusterGraphAttributes CA(CG);
 
-			const bool readStatus = GraphIO::readDOT(CA, CG, G, is);
+			const bool readStatus = GraphIO::readDOT(CG, G, is);
 			AssertThat(readStatus, Equals(true));
 
 			// this graph has two clusters inside the root cluster, each of which
@@ -715,8 +713,6 @@ describe("GraphIO", []() {
 	describeDMF<int>("int");
 	describeDMF<double>("double");
 
-	describeDOTwithClusters();
-
 	describeGAFormat("GML", GraphIO::readGML, GraphIO::writeGML, GraphIO::readGML, GraphIO::writeGML, false,
 	                 GraphAttributes::nodeGraphics | GraphAttributes::edgeGraphics | GraphAttributes::edgeDoubleWeight
 	                 | GraphAttributes::edgeLabel | GraphAttributes::nodeLabel | GraphAttributes::edgeType
@@ -737,6 +733,7 @@ describe("GraphIO", []() {
 	                 | GraphAttributes::edgeLabel | GraphAttributes::nodeLabel | GraphAttributes::nodeType
 	                 | GraphAttributes::edgeDoubleWeight | GraphAttributes::edgeArrow | GraphAttributes::nodeTemplate
 	                 | GraphAttributes::nodeWeight | GraphAttributes::nodeStyle | GraphAttributes::threeD);
+	describeDOTwithClusters();
 	describeGAFormat("GEXF", GraphIO::readGEXF, GraphIO::writeGEXF, GraphIO::readGEXF, GraphIO::writeGEXF, true,
 	                 GraphAttributes::nodeGraphics | GraphAttributes::edgeIntWeight
 	                 | GraphAttributes::edgeDoubleWeight | GraphAttributes::nodeType | GraphAttributes::edgeType

--- a/test/src/basic/fileformats.cpp
+++ b/test/src/basic/fileformats.cpp
@@ -671,6 +671,37 @@ void describeGAFormat(const std::string name, GraphIO::AttrReaderFunc readerGA, 
 	});
 }
 
+/**
+ * Tests reading a DOT clustergraph, using a simplified version of:
+ * https://graphviz.gitlab.io/_pages/Gallery/directed/cluster.html
+ */
+void describeDOTwithClusters()
+{
+	describe("DOT with subgraphs as clusters", []() {
+		it("reads a cluster graph", []() {
+			const std::string filename = "fileformats/dot/valid/cluster";
+
+			const ResourceFile* file = ResourceFile::get(filename);
+			std::stringstream is{file->data()};
+
+			Graph G;
+			ClusterGraph CG(G);
+			ClusterGraphAttributes CA(CG);
+
+			const bool readStatus = GraphIO::readDOT(CA, CG, G, is);
+			AssertThat(readStatus, Equals(true));
+
+			// this graph has two clusters inside the root cluster, each of which
+			// has four nodes.
+			AssertThat(CG.numberOfClusters(), Equals(3));
+			AssertThat(CG.rootCluster()->children.size(), Equals(2));
+			for (const auto &cluster : CG.rootCluster()->children) {
+				AssertThat(cluster->nodes.size(), Equals(4));
+			}
+		});
+	});
+}
+
 function<bool(Graph &G, istream &is)> toLambda(const GraphIO::ReaderFunc &reader) {
 	return [&](Graph &G, istream &is) { return reader(G, is); };
 }
@@ -683,6 +714,8 @@ describe("GraphIO", []() {
 
 	describeDMF<int>("int");
 	describeDMF<double>("double");
+
+	describeDOTwithClusters();
 
 	describeGAFormat("GML", GraphIO::readGML, GraphIO::writeGML, GraphIO::readGML, GraphIO::writeGML, false,
 	                 GraphAttributes::nodeGraphics | GraphAttributes::edgeGraphics | GraphAttributes::edgeDoubleWeight


### PR DESCRIPTION
This change should fix the first part of https://github.com/ogdf/ogdf/issues/36. Previously, we were reassigning the node to a cluster with less depth, contrary to the comment.