### PR TITLE
Auto-indent support for Logger

### DIFF
--- a/include/ogdf/basic/Logger.h
+++ b/include/ogdf/basic/Logger.h
@@ -135,8 +135,8 @@ public:
 	//! creates a new Logger-object with given log-mode and local log-level equal globalLogLevel
 	explicit Logger(LogMode m) : Logger(m, m_globalloglevel) { }
 
-	//! creates a new Logger-object with LogMode::Global and given local log-level
-	explicit Logger(Level level) : Logger(LogMode::Global, level) { }
+	//! creates a new Logger-object with LogMode::Log and given local log-level
+	explicit Logger(Level level) : Logger(LogMode::Log, level) { }
 
 	//! creates a new Logger-object with given log-mode and given local log-level
 	Logger(LogMode m, Level level) : m_loglevel(level), m_logmode(m), m_indent(0) { }

--- a/include/ogdf/basic/Logger.h
+++ b/include/ogdf/basic/Logger.h
@@ -113,6 +113,22 @@ public:
 		Statistic
 	};
 
+	class Indent {
+		Logger* m_log;
+		int m_by;
+
+	public:
+		explicit Indent(Logger* log, int by = 1) : m_log(log), m_by(by) { m_log->indent(m_by); }
+
+		explicit Indent(Logger& log, int by = 1) : m_log(&log), m_by(by) { m_log->indent(m_by); }
+
+		Indent(const Indent& copy) = delete;
+
+		Indent& operator=(const Indent& other) = delete;
+
+		~Indent() { m_log->dedent(m_by); }
+	};
+
 	//! creates a new Logger-object with LogMode::Global and local log-level equal globalLogLevel
 	Logger() : Logger(LogMode::Global, m_globalloglevel) { }
 
@@ -123,7 +139,7 @@ public:
 	explicit Logger(Level level) : Logger(LogMode::Global, level) { }
 
 	//! creates a new Logger-object with given log-mode and given local log-level
-	Logger(LogMode m, Level level) : m_loglevel(level), m_logmode(m) { }
+	Logger(LogMode m, Level level) : m_loglevel(level), m_logmode(m), m_indent(0) { }
 
 	//! \name Usage
 	//! @{
@@ -139,8 +155,16 @@ public:
 	}
 
 	//! stream for logging-output (local)
-	std::ostream& lout(Level level = Level::Default) const {
-		return is_lout(level) ? *world : nirvana;
+	std::ostream& lout(Level level = Level::Default, bool indent = true) const {
+		if (is_lout(level)) {
+			if (indent && m_indent > 0) {
+				return *world << std::string(m_indent, '\t');
+			} else {
+				return *world;
+			}
+		} else {
+			return nirvana;
+		}
 	}
 
 	//! stream for statistic-output (local)
@@ -206,6 +230,14 @@ public:
 
 	//! sets the local log-mode
 	void localLogMode(LogMode m) { m_logmode = m; }
+
+	void indent(int by = 1) { setIndent(m_indent + by); }
+
+	void dedent(int by = 1) { setIndent(m_indent - by); }
+
+	int getIndent() const { return m_indent; }
+
+	void setIndent(int indent) { m_indent = std::max(0, indent); }
 
 	//! @}
 	//! \name Global
@@ -280,6 +312,7 @@ private:
 
 	Level m_loglevel;
 	LogMode m_logmode;
+	int m_indent;
 };
 
 inline std::ostream& operator<<(std::ostream& os, Logger::Level level) {


### PR DESCRIPTION
This allows setting a-per instance indent for OGDF Loggers, which is especially useful when debugging nested code. By creating an `Indent _{mylogger};` variable, the indentation can be increased by one until the end of the current scope.