### PR TITLE
FMMMLayout: Prevent parameters overriding when using high level options

### DIFF
--- a/src/ogdf/energybased/FMMMLayout.cpp
+++ b/src/ogdf/energybased/FMMMLayout.cpp
@@ -325,19 +325,6 @@ void FMMMLayout::initialize_all_options()
 
 void FMMMLayout::update_low_level_options_due_to_high_level_options_settings()
 {
-	FMMMOptions::PageFormatType pf = pageFormat();
-	double uel = unitEdgeLength();
-	bool nip = newInitialPlacement();
-	FMMMOptions::QualityVsSpeed qvs = qualityVersusSpeed();
-
-	//update
-	initialize_all_options();
-	useHighLevelOptions(true);
-	pageFormat(pf);
-	unitEdgeLength(uel);
-	newInitialPlacement(nip);
-	qualityVersusSpeed(qvs);
-
 	switch (pageFormat()) {
 	case FMMMOptions::PageFormatType::Square:
 		pageRatio(1.0);

--- a/test/src/layout/energy-based.cpp
+++ b/test/src/layout/energy-based.cpp
@@ -29,6 +29,7 @@
  * http://www.gnu.org/copyleft/gpl.html
  */
 
+#include <ogdf/basic/graph_generators/randomized.h>
 #include <ogdf/energybased/DavidsonHarelLayout.h>
 #include <ogdf/energybased/DTreeMultilevelEmbedder.h>
 #include <ogdf/energybased/FastMultipoleEmbedder.h>
@@ -178,4 +179,21 @@ go_bandit([] { describe("Energy-based layouts", [] {
 	TEST_ENERGY_BASED_LAYOUT(StressMinimization, 0);
 
 	TEST_ENERGY_BASED_LAYOUT(TutteLayout, 0, GraphProperty::triconnected, GraphProperty::planar, GraphProperty::simple);
-}); });
+});
+
+describe("FMMMLayout parameters overriding", [&]() {
+
+	it("should not reset parameters to their default value when using high level options", [&]() {
+		Graph G;
+		randomSimpleGraph(G, 100, 200);
+		GraphAttributes GA(G);
+
+		FMMMLayout fmmm;
+		fmmm.useHighLevelOptions(true);
+		fmmm.allowedPositions(FMMMOptions::AllowedPositions::All);
+		fmmm.call(GA);
+		AssertThat(fmmm.allowedPositions(), Equals(FMMMOptions::AllowedPositions::All));
+	});
+});
+
+});


### PR DESCRIPTION
When using high level options with the FMMMLayout, low level parameters
related to page format, new initial placement and quality vs speed will
be automatically set.

Nervertheless as a side effect some not concerned parameters that might
have been overridden using the dedicated setter methods in the layout
class are resetted to their default value.

For instance, if one sets the AllowedPositions parameter to All while
using high level options, its value will be reset to Integer at the
beginning of the layout process leading to unexpected result.

Parameters are already set to their default value in the FMMMLayout
constructor so there is no need to reset them when setting low level
parameters from high level options.

The issue has been observed by a Tulip user tweaking layout parameters
from the GUI (https://github.com/Tulip-Dev/tulip/issues/179).

All tests are still happy and I have added a new one to showcase the issue.