### PR TITLE
Minor Improvements

### DIFF
--- a/doc/examples/layout/hierarchical.cpp
+++ b/doc/examples/layout/hierarchical.cpp
@@ -16,7 +16,7 @@ int main()
 	  GraphAttributes::edgeStyle |
 	  GraphAttributes::nodeStyle |
 	  GraphAttributes::nodeTemplate);
-	if (!GraphIO::read(GA, G, "unix-history.gml", GraphIO::readGML)) {
+	if (!GraphIO::read(GA, G, "unix-history.gml")) {
 		std::cerr << "Could not load unix-history.gml" << std::endl;
 		return 1;
 	}
@@ -32,8 +32,8 @@ int main()
 	SL.setLayout(ohl);
 
 	SL.call(GA);
-	GraphIO::write(GA, "output-unix-history-hierarchical.gml", GraphIO::writeGML);
-	GraphIO::write(GA, "output-unix-history-hierarchical.svg", GraphIO::drawSVG);
+	GraphIO::write(GA, "output-unix-history-hierarchical.gml");
+	GraphIO::write(GA, "output-unix-history-hierarchical.svg");
 
 	return 0;
 }

--- a/include/ogdf/basic/AdjEntryArray.h
+++ b/include/ogdf/basic/AdjEntryArray.h
@@ -139,11 +139,11 @@ public:
 	using const_iterator = internal::GraphArrayConstIterator<AdjEntryArray<T>>;
 
 	//! Constructs an empty adjacency entry array associated with no graph.
-	AdjEntryArray() : Array<T>(), AdjEntryArrayBase() { }
+	AdjEntryArray() : Array<T>(), AdjEntryArrayBase(), m_x() { }
 
 	//! Constructs an adjacency entry array associated with \p G.
 	explicit AdjEntryArray(const Graph& G)
-		: Array<T>(G.adjEntryArrayTableSize()), AdjEntryArrayBase(&G) { }
+		: Array<T>(G.adjEntryArrayTableSize()), AdjEntryArrayBase(&G), m_x() { }
 
 	//! Constructs an adjacency entry array associated with \p G.
 	/**

--- a/include/ogdf/basic/Array.h
+++ b/include/ogdf/basic/Array.h
@@ -848,7 +848,7 @@ void Array<E, INDEX>::grow(INDEX add) {
 
 	// initialize new array entries
 	for (E* pDest = m_pStart + sOld; pDest < m_pStop; pDest++) {
-		new (pDest) E;
+		new (pDest) E();
 	}
 }
 
@@ -877,7 +877,7 @@ void Array<E, INDEX>::initialize() {
 	E* pDest = m_pStart;
 	try {
 		for (; pDest < m_pStop; pDest++) {
-			new (pDest) E;
+			new (pDest) E();
 		}
 	} catch (...) {
 		while (--pDest >= m_pStart) {

--- a/include/ogdf/basic/EdgeArray.h
+++ b/include/ogdf/basic/EdgeArray.h
@@ -137,10 +137,11 @@ public:
 	using const_iterator = internal::GraphArrayConstIterator<EdgeArray<T>>;
 
 	//! Constructs an empty edge array associated with no graph.
-	EdgeArray() : Array<T>(), EdgeArrayBase() { }
+	EdgeArray() : Array<T>(), EdgeArrayBase(), m_x() { }
 
 	//! Constructs an edge array associated with \p G.
-	explicit EdgeArray(const Graph& G) : Array<T>(G.edgeArrayTableSize()), EdgeArrayBase(&G) { }
+	explicit EdgeArray(const Graph& G)
+		: Array<T>(G.edgeArrayTableSize()), EdgeArrayBase(&G), m_x() { }
 
 	//! Constructs an edge array associated with \p G.
 	/**
@@ -205,24 +206,28 @@ public:
 	//! Returns a reference to the element with index edge of \p adj.
 	const T& operator[](adjEntry adj) const {
 		OGDF_ASSERT(adj != nullptr);
+		OGDF_ASSERT(adj->graphOf() == m_pGraph);
 		return Array<T>::operator[](adj->index() >> 1);
 	}
 
 	//! Returns a reference to the element with index edge of \p adj.
 	T& operator[](adjEntry adj) {
 		OGDF_ASSERT(adj != nullptr);
+		OGDF_ASSERT(adj->graphOf() == m_pGraph);
 		return Array<T>::operator[](adj->index() >> 1);
 	}
 
 	//! Returns a reference to the element with index edge of \p adj.
 	const T& operator()(adjEntry adj) const {
 		OGDF_ASSERT(adj != nullptr);
+		OGDF_ASSERT(adj->graphOf() == m_pGraph);
 		return Array<T>::operator[](adj->index() >> 1);
 	}
 
 	//! Returns a reference to the element with index edge of \p adj.
 	T& operator()(adjEntry adj) {
 		OGDF_ASSERT(adj != nullptr);
+		OGDF_ASSERT(adj->graphOf() == m_pGraph);
 		return Array<T>::operator[](adj->index() >> 1);
 	}
 

--- a/include/ogdf/basic/FaceArray.h
+++ b/include/ogdf/basic/FaceArray.h
@@ -138,11 +138,11 @@ public:
 	using const_iterator = internal::GraphArrayConstIterator<FaceArray<T>>;
 
 	//! Constructs an empty face array associated with no combinatorial embedding.
-	FaceArray() : Array<T>(), FaceArrayBase() { }
+	FaceArray() : Array<T>(), FaceArrayBase(), m_x() { }
 
 	//! Constructs a face array associated with \p E.
 	FaceArray(const ConstCombinatorialEmbedding& E)
-		: Array<T>(E.faceArrayTableSize()), FaceArrayBase(&E) { }
+		: Array<T>(E.faceArrayTableSize()), FaceArrayBase(&E), m_x() { }
 
 	//! Constructs a face array associated with \p E.
 	/**

--- a/include/ogdf/basic/GraphList.h
+++ b/include/ogdf/basic/GraphList.h
@@ -141,21 +141,26 @@ public:
 	//! Sorts the list according to \p newOrder.
 	template<class LIST>
 	void sort(const LIST& newOrder) {
-		GraphElement* pPred = nullptr;
-		typename LIST::const_iterator it = newOrder.begin();
-		if (!it.valid()) {
+		using std::begin;
+		using std::end;
+		sort(begin(newOrder), end(newOrder));
+	}
+
+	//! Sorts the list according to the range defined by two iterators.
+	template<class IT>
+	void sort(IT begin, IT end) {
+		if (begin == end) {
 			return;
 		}
-
-		m_head = *it;
-		for (; it.valid(); ++it) {
+		m_head = *begin;
+		GraphElement* pPred = nullptr;
+		for (auto it = begin; it != end; ++it) {
 			GraphElement* p = *it;
 			if ((p->m_prev = pPred) != nullptr) {
 				pPred->m_next = p;
 			}
 			pPred = p;
 		}
-
 		(m_tail = pPred)->m_next = nullptr;
 	}
 
@@ -368,6 +373,12 @@ public:
 	template<class T_LIST>
 	void sort(const T_LIST& newOrder) {
 		GraphListBase::sort(newOrder);
+	}
+
+	//! Sorts the list according to the range defined by two iterators.
+	template<class IT>
+	void sort(IT begin, IT end) {
+		GraphListBase::sort(begin, end);
 	}
 
 	//! Reverses the order of the list elements.

--- a/include/ogdf/basic/Graph_d.h
+++ b/include/ogdf/basic/Graph_d.h
@@ -1084,11 +1084,28 @@ public:
 	 */
 	template<class ADJ_ENTRY_LIST>
 	void sort(node v, const ADJ_ENTRY_LIST& newOrder) {
+		using std::begin;
+		using std::end;
+		sort(v, begin(newOrder), end(newOrder));
+	}
+
+	//! Sorts the adjacency list of node \p v according to the range denoted by two iterators.
+	/**
+	 * \pre \p begin ... \p end contains exactly the adjacency entries of \p v!
+	 *
+	 * @tparam IT        is the type of the input adjacency entry list iterator.
+	 * @param  v         is the node whose adjacency list will be sorted.
+	 * @param  begin     is the iterator to the adjacency entry that should come first
+	 * @param  end       is the iterator one past the adjacency entry that should come last
+	 */
+	template<class IT>
+	void sort(node v, IT begin, IT end) {
 #ifdef OGDF_DEBUG
 		std::set<int> entries;
 		int counter = 0;
 
-		for (adjEntry adj : newOrder) {
+		for (auto it = begin; it != end; ++it) {
+			adjEntry adj = *it;
 			entries.insert(adj->index());
 			OGDF_ASSERT(adj->theNode() == v);
 			counter++;
@@ -1097,7 +1114,7 @@ public:
 		OGDF_ASSERT(counter == v->degree());
 		OGDF_ASSERT(entries.size() == static_cast<unsigned int>(v->degree()));
 #endif
-		v->adjEntries.sort(newOrder);
+		v->adjEntries.sort(begin, end);
 	}
 
 	//! Reverses the adjacency list of \p v.

--- a/include/ogdf/basic/Graph_d.h
+++ b/include/ogdf/basic/Graph_d.h
@@ -1313,6 +1313,8 @@ public:
 	 */
 	void resetEdgeIdCount(int maxId);
 
+	void resetNodeIdCount(int maxId);
+
 
 	//! @}
 	/**

--- a/include/ogdf/basic/NodeArray.h
+++ b/include/ogdf/basic/NodeArray.h
@@ -135,10 +135,10 @@ public:
 			internal::GraphArrayConstIterator<NodeArray<T>>; //!< The type for node array const iterators.
 
 	//! Constructs an empty node array associated with no graph.
-	NodeArray() : Array<T>(), NodeArrayBase() { }
+	NodeArray() : Array<T>(), NodeArrayBase(), m_x() { }
 
 	//! Constructs a node array associated with \p G.
-	NodeArray(const Graph& G) : Array<T>(G.nodeArrayTableSize()), NodeArrayBase(&G) { }
+	NodeArray(const Graph& G) : Array<T>(G.nodeArrayTableSize()), NodeArrayBase(&G), m_x() { }
 
 	//! Constructs a node array associated with \p G.
 	/**

--- a/include/ogdf/basic/PriorityQueue.h
+++ b/include/ogdf/basic/PriorityQueue.h
@@ -63,7 +63,6 @@ public:
 
 private:
 	size_type m_size; //!< Number of entries.
-	const C& m_cmp;
 	using SpecImpl = Impl<T, C>;
 	SpecImpl* m_impl; //!< Underlying heap data structure.
 
@@ -79,7 +78,7 @@ public:
 	 * @param initialSize The initial capacity preference (ignored if not supported by underlying heap).
 	 */
 	explicit PriorityQueue(const C& cmp = C(), int initialSize = 128)
-		: m_size(0), m_cmp(cmp), m_impl(new SpecImpl(cmp, initialSize)) { }
+		: m_size(0), m_impl(new SpecImpl(cmp, initialSize)) { }
 
 	//! Copy constructor.
 	PriorityQueue(const PriorityQueue& other)
@@ -202,7 +201,7 @@ public:
 
 	//! Removes all the entries from the queue.
 	void clear() {
-		PriorityQueue tmp(m_cmp);
+		PriorityQueue tmp(m_impl->comparator());
 		tmp.swap(*this);
 	}
 
@@ -219,6 +218,9 @@ public:
 	* @return The priority
 	*/
 	const T& value(handle pos) const { return m_impl->value(pos); }
+
+	//! Returns the comparator used for ordering elements.
+	const C& comparator() const { return m_impl->comparator(); }
 };
 
 /**

--- a/include/ogdf/basic/exceptions.h
+++ b/include/ogdf/basic/exceptions.h
@@ -159,7 +159,7 @@ enum class LibraryNotSupportedCode {
 /**
  * @ingroup exceptions
  */
-class OGDF_EXPORT Exception {
+class OGDF_EXPORT Exception : std::exception {
 private:
 	const char* m_file; //!< Source file where exception occurred.
 	int m_line; //!< Line number where exception occurred.
@@ -183,6 +183,8 @@ public:
 	 * Returns -1 if the line number is unknown.
 	 */
 	int line() const { return m_line; }
+
+	const char* what() const noexcept override { return "Unknown OGDF Exception"; }
 };
 
 //! %Exception thrown when result of cast is 0.
@@ -251,6 +253,10 @@ public:
 
 	//! Returns the error code of the exception.
 	AlgorithmFailureCode exceptionCode() const { return m_exceptionCode; }
+
+	const char* what() const noexcept override { return codeToString(m_exceptionCode); }
+
+	static const char* codeToString(AlgorithmFailureCode code);
 
 private:
 	AlgorithmFailureCode m_exceptionCode; //!< The error code specifying the exception.

--- a/include/ogdf/basic/simple_graph_alg.h
+++ b/include/ogdf/basic/simple_graph_alg.h
@@ -471,12 +471,13 @@ inline void makeConnected(Graph& G) {
  *
  * @param G         is the input graph.
  * @param component is assigned a mapping from nodes to component numbers.
- * @param isolated  is assigned the list of isolated nodes. An isolated node is
- *                  a node without incident edges.
+ * @param isolated  if non-null, will contain the list of isolated nodes afterwards.
+ *                  An isolated node is a node without incident edges.
+ * @param reprs     if non-null, will contain a node from component c at index c afterwards.
  * @return the number of connected components.
  */
 OGDF_EXPORT int connectedComponents(const Graph& G, NodeArray<int>& component,
-		List<node>* isolated = nullptr);
+		List<node>* isolated = nullptr, ArrayBuffer<node>* reprs = nullptr);
 
 //! Computes the amount of connected components of \p G.
 /**
@@ -494,7 +495,7 @@ inline int connectedComponents(const Graph& G) {
 OGDF_DEPRECATED("connectedComponents() should be used instead.")
 
 /**
- * @copydoc ogdf::connectedComponents(const Graph&, NodeArray<int>&, List<node>*);
+ * @see ogdf::connectedComponents(const Graph&, NodeArray<int>&, List<node>*, ArrayBuffer<node>*)
  */
 inline int connectedIsolatedComponents(const Graph& G, List<node>& isolated,
 		NodeArray<int>& component) {

--- a/include/ogdf/cluster/ClusterArray.h
+++ b/include/ogdf/cluster/ClusterArray.h
@@ -136,11 +136,11 @@ public:
 	using const_iterator = internal::GraphArrayConstIterator<ClusterArray<T>>;
 
 	//! Constructs an empty cluster array associated with no graph.
-	ClusterArray() : Array<T>(), ClusterArrayBase() { }
+	ClusterArray() : Array<T>(), ClusterArrayBase(), m_x() { }
 
 	//! Constructs a cluster array associated with \p C.
 	ClusterArray(const ClusterGraph& C)
-		: Array<T>(C.clusterArrayTableSize()), ClusterArrayBase(&C) { }
+		: Array<T>(C.clusterArrayTableSize()), ClusterArrayBase(&C), m_x() { }
 
 	//! Constructs a cluster array associated with \p C.
 	/**

--- a/include/ogdf/graphalg/MinSteinerTreeDirectedCut.h
+++ b/include/ogdf/graphalg/MinSteinerTreeDirectedCut.h
@@ -1130,7 +1130,7 @@ void MinSteinerTreeDirectedCut<T>::Master::initializeParameters() {
 		bool objectiveInteger = false;
 		try {
 			this->readParameters(m_configfile);
-		} catch (AlgorithmFailureException) {
+		} catch (const AlgorithmFailureException&) {
 #ifdef OGDF_STP_EXACT_LOGGING
 			lout(Level::Alarm) << "Master::initializeParameters(): Error reading parameters."
 							   << "Using default values." << std::endl;

--- a/include/ogdf/hypergraph/HypergraphArray.h
+++ b/include/ogdf/hypergraph/HypergraphArray.h
@@ -85,7 +85,7 @@ class HypernodeArray : private Array<T>, protected HypergraphArrayBase {
 
 public:
 	//! Constructs an empty hypernode array associated with no hypergraph.
-	HypernodeArray() : Array<T>(), HypergraphArrayBase() { }
+	HypernodeArray() : Array<T>(), HypergraphArrayBase(), m_x() { }
 
 	//! Constructs a hypernode array associated with \p H.
 	HypernodeArray(const Hypergraph& H, const T& x)
@@ -162,7 +162,7 @@ class HyperedgeArray : private Array<T>, protected HypergraphArrayBase {
 
 public:
 	//! Constructs an empty hypernode array associated with no graph.
-	HyperedgeArray() : Array<T>(), HypergraphArrayBase() { }
+	HyperedgeArray() : Array<T>(), HypergraphArrayBase(), m_x() { }
 
 	//! Constructs a hypernode array associated with \p H.
 	HyperedgeArray(const Hypergraph& H, const T& x)

--- a/src/ogdf/basic/Graph.cpp
+++ b/src/ogdf/basic/Graph.cpp
@@ -1125,6 +1125,18 @@ void Graph::resetEdgeIdCount(int maxId) {
 #endif
 }
 
+void Graph::resetNodeIdCount(int maxId) {
+	m_nodeIdCount = maxId + 1;
+
+#ifdef OGDF_HEAVY_DEBUG
+	for (node n : nodes) {
+		// if there is a node with higer index than maxId, we cannot
+		// set the node id count to maxId+1
+		OGDF_ASSERT(n->index() <= maxId);
+	}
+#endif
+}
+
 node Graph::splitNode(adjEntry adjStartLeft, adjEntry adjStartRight) {
 	OGDF_ASSERT(adjStartLeft != nullptr);
 	OGDF_ASSERT(adjStartRight != nullptr);

--- a/src/ogdf/basic/System.cpp
+++ b/src/ogdf/basic/System.cpp
@@ -425,4 +425,118 @@ int System::getProcessID() { return getpid(); }
 
 #endif
 
+
+const char* AlgorithmFailureException::codeToString(AlgorithmFailureCode code) {
+	switch (code) {
+	default:
+		return "AlgorithmFailureCode::Unknown";
+	case AlgorithmFailureCode::IllegalParameter:
+		return "AlgorithmFailureCode::IllegalParameter";
+	case AlgorithmFailureCode::NoFlow:
+		return "AlgorithmFailureCode::NoFlow";
+	case AlgorithmFailureCode::Sort:
+		return "AlgorithmFailureCode::Sort";
+	case AlgorithmFailureCode::Label:
+		return "AlgorithmFailureCode::Label";
+	case AlgorithmFailureCode::ExternalFace:
+		return "AlgorithmFailureCode::ExternalFace";
+	case AlgorithmFailureCode::ForbiddenCrossing:
+		return "AlgorithmFailureCode::ForbiddenCrossing";
+	case AlgorithmFailureCode::TimelimitExceeded:
+		return "AlgorithmFailureCode::TimelimitExceeded";
+	case AlgorithmFailureCode::NoSolutionFound:
+		return "AlgorithmFailureCode::NoSolutionFound";
+	case AlgorithmFailureCode::IndexOutOfBounds:
+		return "AlgorithmFailureCode::IndexOutOfBounds";
+	case AlgorithmFailureCode::PrimalBound:
+		return "AlgorithmFailureCode::PrimalBound";
+	case AlgorithmFailureCode::DualBound:
+		return "AlgorithmFailureCode::DualBound";
+	case AlgorithmFailureCode::NotInteger:
+		return "AlgorithmFailureCode::NotInteger";
+	case AlgorithmFailureCode::Buffer:
+		return "AlgorithmFailureCode::Buffer";
+	case AlgorithmFailureCode::AddVar:
+		return "AlgorithmFailureCode::AddVar";
+	case AlgorithmFailureCode::Sorter:
+		return "AlgorithmFailureCode::Sorter";
+	case AlgorithmFailureCode::Phase:
+		return "AlgorithmFailureCode::Phase";
+	case AlgorithmFailureCode::Active:
+		return "AlgorithmFailureCode::Active";
+	case AlgorithmFailureCode::NoSolution:
+		return "AlgorithmFailureCode::NoSolution";
+	case AlgorithmFailureCode::MakeFeasible:
+		return "AlgorithmFailureCode::MakeFeasible";
+	case AlgorithmFailureCode::Guarantee:
+		return "AlgorithmFailureCode::Guarantee";
+	case AlgorithmFailureCode::BranchingVariable:
+		return "AlgorithmFailureCode::BranchingVariable";
+	case AlgorithmFailureCode::Strategy:
+		return "AlgorithmFailureCode::Strategy";
+	case AlgorithmFailureCode::CloseHalf:
+		return "AlgorithmFailureCode::CloseHalf";
+	case AlgorithmFailureCode::StandardPool:
+		return "AlgorithmFailureCode::StandardPool";
+	case AlgorithmFailureCode::Variable:
+		return "AlgorithmFailureCode::Variable";
+	case AlgorithmFailureCode::LpIf:
+		return "AlgorithmFailureCode::LpIf";
+	case AlgorithmFailureCode::Lp:
+		return "AlgorithmFailureCode::Lp";
+	case AlgorithmFailureCode::Bstack:
+		return "AlgorithmFailureCode::Bstack";
+	case AlgorithmFailureCode::LpStatus:
+		return "AlgorithmFailureCode::LpStatus";
+	case AlgorithmFailureCode::BranchingRule:
+		return "AlgorithmFailureCode::BranchingRule";
+	case AlgorithmFailureCode::FixSet:
+		return "AlgorithmFailureCode::FixSet";
+	case AlgorithmFailureCode::LpSub:
+		return "AlgorithmFailureCode::LpSub";
+	case AlgorithmFailureCode::String:
+		return "AlgorithmFailureCode::String";
+	case AlgorithmFailureCode::Constraint:
+		return "AlgorithmFailureCode::Constraint";
+	case AlgorithmFailureCode::Pool:
+		return "AlgorithmFailureCode::Pool";
+	case AlgorithmFailureCode::Global:
+		return "AlgorithmFailureCode::Global";
+	case AlgorithmFailureCode::FsVarStat:
+		return "AlgorithmFailureCode::FsVarStat";
+	case AlgorithmFailureCode::LpVarStat:
+		return "AlgorithmFailureCode::LpVarStat";
+	case AlgorithmFailureCode::OsiIf:
+		return "AlgorithmFailureCode::OsiIf";
+	case AlgorithmFailureCode::ConBranchRule:
+		return "AlgorithmFailureCode::ConBranchRule";
+	case AlgorithmFailureCode::Timer:
+		return "AlgorithmFailureCode::Timer";
+	case AlgorithmFailureCode::Array:
+		return "AlgorithmFailureCode::Array";
+	case AlgorithmFailureCode::Csense:
+		return "AlgorithmFailureCode::Csense";
+	case AlgorithmFailureCode::BPrioQueue:
+		return "AlgorithmFailureCode::BPrioQueue";
+	case AlgorithmFailureCode::FixCand:
+		return "AlgorithmFailureCode::FixCand";
+	case AlgorithmFailureCode::BHeap:
+		return "AlgorithmFailureCode::BHeap";
+	case AlgorithmFailureCode::Poolslot:
+		return "AlgorithmFailureCode::Poolslot";
+	case AlgorithmFailureCode::SparVec:
+		return "AlgorithmFailureCode::SparVec";
+	case AlgorithmFailureCode::Convar:
+		return "AlgorithmFailureCode::Convar";
+	case AlgorithmFailureCode::Ostream:
+		return "AlgorithmFailureCode::Ostream";
+	case AlgorithmFailureCode::Hash:
+		return "AlgorithmFailureCode::Hash";
+	case AlgorithmFailureCode::Paramaster:
+		return "AlgorithmFailureCode::Paramaster";
+	case AlgorithmFailureCode::InfeasCon:
+		return "AlgorithmFailureCode::InfeasCon";
+	}
+}
+
 }

--- a/src/ogdf/basic/simple_graph_alg.cpp
+++ b/src/ogdf/basic/simple_graph_alg.cpp
@@ -195,7 +195,8 @@ void makeConnected(Graph& G, List<edge>& added) {
 	}
 }
 
-int connectedComponents(const Graph& G, NodeArray<int>& component, List<node>* isolated) {
+int connectedComponents(const Graph& G, NodeArray<int>& component, List<node>* isolated,
+		ArrayBuffer<node>* reprs) {
 	int nComponent = 0;
 	component.fill(-1);
 
@@ -208,6 +209,9 @@ int connectedComponents(const Graph& G, NodeArray<int>& component, List<node>* i
 
 		if (isolated != nullptr && v->degree() == 0) {
 			isolated->pushBack(v);
+		}
+		if (reprs != nullptr) {
+			reprs->push(v);
 		}
 		S.push(v);
 		component[v] = nComponent;

--- a/src/ogdf/cluster/ClusterPlanarity.cpp
+++ b/src/ogdf/cluster/ClusterPlanarity.cpp
@@ -271,9 +271,9 @@ bool ClusterPlanarity::doTest(const ClusterGraph& G, NodePairs& addedEdges) {
 	Master::STATUS abastatus;
 	try {
 		abastatus = cplanMaster->optimize();
-	} catch (...) {
+	} catch (const std::exception& exc) {
 #ifdef OGDF_DEBUG
-		std::cerr << "ABACUS Optimization failed...\n";
+		std::cerr << "ABACUS Optimization failed: " << exc.what() << "\n";
 #endif
 	}
 

--- a/src/ogdf/fileformats/GraphIO.cpp
+++ b/src/ogdf/fileformats/GraphIO.cpp
@@ -228,6 +228,7 @@ std::ostream& GraphIO::indent(std::ostream& os, int depth) {
 				reader = t->FUNC;                      \
 			}                                          \
 		}                                              \
+		OGDF_ASSERT(reader);                           \
 		std::ifstream is(filename);                    \
 		return is.good() && reader(__VA_ARGS__, is);   \
 	}
@@ -258,6 +259,7 @@ bool GraphIO::read(ClusterGraphAttributes& GA, ClusterGraph& CG, Graph& G, const
 				writer = t->FUNC;                                                                      \
 			}                                                                                          \
 		}                                                                                              \
+		OGDF_ASSERT(writer);                                                                           \
 		std::ofstream os(filename);                                                                    \
 		return os.good() && writer(ARG, os);                                                           \
 	}

--- a/src/ogdf/orthogonal/OrthoLayout.cpp
+++ b/src/ogdf/orthogonal/OrthoLayout.cpp
@@ -167,7 +167,7 @@ void OrthoLayout::call(PlanRep& PG, adjEntry adjExternal, Layout& drawing) {
 		// call flow compaction on grid
 		fc.improvementHeuristics(PG, OR, minDistGrid, gridDrawing,
 				int(gridDrawing.toGrid(m_separation)));
-	} catch (AlgorithmFailureException) {
+	} catch (const AlgorithmFailureException&) {
 		// too bad, that did not work out..
 	}
 


### PR DESCRIPTION
This PR fixes minor inconsistencies and annoyances  throughout the code base. There are two important changes:
- ogdf::Exception now derives from std::exception, so it can also be properly caught by generic exception handlers
- NodeArrays, EdgeArrays and the like no longer contain trash if no explicit default value is specified. This comes as no additional overhead as the default values is always copied anyways, but previously it might have contained trash if not explicitly specified (e.g. in case of pointers).