### PR TITLE
src/coin/CoinUtils/CoinOslFactorization2.cpp: Minor fix for debug build

### DIFF
--- a/src/coin/CoinUtils/CoinOslFactorization2.cpp
+++ b/src/coin/CoinUtils/CoinOslFactorization2.cpp
@@ -1453,8 +1453,8 @@ static int c_ekkbtrn_mpt(const EKKfactinfo * COIN_RESTRICT2 fact,
   const int * COIN_RESTRICT mpermu=fact->mpermu;
   /*const int *mrstrt	= fact->xrsadr;*/
 
-#ifdef DEBUG
   int i;
+#ifdef DEBUG
   memset(spare,'A',3*nrow*sizeof(int));
   {
 
@@ -1467,7 +1467,6 @@ static int c_ekkbtrn_mpt(const EKKfactinfo * COIN_RESTRICT2 fact,
 #endif
 
 
-  int i;
 #ifdef DEBUG
   for (i=1;i<=nrow;i++) {
     if (fact->nonzero[i]||dpermu[i]) {


### PR DESCRIPTION
This PR adds a very minor fix for builds that have the symbol `DEBUG` defined. This commonly happens on MSVC, where many libraries may use this flag to enable extra debugging code.

With `DEBUG` defined, the file `src/coin/CoinUtils/CoinOslFactorization2.cpp` does not compile due to `int i` being duplicate in the same scope.