### PR TITLE
ClusterPlanarizationLayout: remove unused variable

### DIFF
--- a/src/ogdf/cluster/ClusterPlanarizationLayout.cpp
+++ b/src/ogdf/cluster/ClusterPlanarizationLayout.cpp
@@ -126,8 +126,6 @@ void ClusterPlanarizationLayout::call(
 	// correct the problem by planarizing or inserting connection edges.
 	if (!cplanar)
 	{
-		bool connect = false;
-
 		if ( (CCPE.errCode() == CconnectClusterPlanarEmbed::ErrorCode::nonConnected) ||
 			(CCPE.errCode() == CconnectClusterPlanarEmbed::ErrorCode::nonCConnected) )
 		{


### PR DESCRIPTION
Fixes a warning. This change has **not** been tested in any way.