### PR TITLE
Output file doesnt conteins the same node ids 

### DIFF
--- a/src/ogdf/fileformats/GraphIO_gml.cpp
+++ b/src/ogdf/fileformats/GraphIO_gml.cpp
@@ -128,7 +128,13 @@ static void write_gml_graph(const GraphAttributes &A, std::ostream &os, NodeArra
 	for(node v : G.nodes) {
 		GraphIO::indent(os,1) << "node\n";
 		GraphIO::indent(os,1) << "[\n";
-		GraphIO::indent(os,2) << "id\t" << (index[v] = nextId++) << "\n";
+		
+		if (A.attributes() & GraphAttributes::nodeId) {
+			GraphIO::indent(os,2) << "id\t" << A.idNode(v) << "\n";
+		}
+		else {
+			GraphIO::indent(os,2) << "id\t" << (index[v] = nextId++) << "\n";
+		}
 
 		if (A.has(GraphAttributes::nodeTemplate)) {
 			GraphIO::indent(os,2) << "template\t";
@@ -172,8 +178,15 @@ static void write_gml_graph(const GraphAttributes &A, std::ostream &os, NodeArra
 	for(edge e : G.edges) {
 		GraphIO::indent(os,1) << "edge\n";
 		GraphIO::indent(os,1) << "[\n";
-		GraphIO::indent(os,2) << "source\t" << index[e->source()] << "\n";
-		GraphIO::indent(os,2) << "target\t" << index[e->target()] << "\n";
+		
+		if (A.attributes() & GraphAttributes::nodeId) {
+			GraphIO::indent(os, 2) << "source\t" << A.idNode(e->source()) << "\n";
+			GraphIO::indent(os, 2) << "target\t" << A.idNode(e->target()) << "\n";
+		}
+		else {
+			GraphIO::indent(os,2) << "source\t" << index[e->source()] << "\n";
+			GraphIO::indent(os,2) << "target\t" << index[e->target()] << "\n";
+		}
 
 		if (A.has(GraphAttributes::edgeType)){
 			GraphIO::indent(os, 2) << "generalization\t" << int(A.type(e)) << "\n";


### PR DESCRIPTION
as in input file even when node id attribute is present as savable.

We found that the library is losing node id in return file even when we set it to store it. And based on that we done some modifications so now it not just increment node id's starting from zero but use saved node id if it is present in input file and set to save.

Maybe this modifications will be useful.