### PR TITLE
Fix CI ccache usage, add `OGDF_ARCH` parameter

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -9,12 +9,13 @@ on: [push]
 
 jobs:
   style:
+    name: "Check code style"
     runs-on: ubuntu-latest
     container: docker.io/ogdf/clang:15
     steps:
-      - uses: actions/checkout@v3
       - name: "Add workspace as a safe directory in containers"
         run: git config --system --add safe.directory $GITHUB_WORKSPACE
+      - uses: actions/checkout@v4
       - run: util/test_clang_format.sh
       - run: util/test_eols.sh
       - run: util/test_number_newlines.sh
@@ -26,28 +27,20 @@ jobs:
       - run: util/test_no_enums.sh
 
   dirs:
+    name: "Check directory structure"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Test directory structure
         run: util/test_directory_structure.sh
 
-  docs:
-    runs-on: ubuntu-latest
-    container: docker.io/ogdf/clang:15
-    steps:
-      - uses: actions/checkout@v3
-      - name: "Add workspace as a safe directory in containers"
-        run: git config --system --add safe.directory $GITHUB_WORKSPACE
-      - name: Test doxygen build
-        run: util/test_doxygen.sh
-
   self-sufficiency:
+    name: "Test self-sufficiency"
     runs-on: ubuntu-latest
     env:
       CCACHE_COMPILERCHECK: "%compiler% -v"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set-up ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
@@ -64,15 +57,16 @@ jobs:
           path: ${{ github.workspace }}/ccache-debug
 
   build-linux:
+    name: "Test ${{ matrix.mode }} build on Linux with ${{ matrix.compiler }}"
     strategy:
       matrix:
         mode: [debug, release]
-        compiler: ['gcc:7', 'gcc:10', 'clang:15']
+        compiler: ['gcc:10', 'clang:15']
     runs-on: ubuntu-latest
     env:
       CCACHE_COMPILERCHECK: "%compiler% -v"
     container: docker.io/ogdf/${{ matrix.compiler }}
-    needs: [style, dirs, docs, self-sufficiency]
+    needs: [style, dirs, self-sufficiency]
     steps:
       - name: Set compiler name
         run: |
@@ -80,15 +74,17 @@ jobs:
           GH_COMPILER_NAME="${GH_COMPILER_NAME//:}"
           echo "GH_COMPILER_NAME=${GH_COMPILER_NAME}" >> "$GITHUB_ENV"
         shell: bash
-      - uses: actions/checkout@v3
       - name: "Add workspace as a safe directory in containers"
         run: git config --system --add safe.directory $GITHUB_WORKSPACE
+      - uses: actions/checkout@v4
       - name: Set-up ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.job }}-${{ matrix.compiler }}-${{ matrix.mode }}
       - name: Check ccache version
         run: ccache --version
+      - name: Check CPU model
+        run: lscpu
       - name: Test ${{ matrix.mode }} build with ${{ matrix.compiler }} and run
         run: |
           util/test_build_and_run.sh \
@@ -96,8 +92,10 @@ jobs:
             ${{ matrix.mode }} \
             ${{ startsWith(matrix.compiler, 'gcc') && 'gcc' || 'clang' }} \
             default_s \
-            -DOGDF_INCLUDE_CGAL=ON \
+            -DOGDF_INCLUDE_CGAL=ON -DOGDF_ARCH=haswell \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        # see "Cloud hosts used by GitHub-hosted runners" in the GH Actions docs
+        # for the oldest used microarchitecture to use with OGDF_ARCH
       - uses: actions/upload-artifact@v3
         name: Upload ccache debug info
         if: ${{ env.CCACHE_DEBUG == 1 }}
@@ -106,13 +104,14 @@ jobs:
           path: ${{ github.workspace }}/ccache-debug
 
   build-macos:
+    name: "Test ${{ matrix.mode }} build on MacOS"
     strategy:
       matrix:
         mode: [debug, release]
     runs-on: macos-latest
-    needs: [style, dirs, docs, self-sufficiency]
+    needs: [style, dirs, self-sufficiency]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: brew install coreutils findutils
       - name: Set-up ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -134,13 +133,37 @@ jobs:
           path: ${{ github.workspace }}/ccache-debug
 
   build-windows:
+    name: "Test ${{ matrix.mode }} build on Windows"
     strategy:
       matrix:
         mode: [debug, release]
     runs-on: windows-latest
-    needs: [style, dirs, docs, self-sufficiency]
+    needs: [style, dirs, self-sufficiency]
     steps:
-      - uses: actions/checkout@v3
-      - uses: microsoft/setup-msbuild@v1.1
+      - uses: actions/checkout@v4
+      - uses: microsoft/setup-msbuild@v1.3
+      - name: Set-up ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.job }}-${{ matrix.mode }}
       - name: Test ${{ matrix.mode }} build and run
         run: powershell util\test_build_and_run.ps1 ${{ matrix.mode == 'debug' && '-debug' }}
+        env:
+          CMAKE_C_COMPILER_LAUNCHER: ccache.exe
+          CMAKE_CXX_COMPILER_LAUNCHER: ccache.exe
+      - uses: actions/upload-artifact@v3
+        name: Upload ccache debug info
+        if: ${{ env.CCACHE_DEBUG == 1 }}
+        with:
+          name: ${{ github.job }}-${{ matrix.mode }}
+          path: ${{ github.workspace }}/ccache-debug
+
+  # this is mostly used to keep the required status checks for PR merging simply
+  summary:
+    needs: [build-linux, build-macos, build-windows]
+    name: "All tests succeeded"
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Everything worked!"
+        shell: bash

--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       matrix:
         mode: [debug, release]
-        compiler: ['gcc:10', 'clang:15']
+        compiler: ['gcc:7', 'gcc:10', 'clang:15']
     runs-on: ubuntu-latest
     env:
       CCACHE_COMPILERCHECK: "%compiler% -v"
@@ -158,7 +158,7 @@ jobs:
           name: ${{ github.job }}-${{ matrix.mode }}
           path: ${{ github.workspace }}/ccache-debug
 
-  # this is mostly used to keep the required status checks for PR merging simply
+  # this is mostly used to keep the required status checks for PR merging simple
   summary:
     needs: [build-linux, build-macos, build-windows]
     name: "All tests succeeded"

--- a/cmake/compiler-specifics.cmake
+++ b/cmake/compiler-specifics.cmake
@@ -39,10 +39,15 @@ if(MSVC)
   endif()
 endif()
 
-# use native arch (ie, activate things like SSE)
+# use specified or native arch (ie, activate things like SSE)
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang" AND NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "^arm")
+  set(OGDF_ARCH "native" CACHE STRING "Target CPU (micro)architecture passed to the compiler via `-march`.")
+  mark_as_advanced(OGDF_ARCH)
+
   # cannot use add_definitions() here because it does not work with check-sse3.cmake
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=${OGDF_ARCH}")
+else()
+  unset(OGDF_ARCH CACHE)
 endif()
 
 # set default warning flags for OGDF and tests

--- a/cmake/compiler-specifics.cmake
+++ b/cmake/compiler-specifics.cmake
@@ -15,7 +15,7 @@ endif()
 # use native arch (ie, activate things like SSE)
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang" AND NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "^arm")
   # cannot use add_definitions() here because it does not work with check-sse3.cmake
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=${OGDF_ARCH}")
 endif()
 
 # set default warning flags for OGDF and tests

--- a/cmake/compiler-specifics.cmake
+++ b/cmake/compiler-specifics.cmake
@@ -10,6 +10,33 @@ if(MSVC)
 
   # COIN has no DLL exports, must hence always be compiled as a static library
   set(COIN_LIBRARY_TYPE STATIC)
+
+  if(CMAKE_CXX_COMPILER_LAUNCHER STREQUAL "ccache.exe")
+    message(STATUS "Configuring MSVC build to use ccache.exe")
+
+    # https://github.com/ccache/ccache/wiki/MS-Visual-Studio#usage-with-cmake
+    find_program(ccache_exe ccache)
+    if(ccache_exe)
+      file(COPY_FILE
+        ${ccache_exe} ${CMAKE_BINARY_DIR}/cl.exe
+        ONLY_IF_DIFFERENT)
+
+      # By default visual studio generators will use /Zi which is not compatible
+      # with ccache for whatever reason.
+      message(STATUS "Setting MSVC debug information format to 'Embedded'")
+      set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>")
+
+      set(CMAKE_VS_GLOBALS
+        "CLToolExe=cl.exe"
+        "CLToolPath=${CMAKE_BINARY_DIR}"
+        "TrackFileAccess=false"
+        "UseMultiToolTask=true"
+        "DebugInformationFormat=OldStyle"
+      )
+    else()
+      message(FATAL_ERROR "Could not find ccache.exe")
+    endif()
+  endif()
 endif()
 
 # use native arch (ie, activate things like SSE)

--- a/cmake/ogdf.cmake
+++ b/cmake/ogdf.cmake
@@ -23,12 +23,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang" AND OGDF_MEMORY_MANAGER STREQUAL MA
 else()
   unset(OGDF_LEAK_CHECK CACHE)
 endif()
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-  set(OGDF_ARCH "native" CACHE STRING "Target CPU (micro)architecture passed to the compiler via `-march`.")
-  mark_as_advanced(OGDF_ARCH)
-else()
-  unset(OGDF_ARCH CACHE)
-endif()
 
 # set debug mode
 if(OGDF_DEBUG_MODE STREQUAL HEAVY)

--- a/cmake/ogdf.cmake
+++ b/cmake/ogdf.cmake
@@ -23,6 +23,12 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang" AND OGDF_MEMORY_MANAGER STREQUAL MA
 else()
   unset(OGDF_LEAK_CHECK CACHE)
 endif()
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  set(OGDF_ARCH "native" CACHE STRING "Target CPU (micro)architecture passed to the compiler via `-march`.")
+  mark_as_advanced(OGDF_ARCH)
+else()
+  unset(OGDF_ARCH CACHE)
+endif()
 
 # set debug mode
 if(OGDF_DEBUG_MODE STREQUAL HEAVY)


### PR DESCRIPTION
This assigns proper names to the individual job steps, allowing them to be properly set as required for merging PRs.
I could no longer reproduce the Windows problems from #97. 
`ccache` is now used on all platforms (including Windows), the script in the comment below can be used to check its coverage.
Finally, the new build flag `OGDF_ARCH` can be used to control the value of `-march`, defaulting to `native`. In the case of our CI, this ensures that the cached binaries are compatible with the oldest generation of runner machines ([`haswell`](https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html)), but this should also be useful for generating portable builds that can be packaged on conan, pypi, etc. (using [`x86-64`](https://stackoverflow.com/questions/27786932/what-is-the-default-for-gcc-march-option)).
