### PR TITLE
TreeLayout only handles TreeLayout::RootSelectionType::Source

### DIFF
--- a/include/ogdf/basic/simple_graph_alg.h
+++ b/include/ogdf/basic/simple_graph_alg.h
@@ -922,37 +922,43 @@ inline bool isTree(const Graph& G) {
  * @param G is the input graph.
  * @param roots is assigned the list of root nodes of the arborescences in the forest.
  * If false is returned, \p roots is undefined.
+ * @param outTree set to false if the root nodes are sinks.
  * @return true if \p G represents an arborescence forest, false otherwise.
  */
-OGDF_EXPORT bool isArborescenceForest(const Graph& G, List<node>& roots);
+OGDF_EXPORT bool isArborescenceForest(const Graph& G, List<node>& roots, bool outTree = true);
 
 //! Returns true iff \p G is a forest consisting only of arborescences.
 /**
  * @ingroup ga-tree
  *
  * @param G is the input graph.
+ * @param outTree set to false if the root nodes are sinks.
  * @return true if \p G represents an arborescence forest, false otherwise.
  */
-inline bool isArborescenceForest(const Graph& G) {
+inline bool isArborescenceForest(const Graph& G, bool outTree = true) {
 	List<node> roots;
-	return isArborescenceForest(G, roots);
+	return isArborescenceForest(G, roots, outTree);
 }
 
 
 OGDF_DEPRECATED("isArborescenceForest() should be used instead.")
 
 /**
- * @copydoc ogdf::isArborescenceForest(const Graph& G, List<node> &roots)
+ * @copydoc ogdf::isArborescenceForest(const Graph& G, List<node> &roots, bool outTree = true)
  */
-inline bool isForest(const Graph& G, List<node>& roots) { return isArborescenceForest(G, roots); }
+inline bool isForest(const Graph& G, List<node>& roots, bool outTree = true) {
+	return isArborescenceForest(G, roots, outTree);
+}
 
 
 OGDF_DEPRECATED("isArborescenceForest() should be used instead.")
 
 /**
- * @copydoc ogdf::isArborescenceForest(const Graph& G)
+ * @copydoc ogdf::isArborescenceForest(const Graph& G, bool outTree = true)
  */
-inline bool isForest(const Graph& G) { return isArborescenceForest(G); }
+inline bool isForest(const Graph& G, bool outTree = true) {
+	return isArborescenceForest(G, outTree);
+}
 
 //! Returns true iff \p G represents an arborescence.
 /**
@@ -960,20 +966,22 @@ inline bool isForest(const Graph& G) { return isArborescenceForest(G); }
  *
  * @param G    is the input graph.
  * @param root is assigned the root node (if true is returned).
+ * @param outTree set to false if the root node is a sink.
  * @return true if \p G represents an arborescence, false otherwise.
  */
-OGDF_EXPORT bool isArborescence(const Graph& G, node& root);
+OGDF_EXPORT bool isArborescence(const Graph& G, node& root, bool outTree = true);
 
 //! Returns true iff \p G represents an arborescence.
 /**
  * @ingroup ga-tree
  *
  * @param G  is the input graph.
+ * @param outTree set to false if the root node is a sink.
  * @return true if \p G represents an arborescence, false otherwise.
  */
-inline bool isArborescence(const Graph& G) {
+inline bool isArborescence(const Graph& G, bool outTree = true) {
 	node root;
-	return isArborescence(G, root);
+	return isArborescence(G, root, outTree);
 }
 
 //! @}

--- a/src/ogdf/basic/simple_graph_alg.cpp
+++ b/src/ogdf/basic/simple_graph_alg.cpp
@@ -1210,7 +1210,7 @@ void makeBimodal(Graph& G, List<edge>& newEdge) {
 
 // Forest and arborescence testing
 
-bool isArborescenceForest(const Graph& G, List<node>& roots) {
+bool isArborescenceForest(const Graph& G, List<node>& roots, bool outTree) {
 	roots.clear();
 	if (G.empty()) {
 		return true;
@@ -1220,12 +1220,13 @@ bool isArborescenceForest(const Graph& G, List<node>& roots) {
 		return false;
 	}
 
+	bool inTree = !outTree;
 	ArrayBuffer<node> stack;
 	int nodeCount = 0;
 
 	// Push every source node to roots and start a dfs from it.
 	for (node u : G.nodes) {
-		if (u->indeg() == 0) {
+		if ((outTree && u->indeg() == 0) || (inTree && u->outdeg() == 0)) {
 			roots.pushBack(u);
 			stack.push(u);
 
@@ -1237,9 +1238,9 @@ bool isArborescenceForest(const Graph& G, List<node>& roots) {
 				// Push all successors of v to the stack.
 				// If one of them has indegree > 1, return false.
 				for (adjEntry adj : v->adjEntries) {
-					if (adj->isSource()) {
+					if ((outTree && adj->isSource()) || (inTree && !adj->isSource())) {
 						node w = adj->twinNode();
-						if (w->indeg() > 1) {
+						if ((outTree && w->indeg() > 1) || (inTree && w->outdeg() > 1)) {
 							return false;
 						}
 						stack.push(w);
@@ -1253,10 +1254,10 @@ bool isArborescenceForest(const Graph& G, List<node>& roots) {
 	return nodeCount == G.numberOfNodes();
 }
 
-bool isArborescence(const Graph& G, node& root) {
+bool isArborescence(const Graph& G, node& root, bool outTree) {
 	List<node> roots;
 
-	if (isArborescenceForest(G, roots) && roots.size() == 1) {
+	if (isArborescenceForest(G, roots, outTree) && roots.size() == 1) {
 		root = roots.front();
 		return true;
 	}

--- a/src/ogdf/tree/TreeLayout.cpp
+++ b/src/ogdf/tree/TreeLayout.cpp
@@ -373,10 +373,18 @@ void TreeLayout::call(GraphAttributes& AG) {
 		return;
 	}
 
-	OGDF_ASSERT(isArborescenceForest(tree));
+#ifdef OGDF_DEBUG
+	if (m_selectRoot == RootSelectionType::Source) {
+		OGDF_ASSERT(isArborescenceForest(tree, true));
+	} else if (m_selectRoot == RootSelectionType::Sink) {
+		OGDF_ASSERT(isArborescenceForest(tree, false));
+	} else {
+		OGDF_ASSERT(isAcyclicUndirected(tree));
+	}
 	OGDF_ASSERT(m_siblingDistance > 0);
 	OGDF_ASSERT(m_subtreeDistance > 0);
 	OGDF_ASSERT(m_levelDistance > 0);
+#endif
 
 	// compute the tree structure
 	List<node> roots;

--- a/src/ogdf/tree/TreeLayout.cpp
+++ b/src/ogdf/tree/TreeLayout.cpp
@@ -437,7 +437,7 @@ void TreeLayout::call(GraphAttributes& AG) {
 			firstWalk(ts, root, false);
 			secondWalkY(ts, root, -ts.m_preliminary[root]);
 
-			// compute y-coordinates
+			// compute x-coordinates
 			computeXCoordinatesAndEdgeShapes(root, AG);
 
 			if (it != roots.begin()) {


### PR DESCRIPTION
Addresses issue #195 (314 on GitLab).
The layout may not be what one would expect but it does not crash anymore.
Adjusting the layout would require further work.