### PR TITLE
Support ARM64 windows

### DIFF
--- a/src/ogdf/basic/System.cpp
+++ b/src/ogdf/basic/System.cpp
@@ -73,7 +73,7 @@
 
 static inline void cpuid(int CPUInfo[4], int infoType)
 {
-#if defined(OGDF_SYSTEM_WINDOWS) && !defined(__GNUC__)
+#if defined(OGDF_SYSTEM_WINDOWS) && !defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
 	__cpuid(CPUInfo, infoType);
 #else
 	uint32_t a = 0;


### PR DESCRIPTION
As seen here: https://docs.microsoft.com/en-us/cpp/intrinsics/cpuid-cpuidex `__cpuid` is only supported on x86 and x64.

With this change I am able to build and successfully run the tests natively on ARM64 windows. Screenshot showing test results from a ARM64 Windows VM running on my M1 macbook.

<img width="1039" alt="Screenshot 2022-06-29 at 20 54 30" src="https://user-images.githubusercontent.com/4324090/176533145-b48b3291-7a0e-4c29-842d-53095e4e8184.png">

Please don't hesitate to ask for further info or changes. Thanks 👍 

