### PR TITLE
Fixed numeric literal tokenization in DotLexer.cpp

### DIFF
--- a/src/ogdf/fileformats/DotLexer.cpp
+++ b/src/ogdf/fileformats/DotLexer.cpp
@@ -280,7 +280,7 @@ bool Lexer::identifier(Token &token)
 			m_col = m_buffer.size();
 		} else {
 			token.value = new std::string(m_buffer.substr(m_col, length));
-			m_col += length;
+			m_col += (static_cast<long>(length) - 1);
 		}
 		return true;
 	}


### PR DESCRIPTION
Sorry for my bad english((

Imagine we have string like
```
digraph G { node [fontsize=12] .....
```

After tokenizing numeric literal 12 the lexer sets the current char pointer/index to right bracket character. But because this process is inside the loop, the pointer is incremented again and erroneously skips the right bracket.
