### PR TITLE
Add a copy ctor to avoid clang 10.1 warning

### DIFF
--- a/include/ogdf/basic/CombinatorialEmbedding.h
+++ b/include/ogdf/basic/CombinatorialEmbedding.h
@@ -53,6 +53,7 @@ public:
 	FaceAdjIterator() : m_adj(nullptr), m_adjFirst(nullptr) { }
 	explicit FaceAdjIterator(adjEntry adj) : m_adj(adj), m_adjFirst(adj) { }
 	FaceAdjIterator(adjEntry adjFirst, adjEntry adj) : m_adj(adj), m_adjFirst(adjFirst) { }
+	FaceAdjIterator(const FaceAdjIterator &other) : m_adjFirst(other.m_adjFirst), m_adj(other.m_adj) { }
 
 	bool operator==(const FaceAdjIterator &other) const {
 		return m_adj == other.m_adj;

--- a/include/ogdf/basic/CombinatorialEmbedding.h
+++ b/include/ogdf/basic/CombinatorialEmbedding.h
@@ -53,7 +53,7 @@ public:
 	FaceAdjIterator() : m_adj(nullptr), m_adjFirst(nullptr) { }
 	explicit FaceAdjIterator(adjEntry adj) : m_adj(adj), m_adjFirst(adj) { }
 	FaceAdjIterator(adjEntry adjFirst, adjEntry adj) : m_adj(adj), m_adjFirst(adjFirst) { }
-	FaceAdjIterator(const FaceAdjIterator &other) : m_adjFirst(other.m_adjFirst), m_adj(other.m_adj) { }
+	FaceAdjIterator(const FaceAdjIterator &other) : m_adj(other.m_adj), m_adjFirst(other.m_adjFirst) { }
 
 	bool operator==(const FaceAdjIterator &other) const {
 		return m_adj == other.m_adj;


### PR DESCRIPTION
This just silences clang++ 10.1's warning about, since you have a user assignment operator, that relying on a compiler generated one is deprecated. (There are two members, it was pretty clear what should happen in the copy ctor.) 