### PR TITLE
Minor fixes for MSVC ClangCl build

### DIFF
--- a/cmake/compiler-specifics.cmake
+++ b/cmake/compiler-specifics.cmake
@@ -23,7 +23,20 @@ set(available_default_warning_flags "")
 set(available_default_warning_flags_debug "")
 set(available_default_warning_flags_release "")
 set(warnings_as_errors_flag "")
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+if(MSVC)
+  set(available_default_warning_flags "/W3 /wd4018 /wd4068 /wd4101 /wd4244 /wd4250 /wd4267 /wd4373 /wd4800")
+  # this has to be explained because MSVC is so cryptic:
+  # /W3 sets the warning level of MSVC to 3 (all warnings except informational warnings),
+  # /wd<code> disables the warning with the specific code,
+  #     4018 = signed/unsigned mismatch
+  #     4068 = unknown pragmas
+  #     4101 = unused variable
+  #     4244, 4267 = implicit conversion
+  #     4250 = class inherits a member from another class via dominance
+  #     4373 = behavior in old MSVC versions is different to C++ standard
+  #     4800 = bool conversion from int or pointers
+  set(warnings_as_errors_flag "/WX")
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   set(available_default_warning_flags "-Wall -Wextra -Wno-unused-parameter -Wno-unknown-pragmas \
       -Wno-error=sign-compare -Wno-error=conversion -Wno-error=strict-aliasing")
   if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
@@ -42,17 +55,4 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   endif()
   set(available_default_warning_flags_release "${available_default_warning_flags_release} -Wno-error=unused-variable")
   set(warnings_as_errors_flag "-Werror")
-elseif(MSVC)
-  set(available_default_warning_flags "/W3 /wd4018 /wd4068 /wd4101 /wd4244 /wd4250 /wd4267 /wd4373 /wd4800")
-  # this has to be explained because MSVC is so cryptic:
-  # /W3 sets the warning level of MSVC to 3 (all warnings except informational warnings),
-  # /wd<code> disables the warning with the specific code,
-  #     4018 = signed/unsigned mismatch
-  #     4068 = unknown pragmas
-  #     4101 = unused variable
-  #     4244, 4267 = implicit conversion
-  #     4250 = class inherits a member from another class via dominance
-  #     4373 = behavior in old MSVC versions is different to C++ standard
-  #     4800 = bool conversion from int or pointers
-  set(warnings_as_errors_flag "/WX")
 endif()

--- a/cmake/ogdf.cmake
+++ b/cmake/ogdf.cmake
@@ -144,7 +144,7 @@ if(has_linux_cpu_macros)
   set(OGDF_HAS_LINUX_CPU_MACROS 1)
 endif()
 
-if(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+if(CMAKE_COMPILER_IS_GNUCXX OR ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND NOT "${CMAKE_CXX_SIMULATE_ID}" STREQUAL "MSVC"))
   target_link_libraries(OGDF PUBLIC pthread)
 endif()
 


### PR DESCRIPTION
Newer versions of Visual Studio ship the ClangCL compiler front-end. ClangCl can have a significant impact on the efficiency of the compiled code, with typical speedups anywhere between 5% and 30%.

This PR allows OGDF to be compiled with ClangCl. The changes are rather minor. The change in `cmake/compiler-specifics.cmake` is not a strict requirement, but it allows to correctly set warnings for MSVC with ClangCL by moving the MSVC settings above the plain Clang settings.