### PR TITLE
Automatically indent Doxygen comments

### DIFF
--- a/include/ogdf/basic/DisjointSets.h
+++ b/include/ogdf/basic/DisjointSets.h
@@ -140,8 +140,8 @@ private:
 public:
 	//! Creates an empty DisjointSets structure.
 	/**
-	* \param maxNumberOfElements Expected number of Elements.
-	*/
+	 * \param maxNumberOfElements Expected number of Elements.
+	 */
 	explicit DisjointSets(int maxNumberOfElements = (1 << 15))
 		: m_parents(nullptr), m_parameters(nullptr), m_siblings(nullptr) {
 		init(maxNumberOfElements);
@@ -181,10 +181,10 @@ public:
 
 	//! Returns the id of the largest superset of \p set and compresses the path according to ::CompressionOptions.
 	/**
-	* \param set Set.
-	* \return Superset id
-	* \pre \p set is a non negative properly initialized id.
-	*/
+	 * \param set Set.
+	 * \return Superset id
+	 * \pre \p set is a non negative properly initialized id.
+	 */
 	int find(int set) {
 		OGDF_ASSERT(set >= 0);
 		OGDF_ASSERT(set < m_numberOfElements);
@@ -193,10 +193,10 @@ public:
 
 	//! Returns the id of the largest superset of \p set.
 	/**
-	* \param set Set.
-	* \return Superset id
-	* \pre \p set is a non negative properly initialized id.
-	*/
+	 * \param set Set.
+	 * \return Superset id
+	 * \pre \p set is a non negative properly initialized id.
+	 */
 	int getRepresentative(int set) const {
 		OGDF_ASSERT(set >= 0);
 		OGDF_ASSERT(set < m_numberOfElements);
@@ -208,8 +208,8 @@ public:
 
 	//! Initializes a singleton set.
 	/**
-	* \return Set id of the initialized singleton set.
-	*/
+	 * \return Set id of the initialized singleton set.
+	 */
 	int makeSet() {
 		if (this->m_numberOfElements == this->m_maxNumberOfElements) {
 			int* parents = this->m_parents;
@@ -249,9 +249,9 @@ public:
 
 	//! Unions \p set1 and \p set2.
 	/**
-	* \pre \p set1 and \p set2 are maximal disjoint sets.
-	* \return Set id of the union.
-	*/
+	 * \pre \p set1 and \p set2 are maximal disjoint sets.
+	 * \return Set id of the union.
+	 */
 	int link(int set1, int set2) {
 		OGDF_ASSERT(set1 == getRepresentative(set1));
 		OGDF_ASSERT(set2 == getRepresentative(set2));
@@ -264,8 +264,8 @@ public:
 
 	//! Unions the maximal disjoint sets containing \p set1 and \p set2.
 	/**
-	* \return True, if the maximal sets containing \p set1 and \p set2 were disjoint und joined correctly. False otherwise.
-	*/
+	 * \return True, if the maximal sets containing \p set1 and \p set2 were disjoint und joined correctly. False otherwise.
+	 */
 	bool quickUnion(int set1, int set2) {
 		if (set1 == set2) {
 			return false;

--- a/include/ogdf/basic/DualGraph.h
+++ b/include/ogdf/basic/DualGraph.h
@@ -143,44 +143,44 @@ public:
 
 	//! Returns the node in the primal graph corresponding to \p f.
 	/**
-	* @param f is a face in the embedding of the dual graph
-	* \return the corresponding node in the primal graph
-	*/
+	 * @param f is a face in the embedding of the dual graph
+	 * \return the corresponding node in the primal graph
+	 */
 	const node& primalNode(face f) const { return m_primalNode[f]; }
 
 	//! Returns the edge in the primal graph corresponding to \p e.
 	/**
-	* @param e is an edge in the dual graph
-	* \return the corresponding edge in the primal graph
-	*/
+	 * @param e is an edge in the dual graph
+	 * \return the corresponding edge in the primal graph
+	 */
 	const edge& primalEdge(edge e) const { return m_primalEdge[e]; }
 
 	//! Returns the face in the embedding of the primal graph corresponding to \p v.
 	/**
-	* @param v is a node in the dual graph
-	* \return the corresponding face in the embedding of the primal graph
-	*/
+	 * @param v is a node in the dual graph
+	 * \return the corresponding face in the embedding of the primal graph
+	 */
 	const face& primalFace(node v) const { return m_primalFace[v]; }
 
 	//! Returns the node in the dual graph corresponding to \p f.
 	/**
-	* @param f is a face in the embedding of the primal graph
-	* \return the corresponding node in the dual graph
-	*/
+	 * @param f is a face in the embedding of the primal graph
+	 * \return the corresponding node in the dual graph
+	 */
 	const node& dualNode(face f) const { return m_dualNode[f]; }
 
 	//! Returns the edge in the dual graph corresponding to \p e.
 	/**
-	* @param e is an edge in the primal graph
-	* \return the corresponding edge in the dual graph
-	*/
+	 * @param e is an edge in the primal graph
+	 * \return the corresponding edge in the dual graph
+	 */
 	const edge& dualEdge(edge e) const { return m_dualEdge[e]; }
 
 	//! Returns the face in the embedding of the dual graph corresponding to \p v.
 	/**
-	* @param v is a node in the primal graph
-	* \return the corresponding face in the embedding of the dual graph
-	*/
+	 * @param v is a node in the primal graph
+	 * \return the corresponding face in the embedding of the dual graph
+	 */
 	const face& dualFace(node v) const { return m_dualFace[v]; }
 
 	//! @}

--- a/include/ogdf/basic/GraphAttributes.h
+++ b/include/ogdf/basic/GraphAttributes.h
@@ -874,8 +874,8 @@ public:
 
 	//! @}
 	/**
-	* @name Layout transformations
-	*/
+	 * @name Layout transformations
+	 */
 	//! @{
 
 	//! Scales the layout by (\p sx,\p sy).
@@ -892,13 +892,13 @@ public:
 
 	//! Scales the layout by \p s.
 	/**
-	* If \p scaleNodes is true, node sizes are scaled as well.
-	*
-	* \param s          is the scaling factor for both x- and y-coordinates.
-	* \param scaleNodes determines if nodes size are scaled as well (true) or not.
-	*
-	* \pre #nodeGraphics and #edgeGraphics are enabled
-	*/
+	 * If \p scaleNodes is true, node sizes are scaled as well.
+	 *
+	 * \param s          is the scaling factor for both x- and y-coordinates.
+	 * \param scaleNodes determines if nodes size are scaled as well (true) or not.
+	 *
+	 * \pre #nodeGraphics and #edgeGraphics are enabled
+	 */
 	virtual void scale(double s, bool scaleNodes = true) { scale(s, s, scaleNodes); }
 
 	//! Translates the layout by (\p dx,\p dy).
@@ -927,42 +927,42 @@ public:
 
 	//! Flips the layout horizontally within its bounding box.
 	/**
-	* If preserving the bounding box is not required, the layout can also be flipped horizontally
-	* by calling <tt>scale(-1.0, 1.0, false)</tt>.
-	*/
+	 * If preserving the bounding box is not required, the layout can also be flipped horizontally
+	 * by calling <tt>scale(-1.0, 1.0, false)</tt>.
+	 */
 	virtual void flipHorizontal() { flipHorizontal(boundingBox()); }
 
 	//! Flips the (whole) layout horizontally such that the part in \p box remains in this area.
 	/**
-	* The whole layout is flipped and then moved such that the part that was in \p box before
-	* flipping is moved to this area.
-	*/
+	 * The whole layout is flipped and then moved such that the part that was in \p box before
+	 * flipping is moved to this area.
+	 */
 	virtual void flipHorizontal(const DRect& box);
 
 	//! Scales the layout by (\p sx,\p sy) and then translates it by (\p dx,\p dy).
 	/**
-	* If \p scaleNodes is true, node sizes are scaled as well. A point (\a x,\a y) is
-	* moved to (\p sx &sdot; \a x + \p dx, \p sy &sdot; \a y + \p dy).
-	*
-	* \param sx         is the scaling factor for x-coordinates.
-	* \param sy         is the scaling factor for y-coordinates.
-	* \param dx         is the translation in x-direction.
-	* \param dy         is the translation in y-direction.
-	* \param scaleNodes determines if nodes size are scaled as well (true) or not.
-	*/
+	 * If \p scaleNodes is true, node sizes are scaled as well. A point (\a x,\a y) is
+	 * moved to (\p sx &sdot; \a x + \p dx, \p sy &sdot; \a y + \p dy).
+	 *
+	 * \param sx         is the scaling factor for x-coordinates.
+	 * \param sy         is the scaling factor for y-coordinates.
+	 * \param dx         is the translation in x-direction.
+	 * \param dy         is the translation in y-direction.
+	 * \param scaleNodes determines if nodes size are scaled as well (true) or not.
+	 */
 	virtual void scaleAndTranslate(double sx, double sy, double dx, double dy,
 			bool scaleNodes = true);
 
 	//! Scales the layout by \p s and then translates it by (\p dx,\p dy).
 	/**
-	* If \p scaleNodes is true, node sizes are scaled as well. A point (\a x,\a y) is
-	* moved to (\p s &sdot; \a x + \p dx, \p s &sdot; \a y + \p dy).
-	*
-	* \param s          is the scaling factor for both x- and y-coordinates.
-	* \param dx         is the translation in x-direction.
-	* \param dy         is the translation in y-direction.
-	* \param scaleNodes determines if nodes size are scaled as well (true) or not.
-	*/
+	 * If \p scaleNodes is true, node sizes are scaled as well. A point (\a x,\a y) is
+	 * moved to (\p s &sdot; \a x + \p dx, \p s &sdot; \a y + \p dy).
+	 *
+	 * \param s          is the scaling factor for both x- and y-coordinates.
+	 * \param dx         is the translation in x-direction.
+	 * \param dy         is the translation in y-direction.
+	 * \param scaleNodes determines if nodes size are scaled as well (true) or not.
+	 */
 	virtual void scaleAndTranslate(double s, double dx, double dy, bool scaleNodes = true) {
 		scaleAndTranslate(s, s, dx, dy, scaleNodes);
 	}

--- a/include/ogdf/basic/GraphCopy.h
+++ b/include/ogdf/basic/GraphCopy.h
@@ -101,15 +101,15 @@ public:
 	edge original(edge e) const { return m_eOrig[e]; }
 
 	/**
-	* Returns the adjacency entry in the original graph corresponding to \p adj.
-	*
-	* Note that this method does not pay attention to reversed edges.
-	* Given a source (target) adjacency entry, the source (target) adjacency entry of the
-	* original edge is returned.
-	*
-	* @param adj is an adjacency entry in the copy graph.
-	* \return the corresponding adjacency entry in the original graph.
-	*/
+	 * Returns the adjacency entry in the original graph corresponding to \p adj.
+	 *
+	 * Note that this method does not pay attention to reversed edges.
+	 * Given a source (target) adjacency entry, the source (target) adjacency entry of the
+	 * original edge is returned.
+	 *
+	 * @param adj is an adjacency entry in the copy graph.
+	 * \return the corresponding adjacency entry in the original graph.
+	 */
 	adjEntry original(adjEntry adj) const {
 		edge f = m_eOrig[adj->theEdge()];
 		return adj->isSource() ? f->adjSource() : f->adjTarget();
@@ -305,18 +305,18 @@ public:
 	edge original(edge e) const { return m_eOrig[e]; }
 
 	/**
-	* Returns the adjacency entry in the original graph corresponding to \p adj.
-	*
-	* Note that this method does not pay attention to reversed edges.
-	* Given a source (target) adjacency entry, the source (target) adjacency entry of the
-	* original edge is returned.
-	*
-	* This method must not be called on inner adjacency entries of a
-	* copy chain but only on a chain's source/target entry.
-	*
-	* @param adj is an adjacency entry in the copy graph.
-	* \return the corresponding adjacency entry in the original graph.
-	*/
+	 * Returns the adjacency entry in the original graph corresponding to \p adj.
+	 *
+	 * Note that this method does not pay attention to reversed edges.
+	 * Given a source (target) adjacency entry, the source (target) adjacency entry of the
+	 * original edge is returned.
+	 *
+	 * This method must not be called on inner adjacency entries of a
+	 * copy chain but only on a chain's source/target entry.
+	 *
+	 * @param adj is an adjacency entry in the copy graph.
+	 * \return the corresponding adjacency entry in the original graph.
+	 */
 	adjEntry original(adjEntry adj) const {
 		edge e = adj->theEdge();
 		edge f = m_eOrig[e];
@@ -354,15 +354,15 @@ public:
 	edge copy(edge e) const { return m_eCopy[e].empty() ? nullptr : m_eCopy[e].front(); }
 
 	/**
-	* Returns the adjacency entry in the copy graph corresponding to \p adj.
-	*
-	* Note that this method does not pay attention to reversed edges.
-	* Given a source (target) adjacency entry, the first (last) source (target) adjacency entry of the
-	* copy chain is returned.
-	*
-	* @param adj is an adjacency entry in the copy graph.
-	* \return the corresponding adjacency entry in the original graph.
-	*/
+	 * Returns the adjacency entry in the copy graph corresponding to \p adj.
+	 *
+	 * Note that this method does not pay attention to reversed edges.
+	 * Given a source (target) adjacency entry, the first (last) source (target) adjacency entry of the
+	 * copy chain is returned.
+	 *
+	 * @param adj is an adjacency entry in the copy graph.
+	 * \return the corresponding adjacency entry in the original graph.
+	 */
 	adjEntry copy(adjEntry adj) const {
 		edge e = adj->theEdge();
 
@@ -582,7 +582,7 @@ public:
 	 * @param rightToLeft is used as follows: If set to true, \p crossingEdge will cross
 	 *        \p crossedEdge from right to left, otherwise from left to right.
 	 * @return the rear edge resulting from the split operation: (\a u, \a w)
-	*/
+	 */
 	edge insertCrossing(edge& crossingEdge, edge crossedEdge, bool rightToLeft);
 
 

--- a/include/ogdf/basic/Graph_d.h
+++ b/include/ogdf/basic/Graph_d.h
@@ -542,10 +542,10 @@ private:
 
 public:
 	/**
-	* @name Iterators
-	* These types are used for graph object iterators, which are returned by graph object containers
-	* like nodes and edges.
-	*/
+	 * @name Iterators
+	 * These types are used for graph object iterators, which are returned by graph object containers
+	 * like nodes and edges.
+	 */
 	//! @{
 
 	//! Provides a bidirectional iterator to a node in a graph.
@@ -557,9 +557,9 @@ public:
 
 	//! @}
 	/**
-	* @name Enumerations
-	* These enumerations are mainly meant for advanced or internal usage scenarios.
-	*/
+	 * @name Enumerations
+	 * These enumerations are mainly meant for advanced or internal usage scenarios.
+	 */
 	//! @{
 
 	//! The type of edges (only used in derived classes).
@@ -580,9 +580,9 @@ public:
 
 
 	/**
-	* @name Graph object containers
-	* These containers maintain the nodes and edges of the graph, and provide node and edge iterators.
-	*/
+	 * @name Graph object containers
+	 * These containers maintain the nodes and edges of the graph, and provide node and edge iterators.
+	 */
 	//! @{
 
 	//! The container containing all node objects.
@@ -813,7 +813,7 @@ public:
 	 * Hidden edge sets can be restored as a whole. Alternatively a single edge of a such a set can be restored.
 	 *
 	 * Note that all hidden edges are restored when the set of hidden edges is destroyed.
-
+	 *
 	 * Do not delete any nodes incident to hidden edges.
 	 * Do not hide edges while iterating over the edges of a ogdf::Graph.
 	 * Instead, iterate over a copied list of all edges.
@@ -824,17 +824,17 @@ public:
 
 	public:
 		/**
-		* Creates a new set of hidden edges.
-		*
-		* @param graph the graph to be modified
-		*/
+		 * Creates a new set of hidden edges.
+		 *
+		 * @param graph the graph to be modified
+		 */
 		explicit HiddenEdgeSet(Graph& graph) : m_graph(&graph) {
 			m_it = m_graph->m_hiddenEdgeSets.pushFront(this);
 		}
 
 		/**
-		* Restores all hidden edges.
-		*/
+		 * Restores all hidden edges.
+		 */
 		~HiddenEdgeSet() {
 			if (m_graph) {
 				restore();
@@ -843,32 +843,32 @@ public:
 		}
 
 		/**
-		* Hides the given edge.
-		*
-		* \pre the edge is currently not hidden.
-		* \pre the graph associated with this set does still exist.
-		*/
+		 * Hides the given edge.
+		 *
+		 * \pre the edge is currently not hidden.
+		 * \pre the graph associated with this set does still exist.
+		 */
 		void hide(edge e);
 
 		/**
-		* Reveals the given edge.
-		*
-		* \pre the edge is currently hidden using this set.
-		* \pre the graph associated with this set does still exist.
-		*/
+		 * Reveals the given edge.
+		 *
+		 * \pre the edge is currently hidden using this set.
+		 * \pre the graph associated with this set does still exist.
+		 */
 		void restore(edge e);
 
 		/**
-		* Restores all edges contained in this set.
-		* The set will remain valid.
-		*
-		* \pre the graph associated with this set does still exist.
-		*/
+		 * Restores all edges contained in this set.
+		 * The set will remain valid.
+		 *
+		 * \pre the graph associated with this set does still exist.
+		 */
 		void restore();
 
 		/**
-		* Returns the number of edges contained in this set.
-		*/
+		 * Returns the number of edges contained in this set.
+		 */
 		int size();
 
 	private:

--- a/include/ogdf/basic/LayoutStatistics.h
+++ b/include/ogdf/basic/LayoutStatistics.h
@@ -84,7 +84,7 @@ public:
 	 * as each crossing involves two edges.
 	 *
 	 * \param ga Input layout. If it contains bend points, each segment of an edge's polyline is considered as a line segment.
-	             Otherwise, a straight-line drawing is assumed.
+	 *           Otherwise, a straight-line drawing is assumed.
 	 * \return   The number of crossings for each edge.
 	 */
 	static ArrayBuffer<int> numberOfCrossings(const GraphAttributes& ga);
@@ -100,7 +100,7 @@ public:
 	 * corresponding width and height given by \p ga.
 	 *
 	 * \param ga Input layout. If it contains bend points, each segment of an edge's polyline is considered as a line segment.
-	             Otherwise, a straight-line drawing is assumed.
+	 *           Otherwise, a straight-line drawing is assumed.
 	 * \return   The number of node crossings for each edge.
 	 */
 	static ArrayBuffer<int> numberOfNodeCrossings(const GraphAttributes& ga);
@@ -133,7 +133,7 @@ public:
 	 * \warning Do not call this algorithm on drawings with arbitrarily close curves (e.g., curves overlapping on an interval).
 	 *
 	 * \param ga        Input layout. If it contains bend points, each segment of an edge's polyline is considered as a line segment.
-	                    Otherwise, a straight-line drawing is assumed.
+	 *                  Otherwise, a straight-line drawing is assumed.
 	 * \param H         Is assigned the intersection graph.
 	 * \param points    Maps nodes in \p H to their geometric position in the layout.
 	 * \param origNode  Maps nodes in \p H to nodes in \p ga's graph.

--- a/include/ogdf/basic/List.h
+++ b/include/ogdf/basic/List.h
@@ -605,8 +605,8 @@ public:
 
 	//! Adds a new element at the end of the list.
 	/**
-	* The element is constructed in-place with exactly the same arguments \p args as supplied to the function.
-	*/
+	 * The element is constructed in-place with exactly the same arguments \p args as supplied to the function.
+	 */
 	template<class... Args>
 	iterator emplaceBack(Args&&... args) {
 		ListElement<E>* pX = new ListElement<E>(this, nullptr, m_tail, std::forward<Args>(args)...);

--- a/include/ogdf/basic/PQTree.h
+++ b/include/ogdf/basic/PQTree.h
@@ -181,7 +181,7 @@ protected:
 	/**
 	 * Gives every node that has been used once in the
 	 * PQ-tree a unique identification number.
-	*/
+	 */
 	int m_identificationNumber;
 
 	//! Stores the number of leaves.
@@ -531,7 +531,7 @@ protected:
 	 * returning 0 as soon none of the facts is fulfilled.
 	 *
 	 * @return 1 if it succeeded in adding the \p child to \p parent, otherwise 0
-	*/
+	 */
 	virtual bool addNodeToNewParent(PQNode<T, X, Y>* parent, PQNode<T, X, Y>* child,
 			PQNode<T, X, Y>* leftBrother, PQNode<T, X, Y>* rightBrother);
 

--- a/include/ogdf/basic/PriorityQueue.h
+++ b/include/ogdf/basic/PriorityQueue.h
@@ -212,11 +212,11 @@ public:
 	size_type size() const { return m_size; }
 
 	/**
-	* Returns the priority of that handle.
-	*
-	* @param pos The handle
-	* @return The priority
-	*/
+	 * Returns the priority of that handle.
+	 *
+	 * @param pos The handle
+	 * @return The priority
+	 */
 	const T& value(handle pos) const { return m_impl->value(pos); }
 
 	//! Returns the comparator used for ordering elements.

--- a/include/ogdf/basic/Queue.h
+++ b/include/ogdf/basic/Queue.h
@@ -79,9 +79,9 @@ public:
 	~QueuePure() { }
 
 	/**
-	* @name Access methods
-	* These methods provide simple access without changing the list.
-	*/
+	 * @name Access methods
+	 * These methods provide simple access without changing the list.
+	 */
 	//! @{
 
 	//! Returns true iff the queue is empty.
@@ -101,9 +101,9 @@ public:
 
 	//! @}
 	/**
-	* @name Iterators
-	* These methods return forward iterators to elements in the queue.
-	*/
+	 * @name Iterators
+	 * These methods return forward iterators to elements in the queue.
+	 */
 	//! @{
 
 	//! Returns an iterator to the first element of the queue.
@@ -132,9 +132,9 @@ public:
 
 	//! @}
 	/**
-	* @name Operators
-	* The following operators are provided by lists.
-	*/
+	 * @name Operators
+	 * The following operators are provided by lists.
+	 */
 	//! @{
 
 	//! Assignment operator.
@@ -157,9 +157,9 @@ public:
 
 	//! @}
 	/**
-	* @name Adding and removing elements
-	* These method add elements to the list and remove elements from the list.
-	*/
+	 * @name Adding and removing elements
+	 * These method add elements to the list and remove elements from the list.
+	 */
 	//! @{
 
 	//! Adds \p x at the end of queue.
@@ -167,8 +167,8 @@ public:
 
 	//! Adds a new element at the end of the queue.
 	/**
-	* The element is constructed in-place with exactly the same arguments \p args as supplied to the function.
-	*/
+	 * The element is constructed in-place with exactly the same arguments \p args as supplied to the function.
+	 */
 	template<class... Args>
 	iterator emplace(Args&&... args) {
 		return SListPure<E>::emplaceBack(std::forward<Args>(args)...);
@@ -229,9 +229,9 @@ public:
 	~Queue() { }
 
 	/**
-	* @name Access methods
-	* These methods provide simple access without changing the list.
-	*/
+	 * @name Access methods
+	 * These methods provide simple access without changing the list.
+	 */
 	//! @{
 
 	//! Returns true iff the queue is empty.
@@ -254,9 +254,9 @@ public:
 
 	//! @}
 	/**
-	* @name Iterators
-	* These methods return forward iterators to elements in the queue.
-	*/
+	 * @name Iterators
+	 * These methods return forward iterators to elements in the queue.
+	 */
 	//! @{
 
 	//! Returns an iterator to the first element of the queue.
@@ -285,9 +285,9 @@ public:
 
 	//! @}
 	/**
-	* @name Operators
-	* The following operators are provided by lists.
-	*/
+	 * @name Operators
+	 * The following operators are provided by lists.
+	 */
 	//! @{
 
 	//! Assignment operator.
@@ -310,9 +310,9 @@ public:
 
 	//! @}
 	/**
-	* @name Adding and removing elements
-	* These method add elements to the list and remove elements from the list.
-	*/
+	 * @name Adding and removing elements
+	 * These method add elements to the list and remove elements from the list.
+	 */
 	//! @{
 
 	//! Adds \p x at the end of queue.
@@ -320,8 +320,8 @@ public:
 
 	//! Adds a new element at the end of the queue.
 	/**
-	* The element is constructed in-place with exactly the same arguments \p args as supplied to the function.
-	*/
+	 * The element is constructed in-place with exactly the same arguments \p args as supplied to the function.
+	 */
 	template<class... Args>
 	iterator emplace(Args&&... args) {
 		return SList<E>::emplaceBack(std::forward<Args>(args)...);

--- a/include/ogdf/basic/SList.h
+++ b/include/ogdf/basic/SList.h
@@ -454,8 +454,8 @@ public:
 
 	//! Adds a new element at the beginning of the list.
 	/**
-	* The element is constructed in-place with exactly the same arguments \p args as supplied to the function.
-	*/
+	 * The element is constructed in-place with exactly the same arguments \p args as supplied to the function.
+	 */
 	template<class... Args>
 	iterator emplaceFront(Args&&... args) {
 		m_head = new SListElement<E>(this, m_head, std::forward<Args>(args)...);
@@ -478,8 +478,8 @@ public:
 
 	//! Adds a new element at the end of the list.
 	/**
-	* The element is constructed in-place with exactly the same arguments \p args as supplied to the function.
-	*/
+	 * The element is constructed in-place with exactly the same arguments \p args as supplied to the function.
+	 */
 	template<class... Args>
 	iterator emplaceBack(Args&&... args) {
 		SListElement<E>* pNew = new SListElement<E>(this, nullptr, std::forward<Args>(args)...);

--- a/include/ogdf/basic/Skiplist.h
+++ b/include/ogdf/basic/Skiplist.h
@@ -134,9 +134,9 @@ public:
 
 	//! Clears the current skiplist
 	/**
-	* If \p killData is true, the items of the Skiplist (which are stored as
-	* pointers) are automatically deleted.
-	*/
+	 * If \p killData is true, the items of the Skiplist (which are stored as
+	 * pointers) are automatically deleted.
+	 */
 	void clear(bool killData = false) {
 		Element* item = m_start[0];
 		while (item) {

--- a/include/ogdf/basic/basic.h
+++ b/include/ogdf/basic/basic.h
@@ -109,7 +109,7 @@ using std::min;
 /**
  *  The class Initialization is used for initializing global variables.
  *  You should never create instances of it!
-*/
+ */
 class OGDF_EXPORT Initialization {
 public:
 	Initialization();

--- a/include/ogdf/basic/exceptions.h
+++ b/include/ogdf/basic/exceptions.h
@@ -189,8 +189,8 @@ public:
 
 //! %Exception thrown when result of cast is 0.
 /**
-* @ingroup exceptions
-*/
+ * @ingroup exceptions
+ */
 class OGDF_EXPORT DynamicCastFailedException : public Exception {
 public:
 	//! Constructs a dynamic cast failed exception.
@@ -200,8 +200,8 @@ public:
 
 //! %Exception thrown when not enough memory is available to execute an algorithm.
 /**
-* @ingroup exceptions
-*/
+ * @ingroup exceptions
+ */
 class OGDF_EXPORT InsufficientMemoryException : public Exception {
 public:
 	//! Constructs an insufficient memory exception.
@@ -227,8 +227,8 @@ public:
 
 //! %Exception thrown when a data type is not supported by a generic function.
 /**
-* @ingroup exceptions
-*/
+ * @ingroup exceptions
+ */
 class OGDF_EXPORT TypeNotSupportedException : public Exception {
 public:
 	//! Constructs a type-not-supported exception.
@@ -238,8 +238,8 @@ public:
 
 //! %Exception thrown when an algorithm realizes an internal bug that prevents it from continuing.
 /**
-* @ingroup exceptions
-*/
+ * @ingroup exceptions
+ */
 class OGDF_EXPORT AlgorithmFailureException : public Exception {
 public:
 	//! Constructs an algorithm failure exception.
@@ -264,8 +264,8 @@ private:
 
 //! %Exception thrown when an external library shall be used which is not supported.
 /**
-* @ingroup exceptions
-*/
+ * @ingroup exceptions
+ */
 class OGDF_EXPORT LibraryNotSupportedException : public Exception {
 public:
 	//! Constructs a library not supported exception.

--- a/include/ogdf/basic/internal/config.h
+++ b/include/ogdf/basic/internal/config.h
@@ -198,8 +198,8 @@ using std::to_string;
 
 //! Provides information about how OGDF has been configured.
 /**
-* @ingroup system
-*/
+ * @ingroup system
+ */
 class OGDF_EXPORT Configuration {
 public:
 	//! Specifies the operating system for which OGDF has been configured/built.

--- a/include/ogdf/basic/pqtree/PQInternalNode.h
+++ b/include/ogdf/basic/pqtree/PQInternalNode.h
@@ -71,7 +71,7 @@ namespace ogdf {
  * an element of type PQInternalKey automatically sets
  * the PQBasicKey::m_nodePointer (see basicKey) of this element of type
  * PQInternalKey to the newly allocated PQInternalNode.
-*/
+ */
 template<class T, class X, class Y>
 class PQInternalNode : public PQNode<T, X, Y> {
 public:
@@ -123,7 +123,7 @@ public:
 	 * be performed with the deletion of a node, either derive a new class
 	 * with an appropriate destructor, or make use of the function
 	 * CleanNode() of the class template PQTree.
-	*/
+	 */
 	~PQInternalNode() { }
 
 	//! Returns 0. An element of type PQInternalNode does not have a PQLeafKey.

--- a/include/ogdf/basic/pqtree/PQNode.h
+++ b/include/ogdf/basic/pqtree/PQNode.h
@@ -226,7 +226,7 @@ public:
 	/**
 	 * Sets the type of the parent of a node.
 	 * This does not change the type of the parent!
-	*/
+	 */
 	void parentType(PQNodeType newParentType) { m_parentType = newParentType; }
 
 	//! Returs the number of pertinent children of a node.

--- a/include/ogdf/cluster/ClusterAnalysis.h
+++ b/include/ogdf/cluster/ClusterAnalysis.h
@@ -89,9 +89,9 @@ public:
 	// Qualitative
 	//! Returns outer activity status for vertex \p v wrt cluster \p c.
 	/**
-	*  @param c is the cluster for which vertex v's activity status is stored.
-	*  @param v is the vertex for which the activity status is returned.
-	*/
+	 *  @param c is the cluster for which vertex v's activity status is stored.
+	 *  @param v is the vertex for which the activity status is returned.
+	 */
 	bool isOuterActive(node v, cluster c) const;
 	bool isInnerActive(node v, cluster c) const;
 

--- a/include/ogdf/cluster/ClusterGraph.h
+++ b/include/ogdf/cluster/ClusterGraph.h
@@ -123,8 +123,8 @@ public:
 
 
 	/**
-	* @name Access methods
-	*/
+	 * @name Access methods
+	 */
 	//! @{
 
 #ifdef OGDF_DEBUG
@@ -196,9 +196,9 @@ public:
 
 	//! @}
 	/**
-	* @name Iteration over tree structure
-	* Alternatively you can use the containers ClusterElement::nodes, ClusterElement::children and ClusterElement::adjEntries directly.
-	*/
+	 * @name Iteration over tree structure
+	 * Alternatively you can use the containers ClusterElement::nodes, ClusterElement::children and ClusterElement::adjEntries directly.
+	 */
 	//! @{
 
 	//! Returns the first element in the list of child clusters.
@@ -330,10 +330,10 @@ class OGDF_EXPORT ClusterGraph : public GraphObserver {
 
 public:
 	/**
-	* @name Iterators
-	* These types are used for graph object iterators, which are returned by graph object containers
-	* like nodes and edges.
-	*/
+	 * @name Iterators
+	 * These types are used for graph object iterators, which are returned by graph object containers
+	 * like nodes and edges.
+	 */
 	//! @{
 
 	//! Provides a bidirectional iterator to a cluster in a clustered graph.
@@ -342,9 +342,9 @@ public:
 	//! @}
 
 	/**
-	* @name Graph object containers
-	* These containers maintain the nodes and edges of the graph, and provide node and edge iterators.
-	*/
+	 * @name Graph object containers
+	 * These containers maintain the nodes and edges of the graph, and provide node and edge iterators.
+	 */
 	//! @{
 
 	//! The container containing all cluster objects.
@@ -399,8 +399,8 @@ public:
 	virtual ~ClusterGraph();
 
 	/**
-	* @name Access methods
-	*/
+	 * @name Access methods
+	 */
 	//! @{
 
 	//! Returns the root cluster.
@@ -458,8 +458,8 @@ public:
 
 	//! @}
 	/**
-	* @name Modification methods
-	*/
+	 * @name Modification methods
+	 */
 	//! @{
 
 	//! Removes all clusters except for the root cluster.
@@ -547,8 +547,8 @@ public:
 
 
 	/**
-	* @name Cluster tree queries
-	*/
+	 * @name Cluster tree queries
+	 */
 	//! @{
 
 	//! Turns automatic update of node depth values on or off.
@@ -636,8 +636,8 @@ public:
 
 	//! @}
 	/**
-	* @name Adjacent edges
-	*/
+	 * @name Adjacent edges
+	 */
 	//! @{
 
 	//! Returns the list of all edges adjacent to cluster \p c in \p edges.
@@ -683,8 +683,8 @@ public:
 
 	//! @}
 	/**
-	* @name Miscellaneous
-	*/
+	 * @name Miscellaneous
+	 */
 	//! @{
 
 	//! Checks the combinatorial cluster planar embedding.
@@ -706,10 +706,10 @@ public:
 
 	//! @}
 	/**
-	* @name Registering arrays and observers
-	* These methods are used by ClusterArray or ClusterGraphObserver.
-	* There should be no need to use them directly in user code.
-	*/
+	 * @name Registering arrays and observers
+	 * These methods are used by ClusterArray or ClusterGraphObserver.
+	 * There should be no need to use them directly in user code.
+	 */
 	//! @{
 
 	//! Registers a cluster array.
@@ -729,8 +729,8 @@ public:
 
 	//! @}
 	/**
-	* @name Operators and conversion
-	*/
+	 * @name Operators and conversion
+	 */
 	//! @{
 
 	//! Conversion to const Graph reference (to underlying graph).

--- a/include/ogdf/cluster/ClusterGraphAttributes.h
+++ b/include/ogdf/cluster/ClusterGraphAttributes.h
@@ -386,33 +386,33 @@ public:
 
 	//! Scales the layout by (\p sx,\p sy).
 	/**
-	* If \p scaleNodes is true, node sizes are scaled as well.
-	*
-	* \param sx         is the scaling factor for x-coordinates.
-	* \param sy         is the scaling factor for y-coordinates.
-	* \param scaleNodes determines if nodes size are scaled as well (true) or not.
-	*/
+	 * If \p scaleNodes is true, node sizes are scaled as well.
+	 *
+	 * \param sx         is the scaling factor for x-coordinates.
+	 * \param sy         is the scaling factor for y-coordinates.
+	 * \param scaleNodes determines if nodes size are scaled as well (true) or not.
+	 */
 	virtual void scale(double sx, double sy, bool scaleNodes = true) override;
 
 	//! Translates the layout by (\p dx,\p dy).
 	/**
-	* \param dx is the translation in x-direction.
-	* \param dy is the translation in y-direction.
-	*/
+	 * \param dx is the translation in x-direction.
+	 * \param dy is the translation in y-direction.
+	 */
 	virtual void translate(double dx, double dy) override;
 
 	//! Flips the (whole) layout vertically such that the part in \p box remains in this area.
 	/**
-	* The whole layout is flipped and then moved such that the part that was in \p box before
-	* flipping is moved to this area.
-	*/
+	 * The whole layout is flipped and then moved such that the part that was in \p box before
+	 * flipping is moved to this area.
+	 */
 	virtual void flipVertical(const DRect& box) override;
 
 	//! Flips the (whole) layout horizontally such that the part in \p box remains in this area.
 	/**
-	* The whole layout is flipped and then moved such that the part that was in \p box before
-	* flipping is moved to this area.
-	*/
+	 * The whole layout is flipped and then moved such that the part that was in \p box before
+	 * flipping is moved to this area.
+	 */
 	virtual void flipHorizontal(const DRect& box) override;
 
 	//! @}

--- a/include/ogdf/decomposition/BCTree.h
+++ b/include/ogdf/decomposition/BCTree.h
@@ -264,7 +264,7 @@ protected:
 	 *
 	 * It is needed for the generation of the BC-tree by DFS method. It has to be a
 	 * member of class BCTree due to recursive calls to biComp().
-	*/
+	 */
 
 	NodeArray<int> m_number;
 	/**

--- a/include/ogdf/energybased/GEMLayout.h
+++ b/include/ogdf/energybased/GEMLayout.h
@@ -100,7 +100,7 @@ namespace ogdf {
  *     <td>The page ratio used for the layout of connected components.
  *   </tr>
  * </table>
-*/
+ */
 class OGDF_EXPORT GEMLayout : public LayoutModule {
 	// algorithm parameters (see below)
 

--- a/include/ogdf/external/Minisat.h
+++ b/include/ogdf/external/Minisat.h
@@ -71,8 +71,8 @@ public:
 	// values in input are staring with 1/-1 and are recalculated to 0-base in this function
 	//! adds a literal to the clause
 	/**
-	* @param signedVar is a signed int representing a variable
-	*/
+	 * @param signedVar is a signed int representing a variable
+	 */
 	void add(Internal::Var signedVar) {
 		Internal::Lit lit;
 		if (signedVar >= 0) {
@@ -85,8 +85,8 @@ public:
 
 	//! add multiple literals to the clause
 	/**
-	* @param Amount is the number of literals to add to the clause
-	*/
+	 * @param Amount is the number of literals to add to the clause
+	 */
 	void addMultiple(int Amount, ...);
 
 	//! sets the sign of a variable if its present within the clause
@@ -144,9 +144,9 @@ public:
 using clause = Clause*;
 
 /**
-* Represents a simple class for model storage.
-* A model is a feasible assignment of variables.
-*/
+ * Represents a simple class for model storage.
+ * A model is a feasible assignment of variables.
+ */
 class OGDF_EXPORT Model {
 private:
 	//! internal storage of a model by minisat
@@ -205,11 +205,11 @@ public:
 };
 
 /**
-* The Formula class.
-* Variables and Clauses are added to the Formula.
-* The clauses can be resolved to solve a SAT problem.
-* Variables are linear indexed.
-*/
+ * The Formula class.
+ * Variables and Clauses are added to the Formula.
+ * The clauses can be resolved to solve a SAT problem.
+ * Variables are linear indexed.
+ */
 class OGDF_EXPORT Formula : private Internal::Solver {
 private:
 	std::stringstream m_messages;
@@ -235,14 +235,14 @@ public:
 
 	//! creates a new clause within the formula. If not all variables are known, missing ones are generated auomatically
 	/**
-* \returns a Pointer to the created Clause object
-*/
+	 * \returns a Pointer to the created Clause object
+	 */
 	Clause* newClause();
 
 	//! adds a clause to the formula's solver. If not all variables are known, missing ones are generated auomatically
 	/**
-* @param cl is a reference to the clause to be added to the formula
-*/
+	 * @param cl is a reference to the clause to be added to the formula
+	 */
 	void finalizeClause(const clause cl);
 
 	//! Add a clause given by a list of literals
@@ -257,9 +257,9 @@ public:
 
 	//! adds a clause to the formula's solver if all variables are known
 	/**
-* @param cl is a reference to an existing clause within the formula
-* \returns true if the clause was successfully added to the formula's solver, else return false and the clause is NOT added to the formula's solver
-*/
+	 * @param cl is a reference to an existing clause within the formula
+	 * \returns true if the clause was successfully added to the formula's solver, else return false and the clause is NOT added to the formula's solver
+	 */
 	bool finalizeNotExtensibleClause(const clause cl);
 
 	//! returns a clause at position pos in Formula
@@ -279,17 +279,17 @@ public:
 
 	//! tries to solve the formula
 	/**
-* @param ReturnModel is the model output
-* \returns true if the problem is satisfiable and writes the output model to param
-*/
+	 * @param ReturnModel is the model output
+	 * \returns true if the problem is satisfiable and writes the output model to param
+	 */
 	bool solve(Model& ReturnModel);
 
 	//! tries to solve the formula with a time limit in milliseconds
 	/**
- * @param ReturnModel is the model output
- * @param timeLimit is the time limit in milliseconds
- * \returns true if the problem is satisfiable and writes the output model to param
- */
+	 * @param ReturnModel is the model output
+	 * @param timeLimit is the time limit in milliseconds
+	 * \returns true if the problem is satisfiable and writes the output model to param
+	 */
 	bool solve(Model& ReturnModel, double& timeLimit);
 
 	Internal::Var getVarFromLit(const Internal::Lit& lit) { return Internal::var(lit); }

--- a/include/ogdf/fileformats/DotParser.h
+++ b/include/ogdf/fileformats/DotParser.h
@@ -64,33 +64,33 @@ struct SubgraphData;
  * adjustments have been made just for my convenience. Neverthless, my version
  * should be equal to the official one in terms of represented language.
  *
-<a href="http://www.graphviz.org/content/dot-language">
-official DOT specification
-</a>
+ * <a href="http://www.graphviz.org/content/dot-language">
+ * official DOT specification
+ * </a>
  *
-\verbatim
-Graph = [ 'strict' ] ( 'graph' | 'digraph' ) [ id ] '{' [ StmtList ] '}'
-Subgraph = [ 'subgraph' [ id ] ] '{' StmtList '}'
-
-StmtList = Stmt [ ';' ] [ StmtList ]
-Stmt = NodeStmt | EdgeStmt | AttrStmt | AsgnStmt | Subgraph
-
-NodeStmt = NodeId [ AttrList ]
-NodeId = id [ port ]
-
-EdgeStmt = ( NodeId | Subgraph ) EdgeRhs [ AttrList ]
-EdgeRhs = ( '--' | '->' ) ( NodeId | Subgraph) [ EdgeRhs ]
-
-AttrStmt = ( 'graph' | 'node' | 'edge' ) AttrList
-
-AsgnStmt = id '=' id
-
-AttrList = '[' [ AList ] ']' [ AttrList ]
-AList = AsgnStmt [ ',' ] [ AList ]
-
-Port = ':' id [ ':' CompassPt ] | ':' CompassPt
-CompassPt = ( 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w' | 'nw' | 'c' | '_' )
-\endverbatim
+ * \verbatim
+ * Graph = [ 'strict' ] ( 'graph' | 'digraph' ) [ id ] '{' [ StmtList ] '}'
+ * Subgraph = [ 'subgraph' [ id ] ] '{' StmtList '}'
+ *
+ * StmtList = Stmt [ ';' ] [ StmtList ]
+ * Stmt = NodeStmt | EdgeStmt | AttrStmt | AsgnStmt | Subgraph
+ *
+ * NodeStmt = NodeId [ AttrList ]
+ * NodeId = id [ port ]
+ *
+ * EdgeStmt = ( NodeId | Subgraph ) EdgeRhs [ AttrList ]
+ * EdgeRhs = ( '--' | '->' ) ( NodeId | Subgraph) [ EdgeRhs ]
+ *
+ * AttrStmt = ( 'graph' | 'node' | 'edge' ) AttrList
+ *
+ * AsgnStmt = id '=' id
+ *
+ * AttrList = '[' [ AList ] ']' [ AttrList ]
+ * AList = AsgnStmt [ ',' ] [ AList ]
+ *
+ * Port = ':' id [ ':' CompassPt ] | ':' CompassPt
+ * CompassPt = ( 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w' | 'nw' | 'c' | '_' )
+ * \endverbatim
  *
  * The AST building process tries to mirror given grammar as much as possible
  * keeping the code clean and simple. Each grammar's nonterminal symbol has

--- a/include/ogdf/fileformats/TikzWriter.h
+++ b/include/ogdf/fileformats/TikzWriter.h
@@ -182,7 +182,7 @@ private:
 	 *
 	 * @param v node
 	 * @return double width that may be occupied by label text for node \p v
-	*/
+	 */
 	double getTextWidth(node v) const;
 
 	/**

--- a/include/ogdf/geometric/CrossingMinimalPosition.h
+++ b/include/ogdf/geometric/CrossingMinimalPosition.h
@@ -79,9 +79,9 @@ public: // ~Initialize vertex position module
 	}
 
 	/**set the number of edges that are randomly selected to compute the new vertex postion and the number of points that are tested within the best region.
-	* @param number_of_edge_samples  number of randomly selected edges
-	* @param number_of_point_samples number of randomly selected point
-	*/
+	 * @param number_of_edge_samples  number of randomly selected edges
+	 * @param number_of_point_samples number of randomly selected point
+	 */
 	void setSampleSize(const unsigned int number_of_edge_samples,
 			const unsigned int number_of_point_samples) {
 		m_number_of_edge_samples = number_of_edge_samples;

--- a/include/ogdf/graphalg/Clusterer.h
+++ b/include/ogdf/graphalg/Clusterer.h
@@ -54,8 +54,8 @@ public:
 	explicit Clusterer(const Graph& G);
 
 	/**Default constructor allowing to cluster multiple
-	*graphs with the same instance of the Clusterer
-	*graphs */
+	 *graphs with the same instance of the Clusterer
+	 *graphs */
 	Clusterer();
 
 	virtual ~Clusterer() { }

--- a/include/ogdf/graphalg/ClustererModule.h
+++ b/include/ogdf/graphalg/ClustererModule.h
@@ -107,12 +107,12 @@ public:
 	const Graph& getGraph() const { return *m_pGraph; }
 
 	/**
-	* \brief compute some kind of clustering on the graph m_pGraph
-	*
-	* This is the algorithm call that has to be implemented by derived classes
-	*
-	* @param sl is the resulting list of clusters
-	*/
+	 * \brief compute some kind of clustering on the graph m_pGraph
+	 *
+	 * This is the algorithm call that has to be implemented by derived classes
+	 *
+	 * @param sl is the resulting list of clusters
+	 */
 	virtual void computeClustering(SList<SimpleCluster*>& sl) = 0;
 
 	//! translate computed clustering into cluster hierarchy in cluster graph C

--- a/include/ogdf/graphalg/ConnectivityTester.h
+++ b/include/ogdf/graphalg/ConnectivityTester.h
@@ -57,75 +57,75 @@ private:
 	const Graph* m_graph;
 
 	/**
-	* Prepares the graph.
-	* Might create a copy of the actual graph to apply transformations.
-	* This is necessary to compute node connectivity and for undirected graphs.
-	*
-	* @param graph The original graph
-	*/
+	 * Prepares the graph.
+	 * Might create a copy of the actual graph to apply transformations.
+	 * This is necessary to compute node connectivity and for undirected graphs.
+	 *
+	 * @param graph The original graph
+	 */
 	void prepareGraph(const Graph& graph);
 
 	/**
-	* Computes the connectivity of two nodes of the transformed graph.
-	*
-	* @param v The source node
-	* @param u The target node
-	*/
+	 * Computes the connectivity of two nodes of the transformed graph.
+	 *
+	 * @param v The source node
+	 * @param u The target node
+	 */
 	int computeConnectivity(node v, node u);
 
 	/**
-	* Computes the connectivity of all nodes of the transformed graph.
-	*
-	* @param result The connectivity of two nodes each.
-	*               For directed graphs, the first index denotes the source node.
-	*               The connectivity of a node with itself is returned as 0.
-	* @return The minimal connectivity of any two nodes in the graph.
-	*/
+	 * Computes the connectivity of all nodes of the transformed graph.
+	 *
+	 * @param result The connectivity of two nodes each.
+	 *               For directed graphs, the first index denotes the source node.
+	 *               The connectivity of a node with itself is returned as 0.
+	 * @return The minimal connectivity of any two nodes in the graph.
+	 */
 	int computeConnectivity(NodeArray<NodeArray<int>>& result);
 
 	/**
-	* Makes the graph bi-directed.
-	*
-	* @param graph The graph to be altered.
-	*/
+	 * Makes the graph bi-directed.
+	 *
+	 * @param graph The graph to be altered.
+	 */
 	void duplicateEdges(Graph& graph);
 
 	/**
-	* Restricts the flow through each node to 1.
-	* Must be called after #duplicateEdges().
-	*
-	* @param graph The graph to be altered.
-	*/
+	 * Restricts the flow through each node to 1.
+	 * Must be called after #duplicateEdges().
+	 *
+	 * @param graph The graph to be altered.
+	 */
 	void restrictNodes(Graph& graph);
 
 	/**
-	* Retuns the node of the transformed graph corresponding to node \p v.
-	*
-	* @param v the original node
-	* @param isSource Whether to return the corresponding source node.
-	*                 If node connectivity is to be computed, for each original node, two copies exist.
-	*/
+	 * Retuns the node of the transformed graph corresponding to node \p v.
+	 *
+	 * @param v the original node
+	 * @param isSource Whether to return the corresponding source node.
+	 *                 If node connectivity is to be computed, for each original node, two copies exist.
+	 */
 	node copyOf(node v, bool isSource = false) const;
 
 public:
 	/**
-	* Initializes a new connectivity tester using ogdf::MaxFlowGoldbergTarjan.
-	*
-	* @param nodeConnectivity Whether to compute node connectivity instead of edge connectivity
-	* @param directed Whether to consider edges to be directed
-	*/
+	 * Initializes a new connectivity tester using ogdf::MaxFlowGoldbergTarjan.
+	 *
+	 * @param nodeConnectivity Whether to compute node connectivity instead of edge connectivity
+	 * @param directed Whether to consider edges to be directed
+	 */
 	explicit ConnectivityTester(bool nodeConnectivity = true, bool directed = false)
 		: ConnectivityTester(new MaxFlowGoldbergTarjan<int>(), nodeConnectivity, directed) {
 		m_usingDefaultMaxFlow = true;
 	}
 
 	/**
-	* Initializes a new onnectivity tester  using a custom ogdf::MaxFlowModule.
-	*
-	* @param flowAlgo The maximum flow algorithm to be used.
-	* @param nodeConnectivity Whether to compute node connectivity instead of edge connectivity
-	* @param directed Whether to consider edges to be directed
-	*/
+	 * Initializes a new onnectivity tester  using a custom ogdf::MaxFlowModule.
+	 *
+	 * @param flowAlgo The maximum flow algorithm to be used.
+	 * @param nodeConnectivity Whether to compute node connectivity instead of edge connectivity
+	 * @param directed Whether to consider edges to be directed
+	 */
 	ConnectivityTester(MaxFlowModule<int>* flowAlgo, bool nodeConnectivity = true,
 			bool directed = false)
 		: m_flowAlgo(flowAlgo)
@@ -137,8 +137,8 @@ public:
 		, m_graph(nullptr) { }
 
 	/**
-	* Destroys the connectivity tester and frees allocated memory.
-	*/
+	 * Destroys the connectivity tester and frees allocated memory.
+	 */
 	~ConnectivityTester() {
 		if (m_usingDefaultMaxFlow) {
 			delete m_flowAlgo;
@@ -152,14 +152,14 @@ public:
 	}
 
 	/**
-	* Computes the connectivity of two nodes.
-	* To reduce duplicate graph transformations, #computeConnectivity(const Graph &graph, NodeArray<NodeArray<int>> &result)
-	* should be used to compute the connectivity of all nodes.
-	*
-	* @param graph The graph to be investigated
-	* @param v The source node
-	* @param u The target node
-	*/
+	 * Computes the connectivity of two nodes.
+	 * To reduce duplicate graph transformations, #computeConnectivity(const Graph &graph, NodeArray<NodeArray<int>> &result)
+	 * should be used to compute the connectivity of all nodes.
+	 *
+	 * @param graph The graph to be investigated
+	 * @param v The source node
+	 * @param u The target node
+	 */
 	int computeConnectivity(const Graph& graph, node v, node u) {
 		prepareGraph(graph);
 
@@ -167,14 +167,14 @@ public:
 	}
 
 	/**
-	* Computes the connectivity of all nodes of the provided graph.
-	*
-	* @param graph The graph to be investigated
-	* @param result The connectivity of two nodes each.
-	*               For directed graphs, the first index denotes the source node.
-	*               The connectivity of a node with itself is returned as 0.
-	* @return The minimal connectivity of any two nodes in the graph.
-	*/
+	 * Computes the connectivity of all nodes of the provided graph.
+	 *
+	 * @param graph The graph to be investigated
+	 * @param result The connectivity of two nodes each.
+	 *               For directed graphs, the first index denotes the source node.
+	 *               The connectivity of a node with itself is returned as 0.
+	 * @return The minimal connectivity of any two nodes in the graph.
+	 */
 	int computeConnectivity(const Graph& graph, NodeArray<NodeArray<int>>& result) {
 		prepareGraph(graph);
 

--- a/include/ogdf/graphalg/MaxAdjOrdering.h
+++ b/include/ogdf/graphalg/MaxAdjOrdering.h
@@ -53,95 +53,95 @@ namespace ogdf {
 class OGDF_EXPORT MaxAdjOrdering {
 private:
 	/**
-	* \brief This method gets called recursively to generate all MAOs
-	* via backtracking
-	* @param n Number of nodes
-	* @param currentOrder The partial MAO to this point
-	* @param currentUnsorted Nodes that are still left to sort
-	* @param r Values on the nodes that count the edges to the partial MAO
-	* @param MAOs The list of all MAOs to this point
-	*/
+	 * \brief This method gets called recursively to generate all MAOs
+	 * via backtracking
+	 * @param n Number of nodes
+	 * @param currentOrder The partial MAO to this point
+	 * @param currentUnsorted Nodes that are still left to sort
+	 * @param r Values on the nodes that count the edges to the partial MAO
+	 * @param MAOs The list of all MAOs to this point
+	 */
 	void m_calcAllMAOs_recursion(int n, ListPure<node> currentOrder, ListPure<node> currentUnsorted,
 			NodeArray<int> r, ListPure<ListPure<node>>* MAOs);
 
 	/**
-	* \brief This method gets called recursively to generate all MAOs and their
-	* induced forest decompositions of the edges
-	* via backtracking
-	* @param n Number of nodes
-	* @param currentOrder The partial MAO to this point
-	* @param currentForest The partial forest decomposition to this point
-	* @param currentUnsorted Nodes that are still left to sort
-	* @param r Values on the nodes that count the edges to the partial MAO
-	* @param MAOs The list of all MAOs to this point
-	* @param Fs The list of all forests to this point
-	*/
+	 * \brief This method gets called recursively to generate all MAOs and their
+	 * induced forest decompositions of the edges
+	 * via backtracking
+	 * @param n Number of nodes
+	 * @param currentOrder The partial MAO to this point
+	 * @param currentForest The partial forest decomposition to this point
+	 * @param currentUnsorted Nodes that are still left to sort
+	 * @param r Values on the nodes that count the edges to the partial MAO
+	 * @param MAOs The list of all MAOs to this point
+	 * @param Fs The list of all forests to this point
+	 */
 	void m_calcAllMAOs_recursion(int n, ListPure<node> currentOrder,
 			ListPure<ListPure<edge>> currentForest, ListPure<node> currentUnsorted, NodeArray<int> r,
 			ListPure<ListPure<node>>* MAOs, ListPure<ListPure<ListPure<edge>>>* Fs);
 
 public:
 	/**
-	* \brief Standard constructor
-	*/
+	 * \brief Standard constructor
+	 */
 	MaxAdjOrdering();
 	/**
-	* \brief Standard destructor
-	*/
+	 * \brief Standard destructor
+	 */
 	~MaxAdjOrdering();
 
 	/**
-	* \brief Calculates one MAO starting with the node with index 0
-	* @param G is the Graph to work on
-	* @param MAO is the pointer to a list that stores the MAO
-	*/
+	 * \brief Calculates one MAO starting with the node with index 0
+	 * @param G is the Graph to work on
+	 * @param MAO is the pointer to a list that stores the MAO
+	 */
 	void calc(const Graph* G, ListPure<node>* MAO);
 	/**
-	* \brief Calculates one MAO starting with the node with index 0
-	* and lex-bfs tie breaking.
-	* @param G is the Graph to work on
-	* @param MAO is the pointer to a list that stores the MAO
-	*/
+	 * \brief Calculates one MAO starting with the node with index 0
+	 * and lex-bfs tie breaking.
+	 * @param G is the Graph to work on
+	 * @param MAO is the pointer to a list that stores the MAO
+	 */
 	void calcBfs(const Graph* G, ListPure<node>* MAO);
 
 	/**
-	* \brief Calculates one MAO starting with a given node
-	* @param G is the Graph to work on
-	* @param s Node to start the MAO with
-	* @param MAO is the pointer to a list that stores the MAO
-	*/
+	 * \brief Calculates one MAO starting with a given node
+	 * @param G is the Graph to work on
+	 * @param s Node to start the MAO with
+	 * @param MAO is the pointer to a list that stores the MAO
+	 */
 	void calc(const Graph* G, node s, ListPure<node>* MAO);
 
 	/**
-	* \brief Calculates one MAO starting with the node with index 0
-	* @param G is the Graph to work on
-	* @param MAO is the pointer to a list that stores the MAO
-	* @param Forests is the pointer to a list that stores the forest decomposition associated with the MAO
-	*/
+	 * \brief Calculates one MAO starting with the node with index 0
+	 * @param G is the Graph to work on
+	 * @param MAO is the pointer to a list that stores the MAO
+	 * @param Forests is the pointer to a list that stores the forest decomposition associated with the MAO
+	 */
 	void calc(const Graph* G, ListPure<node>* MAO, ListPure<ListPure<edge>>* Forests);
 
 	/**
-	* \brief Calculates one MAO starting with a given node
-	* @param G is the Graph to work on
-	* @param s Node to start the MAO with
-	* @param MAO is the pointer to a list that stores the MAO
-	* @param Forests is the pointer to a list that stores the forest decomposition associated with the MAO
-	*/
+	 * \brief Calculates one MAO starting with a given node
+	 * @param G is the Graph to work on
+	 * @param s Node to start the MAO with
+	 * @param MAO is the pointer to a list that stores the MAO
+	 * @param Forests is the pointer to a list that stores the forest decomposition associated with the MAO
+	 */
 	void calc(const Graph* G, node s, ListPure<node>* MAO, ListPure<ListPure<edge>>* Forests);
 
 	/**
-	* \brief Calculates all MAOs of a given graph
-	* @param G is the Graph to work on
-	* @param MAOs List of all MAOs. So it must be a list of lists
-	*/
+	 * \brief Calculates all MAOs of a given graph
+	 * @param G is the Graph to work on
+	 * @param MAOs List of all MAOs. So it must be a list of lists
+	 */
 	void calcAll(const Graph* G, ListPure<ListPure<node>>* MAOs);
 
 	/**
-	* \brief Calculates all MAOs including their associated forest decompositions of a given graph
-	* @param G is the graph to work on
-	* @param MAOs List of all MAOs. So it must be a list of lists of vertices.
-	* @param Fs List of all forest decompositions. So it must be a list of lists of lists of edges.
-	*/
+	 * \brief Calculates all MAOs including their associated forest decompositions of a given graph
+	 * @param G is the graph to work on
+	 * @param MAOs List of all MAOs. So it must be a list of lists of vertices.
+	 * @param Fs List of all forest decompositions. So it must be a list of lists of lists of edges.
+	 */
 	void calcAll(const Graph* G, ListPure<ListPure<node>>* MAOs,
 			ListPure<ListPure<ListPure<edge>>>* Fs);
 
@@ -162,14 +162,14 @@ public:
 	 * \brief Test if a given ordering is a MAO
 	 * @param G is the graph to work on
 	 * @param Ordering is a ListPure that contains a permutation of the nodes
-	*/
+	 */
 	bool testIfMAO(const Graph* G, ListPure<node>* Ordering);
 
 	/**
 	 * \brief Test if a given ordering is a MAO that follows lex-bfs tie breaking
 	 * @param G is the graph to work on
 	 * @param Ordering is a ListPure that contains a permutation of the nodes
-	*/
+	 */
 	bool testIfMAOBfs(const Graph* G, ListPure<node>* Ordering);
 
 
@@ -186,16 +186,16 @@ public:
 	bool testIfAllMAOs(const Graph* G, ListPure<ListPure<node>>* Orderings,
 			ListPure<ListPure<node>>* Perms);
 	/**
-	* \brief Convenient way to visualize a MAO with the LinearLayout class.
-	* @param GA Graphattributes of the Graph to paint
-	* @param MAO Mao to use for ordering the nodes
-	*/
+	 * \brief Convenient way to visualize a MAO with the LinearLayout class.
+	 * @param GA Graphattributes of the Graph to paint
+	 * @param MAO Mao to use for ordering the nodes
+	 */
 	void visualize(GraphAttributes* GA, ListPure<node>* MAO);
 
 	/**
-	* @copydoc MaxAdjOrdering::visualize(GraphAttributes*, ListPure<node>*)
-	* @param F A forest decomposition that is also visualized
-	*/
+	 * @copydoc MaxAdjOrdering::visualize(GraphAttributes*, ListPure<node>*)
+	 * @param F A forest decomposition that is also visualized
+	 */
 	void visualize(GraphAttributes* GA, ListPure<node>* MAO, ListPure<ListPure<edge>>* F);
 
 	/**

--- a/include/ogdf/graphalg/MinCostFlowModule.h
+++ b/include/ogdf/graphalg/MinCostFlowModule.h
@@ -54,19 +54,19 @@ public:
 	virtual ~MinCostFlowModule() { }
 
 	/**
-	* \brief Computes a min-cost flow in the directed graph \p G.
-	*
-	* \pre \p G must be connected, \p lowerBound[\a e] <= \p upperBound[\a e]
-	*      for all edges \a e, and the sum over all supplies must be zero.
-	*
-	* @param G is the directed input graph.
-	* @param lowerBound gives the lower bound for the flow on each edge.
-	* @param upperBound gives the upper bound for the flow on each edge.
-	* @param cost gives the costs for each edge.
-	* @param supply gives the supply (or demand if negative) of each node.
-	* @param flow is assigned the computed flow on each edge.
-	* \return true iff a feasible min-cost flow exists.
-	*/
+	 * \brief Computes a min-cost flow in the directed graph \p G.
+	 *
+	 * \pre \p G must be connected, \p lowerBound[\a e] <= \p upperBound[\a e]
+	 *      for all edges \a e, and the sum over all supplies must be zero.
+	 *
+	 * @param G is the directed input graph.
+	 * @param lowerBound gives the lower bound for the flow on each edge.
+	 * @param upperBound gives the upper bound for the flow on each edge.
+	 * @param cost gives the costs for each edge.
+	 * @param supply gives the supply (or demand if negative) of each node.
+	 * @param flow is assigned the computed flow on each edge.
+	 * \return true iff a feasible min-cost flow exists.
+	 */
 	virtual bool call(const Graph& G, // directed graph
 			const EdgeArray<int>& lowerBound, // lower bound for flow
 			const EdgeArray<int>& upperBound, // upper bound for flow

--- a/include/ogdf/graphalg/MinCostFlowReinelt.h
+++ b/include/ogdf/graphalg/MinCostFlowReinelt.h
@@ -48,20 +48,20 @@ public:
 	using MinCostFlowModule<TCost>::call;
 
 	/**
-	* \brief Computes a min-cost flow in the directed graph \p G using a network simplex method.
-	*
-	* \pre \p G must be connected, \p lowerBound[\a e] <= \p upperBound[\a e]
-	*      for all edges \a e, and the sum over all supplies must be zero.
-	*
-	* @param G is the directed input graph.
-	* @param lowerBound gives the lower bound for the flow on each edge.
-	* @param upperBound gives the upper bound for the flow on each edge.
-	* @param cost gives the costs for each edge.
-	* @param supply gives the supply (or demand if negative) of each node.
-	* @param flow is assigned the computed flow on each edge.
-	* @param dual is assigned the computed dual variables.
-	* \return true iff a feasible min-cost flow exists.
-	*/
+	 * \brief Computes a min-cost flow in the directed graph \p G using a network simplex method.
+	 *
+	 * \pre \p G must be connected, \p lowerBound[\a e] <= \p upperBound[\a e]
+	 *      for all edges \a e, and the sum over all supplies must be zero.
+	 *
+	 * @param G is the directed input graph.
+	 * @param lowerBound gives the lower bound for the flow on each edge.
+	 * @param upperBound gives the upper bound for the flow on each edge.
+	 * @param cost gives the costs for each edge.
+	 * @param supply gives the supply (or demand if negative) of each node.
+	 * @param flow is assigned the computed flow on each edge.
+	 * @param dual is assigned the computed dual variables.
+	 * \return true iff a feasible min-cost flow exists.
+	 */
 	virtual bool call(const Graph& G, // directed graph
 			const EdgeArray<int>& lowerBound, // lower bound for flow
 			const EdgeArray<int>& upperBound, // upper bound for flow

--- a/include/ogdf/layered/FastHierarchyLayout.h
+++ b/include/ogdf/layered/FastHierarchyLayout.h
@@ -283,7 +283,7 @@ private:
 	 *   1 if it is preferred to move the long edge to the right,
 	 *   0 if there is no preference
 	 * @param marked Array for all nodes. Stores for every node, whether moveLongEdge has already been applied to it.
-	*/
+	 */
 	void moveLongEdge(int actNode, int dir, bool* marked);
 
 	/**

--- a/include/ogdf/layered/GridSifting.h
+++ b/include/ogdf/layered/GridSifting.h
@@ -85,12 +85,9 @@ private:
  * C. Bachmaier, W. Brunner, A. Gleißner, <i>Grid Sifting: Leveling
  * and Crossing Reduction</i>, Technical Report MIP-1103, University
  * of Passau, 2011.
-
+ *
  * This class implements the interface LayeredCrossMinModule and should be
  * used as a part of the Sugiyama algorithm for drawing layered graphs.
- *
- *
- *
  */
 class GridSifting : public LayeredCrossMinModule {
 public:

--- a/include/ogdf/misclayout/BertaultLayout.h
+++ b/include/ogdf/misclayout/BertaultLayout.h
@@ -78,11 +78,11 @@ public:
 	double reqlength() { return req_length; }
 
 	/** Set the initPositions of nodes. Must for graphs without node attributes
-	* c accepts character arguments:
-	* 'm' for Grid-like Layout of nodes
-	* 'c' for arranging nodes in concentric circles
-	* 'r' for random arrangement of nodes
-	*/
+	 * c accepts character arguments:
+	 * 'm' for Grid-like Layout of nodes
+	 * 'c' for arranging nodes in concentric circles
+	 * 'r' for random arrangement of nodes
+	 */
 	void initPositions(GraphAttributes& AG, char c);
 
 	//! Calculates the edge crossings in the graph corresponding to AG. Node attributes required.

--- a/include/ogdf/orthogonal/EdgeRouter.h
+++ b/include/ogdf/orthogonal/EdgeRouter.h
@@ -143,14 +143,14 @@ public:
 
 	//! for all multiple edges, set the delta value on both sides to minimum if not m_minDelta
 	/**
-	* postprocessing function, hmm maybe preprocessing
-	*/
+	 * postprocessing function, hmm maybe preprocessing
+	 */
 	void multiDelta();
 
 	//! set alignment option: place nodes in cage at outgoing generalization
 	/**
-	* postprocessing function, hmm maybe preprocessing
-	*/
+	 * postprocessing function, hmm maybe preprocessing
+	 */
 	void align(bool b) { m_align = b; }
 
 #if 0

--- a/include/ogdf/orthogonal/LongestPathCompaction.h
+++ b/include/ogdf/orthogonal/LongestPathCompaction.h
@@ -59,7 +59,7 @@ class CompactionConstraintGraph;
  *     <td>the maximal number of steps performed by the improvement heuristic; 0 means no upper limit.</td>
  *   </tr>
  * </table>
-*/
+ */
 class OGDF_EXPORT LongestPathCompaction {
 public:
 	//! Creates an instance of the longest path compaction algorithm.

--- a/include/ogdf/planarity/PlanRep.h
+++ b/include/ogdf/planarity/PlanRep.h
@@ -632,7 +632,7 @@ public:
 	 * @param crossedEdge is the edge that is replaced by two new edges.
 	 * @param topDown is used as follows: If set to true, \p crossingEdge will cross
 	 *        \p crossedEdge from right to left, otherwise from left to right.
-	*/
+	 */
 	edge insertCrossing(edge& crossingEdge, edge crossedEdge, bool topDown);
 
 	//! @}

--- a/include/ogdf/planarity/PlanarizerStarReinsertion.h
+++ b/include/ogdf/planarity/PlanarizerStarReinsertion.h
@@ -94,7 +94,7 @@ using embedder::CrossingStructure;
  *     <td>The module for the computation of the planar subgraph.
  *   </tr>
  * </table>
-*/
+ */
 class OGDF_EXPORT PlanarizerStarReinsertion : public CrossingMinimizationModule {
 private:
 	//! The initial planarization algorithm.

--- a/include/ogdf/planarity/SubgraphPlanarizer.h
+++ b/include/ogdf/planarity/SubgraphPlanarizer.h
@@ -102,7 +102,7 @@ namespace ogdf {
  *     subgraph are re-inserted one-by-one, each with as few crossings as possible.
  *   </tr>
  * </table>
-*/
+ */
 class OGDF_EXPORT SubgraphPlanarizer : public CrossingMinimizationModule, public Logger {
 	class ThreadMaster;
 	class Worker;

--- a/include/ogdf/planarity/boyer_myrvold/BoyerMyrvoldInit.h
+++ b/include/ogdf/planarity/boyer_myrvold/BoyerMyrvoldInit.h
@@ -112,12 +112,12 @@ private:
 
 	//! A list to all separated DFS-children of node
 	/** The list is sorted by lowpoint values (in linear time)
-	*/
+	 */
 	NodeArray<ListPure<node>>& m_separatedDFSChildList;
 
 	//! Pointer to node contained in the DFSChildList of his parent, if exists.
 	/** If node isn't in list or list doesn't exist, the pointer is set to nullptr.
-	*/
+	 */
 	NodeArray<ListIterator<node>>& m_pNodeInParent;
 
 	//! Creates and links a virtual vertex of the node belonging to \p father

--- a/include/ogdf/planarity/boyer_myrvold/BoyerMyrvoldPlanar.h
+++ b/include/ogdf/planarity/boyer_myrvold/BoyerMyrvoldPlanar.h
@@ -418,12 +418,12 @@ protected:
 
 	//! A list to all separated DFS-children of node
 	/** The list is sorted by lowpoint values (in linear time)
-	*/
+	 */
 	NodeArray<ListPure<node>> m_separatedDFSChildList;
 
 	//! Pointer to node contained in the DFSChildList of his parent, if exists.
 	/** If node isn't in list or list doesn't exist, the pointer is set to nullptr.
-	*/
+	 */
 	NodeArray<ListIterator<node>> m_pNodeInParent;
 
 	//! @}

--- a/include/ogdf/planarity/boyer_myrvold/FindKuratowskis.h
+++ b/include/ogdf/planarity/boyer_myrvold/FindKuratowskis.h
@@ -263,7 +263,7 @@ protected:
 
 	//! A list to all separated DFS-children of node
 	/** The list is sorted by lowpoint values (in linear time)
-	*/
+	 */
 	const NodeArray<ListPure<node>>& m_separatedDFSChildList;
 
 	//! Identifies the rootnode of the child bicomp the given backedge points to

--- a/include/ogdf/planarity/planar_subgraph_fast/whaInfo.h
+++ b/include/ogdf/planarity/planar_subgraph_fast/whaInfo.h
@@ -36,14 +36,14 @@
 namespace ogdf {
 
 /**
-The definitions for W, B, H and A
-describe the type of a node during the computation of the
-maximal pertinent sequence. A pertinent node X in the PQ-tree will be
-either of type B, W, A or H. Together
-with some other information stored at every node the pertinent leaves
-in the frontier of X that have to be deleted. For further
-description of the types see Jayakumar, Thulasiraman and Swamy 1989.
-*/
+ * The definitions for W, B, H and A
+ * describe the type of a node during the computation of the
+ * maximal pertinent sequence. A pertinent node X in the PQ-tree will be
+ * either of type B, W, A or H. Together
+ * with some other information stored at every node the pertinent leaves
+ * in the frontier of X that have to be deleted. For further
+ * description of the types see Jayakumar, Thulasiraman and Swamy 1989.
+ */
 
 enum class whaType { W, B, H, A };
 

--- a/include/ogdf/simultaneous/SimDraw.h
+++ b/include/ogdf/simultaneous/SimDraw.h
@@ -71,9 +71,9 @@ private:
 public:
 	//! constructs empty simdraw instance
 	/**
-	* GraphAttributes::edgeSubGraphs is activated.
-	* No other attributes are active.
-	*/
+	 * GraphAttributes::edgeSubGraphs is activated.
+	 * No other attributes are active.
+	 */
 	SimDraw();
 
 	//! returns graph
@@ -103,9 +103,9 @@ public:
 
 	//! returns true if node \p v is marked as dummy
 	/**
-	* All dummy node features are introduced for usage when running
-	* callSubgraphPlanarizer of SimDrawCaller.
-	*/
+	 * All dummy node features are introduced for usage when running
+	 * callSubgraphPlanarizer of SimDrawCaller.
+	 */
 	const bool& isDummy(node v) const { return m_isDummy[v]; }
 
 	//! returns true if node \p v is marked as dummy
@@ -134,18 +134,18 @@ public:
 
 	//! calculates maximum number of input graphs
 	/**
-	* Subgraphs are numbered from 0 to 31.
-	* This method returns the number of the maximal used subgraph.
-	* If the graph is empty, the function returns -1.
-	*/
+	 * Subgraphs are numbered from 0 to 31.
+	 * This method returns the number of the maximal used subgraph.
+	 * If the graph is empty, the function returns -1.
+	 */
 	int maxSubGraph() const;
 
 	//! returns number of BasicGraphs in m_G
 	/**
-	* This function uses maxSubGraph to return the number of
-	* basic graphs contained in m_G.
-	* If the graph is empty, the function returns 0.
-	*/
+	 * This function uses maxSubGraph to return the number of
+	 * basic graphs contained in m_G.
+	 * If the graph is empty, the function returns 0.
+	 */
 	int numberOfBasicGraphs() const;
 
 	//! calls GraphAttributes::readGML
@@ -157,29 +157,29 @@ public:
 	const Graph getBasicGraph(int i) const;
 	//! returns graphattributes associated with basic graph \p i
 	/**
-	* Supported attributes are:
-	* nodeGraphics, edgeGraphics, edgeLabel, nodeLabel, nodeId,
-	* edgeIntWeight and edgeColor.
-	*/
+	 * Supported attributes are:
+	 * nodeGraphics, edgeGraphics, edgeLabel, nodeLabel, nodeId,
+	 * edgeIntWeight and edgeColor.
+	 */
 	void getBasicGraphAttributes(int i, GraphAttributes& GA, Graph& G);
 
 	//! adds new GraphAttributes to m_G
 	/**
-	* If the number of subgraphs in m_G is less than 32, this
-	* function will add the new GraphAttributes \p GA to m_G
-	* and return true.
-	* Otherwise this function returns false.
-	* The function uses the current compare mode.
-	*/
+	 * If the number of subgraphs in m_G is less than 32, this
+	 * function will add the new GraphAttributes \p GA to m_G
+	 * and return true.
+	 * Otherwise this function returns false.
+	 * The function uses the current compare mode.
+	 */
 	bool addGraphAttributes(const GraphAttributes& GA);
 
 	//! adds the graph g to the instance m_G
 	/**
-	* If the number of subgraphs in m_G is less than 32 and
-	* m_compareBy is set to index, this function will add graph
-	* \p G to m_G and return true.
-	* Otherwise this function returns false.
-	*/
+	 * If the number of subgraphs in m_G is less than 32 and
+	 * m_compareBy is set to index, this function will add graph
+	 * \p G to m_G and return true.
+	 * Otherwise this function returns false.
+	 */
 	bool addGraph(const Graph& G);
 
 	//! gives access to new attribute if not already given
@@ -195,19 +195,19 @@ private:
 
 	//! compares two nodes \p v and \p w by their labels
 	/**
-	* This method only works, if attribute nodeLabel is activated
-	* and set properly.
-	* Otherwise it is recommended to use compareById.
-	*/
+	 * This method only works, if attribute nodeLabel is activated
+	 * and set properly.
+	 * Otherwise it is recommended to use compareById.
+	 */
 	bool compareByLabel(const GraphAttributes& vGA, node v, const GraphAttributes& wGA, node w) const {
 		return vGA.label(v) == wGA.label(w);
 	}
 
 	//! compares two nodes \p v and \p w by compare mode stored in m_compareBy
 	/**
-	* This method checks whether m_compareBy was set to index or label and
-	* uses the corresponding compare method.
-	*/
+	 * This method checks whether m_compareBy was set to index or label and
+	 * uses the corresponding compare method.
+	 */
 	bool compare(const GraphAttributes& vGA, node v, const GraphAttributes& wGA, node w) const;
 };
 

--- a/include/ogdf/simultaneous/SimDrawCaller.h
+++ b/include/ogdf/simultaneous/SimDrawCaller.h
@@ -58,9 +58,9 @@ private:
 
 	//! updates m_esg
 	/**
-	*  Should be called whenever graph changed and current
-	*  basic graph membership is needed.
-	*/
+	 *  Should be called whenever graph changed and current
+	 *  basic graph membership is needed.
+	 */
 	void updateESG();
 
 public:
@@ -69,43 +69,43 @@ public:
 
 	//! runs SugiyamaLayout with modified SplitHeuristic
 	/**
-	*  Runs special call of SugiyamaLayout using
-	*  SugiyamaLayout::setSubgraphs().
-	*  Saves node coordinates and dummy node bends in current
-	*  simdraw instance.
-	*
-	*  Uses TwoLayerCrossMinSimDraw object to perform crossing
-	*  minimization. The default is SplitHeuristic.
-	*
-	*  Automatically activates GraphAttributes::nodeGraphics.\n
-	*  Automatically activates GraphAttributes::edgeGraphics.
-	*/
+	 *  Runs special call of SugiyamaLayout using
+	 *  SugiyamaLayout::setSubgraphs().
+	 *  Saves node coordinates and dummy node bends in current
+	 *  simdraw instance.
+	 *
+	 *  Uses TwoLayerCrossMinSimDraw object to perform crossing
+	 *  minimization. The default is SplitHeuristic.
+	 *
+	 *  Automatically activates GraphAttributes::nodeGraphics.\n
+	 *  Automatically activates GraphAttributes::edgeGraphics.
+	 */
 	void callSugiyamaLayout();
 
 	//! runs UMLPlanarizationLayout with modified inserter
 	/**
-	*  Runs UMLPlanarizationLayout with callSimDraw and retransfers
-	*  node coordinates and dummy node bend to current simdraw
-	*  instance.
-	*
-	*  Automatically activates GraphAttributes::nodeGraphics.\n
-	*  Automatically activates GraphAttributes::edgeGraphics.
-	*/
+	 *  Runs UMLPlanarizationLayout with callSimDraw and retransfers
+	 *  node coordinates and dummy node bend to current simdraw
+	 *  instance.
+	 *
+	 *  Automatically activates GraphAttributes::nodeGraphics.\n
+	 *  Automatically activates GraphAttributes::edgeGraphics.
+	 */
 	void callPlanarizationLayout();
 
 	//! runs SubgraphPlanarizer with modified inserter
 	/**
-	*  Runs SubgraphPlanarizer on connected component \p cc with simdraw
-	*  call. Integer edge costs of GraphAttributes are used
-	*  (1 for each edge if not available).
-	*
-	*  Modifies graph by inserting dummy nodes for each crossing.
-	*  All dummy nodes are marked as dummy.
-	*  (Method SimDrawColorizer::addColorNodeVersion is recommended
-	*  for visualizing dummy nodes.)
-	*
-	*  No layout is calculated. The result is a planar graph.
-	*/
+	 *  Runs SubgraphPlanarizer on connected component \p cc with simdraw
+	 *  call. Integer edge costs of GraphAttributes are used
+	 *  (1 for each edge if not available).
+	 *
+	 *  Modifies graph by inserting dummy nodes for each crossing.
+	 *  All dummy nodes are marked as dummy.
+	 *  (Method SimDrawColorizer::addColorNodeVersion is recommended
+	 *  for visualizing dummy nodes.)
+	 *
+	 *  No layout is calculated. The result is a planar graph.
+	 */
 	int callSubgraphPlanarizer(int cc = 0, int numberOfPermutations = 1);
 };
 

--- a/include/ogdf/simultaneous/SimDrawColorizer.h
+++ b/include/ogdf/simultaneous/SimDrawColorizer.h
@@ -88,23 +88,23 @@ public:
 public:
 	//! Manages the various color schemes
 	/**
-	*  Color schemes are used within SimDrawColorizer to chose
-	*  different colors for the basic graph visualizations.
-	*  It is used directly within SimDrawColorizer.
-	*
-	*  \code
-	*  SimDraw SD;
-	*  SimDrawColorizer SDC(SD);
-	*  [...]
-	*  SDC.ColorScheme() = SimDrawColorizer::redGre;
-	*  SDC.addColor();
-	*  [...]
-	*  \endcode
-	*
-	*  CAUTION: Some color schemes are only valid for a small
-	*  number (e.g. two or three) of basic graphs. The default color
-	*  scheme can be used for up to 32 basic graphs.
-	*/
+	 *  Color schemes are used within SimDrawColorizer to chose
+	 *  different colors for the basic graph visualizations.
+	 *  It is used directly within SimDrawColorizer.
+	 *
+	 *  \code
+	 *  SimDraw SD;
+	 *  SimDrawColorizer SDC(SD);
+	 *  [...]
+	 *  SDC.ColorScheme() = SimDrawColorizer::redGre;
+	 *  SDC.addColor();
+	 *  [...]
+	 *  \endcode
+	 *
+	 *  CAUTION: Some color schemes are only valid for a small
+	 *  number (e.g. two or three) of basic graphs. The default color
+	 *  scheme can be used for up to 32 basic graphs.
+	 */
 	class SimDrawColorScheme {
 	private:
 		//! stores the current colorscheme (set by constructor)
@@ -112,20 +112,20 @@ public:
 
 		//! red color component
 		/** stores the values of the red color component for every graph
-		*  according to colorscheme
-		*/
+		 *  according to colorscheme
+		 */
 		int* red;
 
 		//! green color component
 		/** stores the values of the green color component for every graph
-		*  according to colorscheme
-		*/
+		 *  according to colorscheme
+		 */
 		int* green;
 
 		//! blue color component
 		/** stores the values of the blue color component for every graph
-		*  according to colorscheme
-		*/
+		 *  according to colorscheme
+		 */
 		int* blue;
 
 	public:

--- a/include/ogdf/simultaneous/SimDrawCreator.h
+++ b/include/ogdf/simultaneous/SimDrawCreator.h
@@ -57,51 +57,51 @@ public:
 
 	//! randomly chose edgeSubGraphs value for two graphs
 	/**
-	* Assigns random edgeSubGraphs values to all edges to create
-	* a SimDraw instance consisting of two basic graphs.
-	* Each edge in m_G has a chance of \p doubleESGProbability (in Percent)
-	* to belong to two SubGraphs.
-	* Otherwise it has equal chance to belong to either basic graph.
-	*/
+	 * Assigns random edgeSubGraphs values to all edges to create
+	 * a SimDraw instance consisting of two basic graphs.
+	 * Each edge in m_G has a chance of \p doubleESGProbability (in Percent)
+	 * to belong to two SubGraphs.
+	 * Otherwise it has equal chance to belong to either basic graph.
+	 */
 	void randomESG2(int doubleESGProbability = 50);
 
 	//! randomly chose edgeSubGraphs value for three graphs
 	/**
-	* Assigns random edgeSubGraphs values to all edges to create
-	* a SimDraw instance consisting of three basic graphs.
-	* Each edge in m_G has a chance of \p doubleESGProbabilit (in Percent)
-	* to belong to two basic graphs and a chance of \p tripleESGProbability
-	* (in Percent) to belong to three basic graphs.
-	*/
+	 * Assigns random edgeSubGraphs values to all edges to create
+	 * a SimDraw instance consisting of three basic graphs.
+	 * Each edge in m_G has a chance of \p doubleESGProbabilit (in Percent)
+	 * to belong to two basic graphs and a chance of \p tripleESGProbability
+	 * (in Percent) to belong to three basic graphs.
+	 */
 	void randomESG3(int doubleESGProbability = 50, int tripleESGProbability = 25);
 
 	//! randomly chose edgeSubGraphs value for graphNumber graphs
 	/**
-	* Assigns random edgeSubGraphs values to all edges to create
-	* a SimDraw instance consisting of \p graphNumber basic graphs.
-	* Each edge has an equal chance for each SubGraphBit - value.
-	*/
+	 * Assigns random edgeSubGraphs values to all edges to create
+	 * a SimDraw instance consisting of \p graphNumber basic graphs.
+	 * Each edge has an equal chance for each SubGraphBit - value.
+	 */
 	void randomESG(int graphNumber);
 
 	//! clears edgeSubGraphs value
 	/**
-	* This method clears all SubGraph values from m_G.
-	* After this function all edges belong to no basic graph.
-	* CAUTION: All edges need to be reset their edgeSubGraphs value
-	* for maintaining consistency.
-	*/
+	 * This method clears all SubGraph values from m_G.
+	 * After this function all edges belong to no basic graph.
+	 * CAUTION: All edges need to be reset their edgeSubGraphs value
+	 * for maintaining consistency.
+	 */
 	void clearESG();
 
 	//! randomly creates a simdraw instance
 	/**
-	* This method creates a random graph with \p numberOfNodes nodes,
-	* \p numberOfEdges edges. It is transfered into a simdraw instance with
-	* \p numberOfBasicGraphs basic graphs.
-	*
-	* randomSimpleGraph from graph_generators.h is used to
-	* create a random graph. Furthermore randomESG is used on this graph
-	* to generate \p numberOfBasicGraphs basic graphs.
-	*/
+	 * This method creates a random graph with \p numberOfNodes nodes,
+	 * \p numberOfEdges edges. It is transfered into a simdraw instance with
+	 * \p numberOfBasicGraphs basic graphs.
+	 *
+	 * randomSimpleGraph from graph_generators.h is used to
+	 * create a random graph. Furthermore randomESG is used on this graph
+	 * to generate \p numberOfBasicGraphs basic graphs.
+	 */
 	void createRandom(int numberOfNodes, int numberOfEdges, int numberOfBasicGraphs);
 };
 

--- a/include/ogdf/simultaneous/SimDrawManipulatorModule.h
+++ b/include/ogdf/simultaneous/SimDrawManipulatorModule.h
@@ -69,7 +69,7 @@ protected:
 public:
 	//! default constructor
 	/** creates its own simdraw instance
-	*/
+	 */
 	SimDrawManipulatorModule();
 
 	//! constructor

--- a/include/ogdf/simultaneous/TwoLayerCrossMinSimDraw.h
+++ b/include/ogdf/simultaneous/TwoLayerCrossMinSimDraw.h
@@ -45,14 +45,14 @@ public:
 	virtual TwoLayerCrossMinSimDraw* clone() const = 0;
 
 	/**
-	* \brief Performs crossing minimization for level \p L.
-	*
-	* @param L is the level in the hierarchy on which nodes are permuted; the
-	*        neighbor level (fixed level) is determined by the hierarchy.
-	* @param esg points to an edge array which specifies to which subgraphs
-	*        an edge belongs; there are up to 32 possible subgraphs each of which
-	*        is represented by a bit of an <code>uint32_t</code>.
-	*/
+	 * \brief Performs crossing minimization for level \p L.
+	 *
+	 * @param L is the level in the hierarchy on which nodes are permuted; the
+	 *        neighbor level (fixed level) is determined by the hierarchy.
+	 * @param esg points to an edge array which specifies to which subgraphs
+	 *        an edge belongs; there are up to 32 possible subgraphs each of which
+	 *        is represented by a bit of an <code>uint32_t</code>.
+	 */
 	virtual void call(Level& L, const EdgeArray<uint32_t>* esg) = 0;
 
 	void call(Level& L) = 0;

--- a/include/ogdf/tree/RadialTreeLayout.h
+++ b/include/ogdf/tree/RadialTreeLayout.h
@@ -56,7 +56,7 @@ namespace ogdf {
  *     <td>Specifies how to select the root of the tree.
  *   </tr>
  * </table>
-*/
+ */
 class OGDF_EXPORT RadialTreeLayout : public LayoutModule {
 public:
 	//! Selection strategies for root of the tree.

--- a/include/ogdf/uml/SubgraphPlanarizerUML.h
+++ b/include/ogdf/uml/SubgraphPlanarizerUML.h
@@ -100,7 +100,7 @@ namespace ogdf {
  *     subgraph are re-inserted one-by-one, each with as few crossings as possible.
  *   </tr>
  * </table>
-*/
+ */
 class OGDF_EXPORT SubgraphPlanarizerUML : public UMLCrossingMinimizationModule, public Logger {
 	class ThreadMaster;
 	class Worker;

--- a/include/ogdf/upward/LayerBasedUPRLayout.h
+++ b/include/ogdf/upward/LayerBasedUPRLayout.h
@@ -96,7 +96,7 @@ private:
 };
 
 /**
- @ingroup gd-layered
+ * @ingroup gd-layered
  */
 class OGDF_EXPORT LayerBasedUPRLayout : public UPRLayoutModule {
 public:

--- a/src/ogdf/cluster/ClusterOrthoLayout.cpp
+++ b/src/ogdf/cluster/ClusterOrthoLayout.cpp
@@ -1,6 +1,6 @@
 /** \file
  * \brief Implements planar orthogonal drawing algorithm for
-//   cluster graphs.
+ *        cluster graphs.
  *
  * \author Carsten Gutwenger, Sebastian Leipert, Karsten Klein
  *

--- a/src/ogdf/layered/OptimalHierarchyLayout.cpp
+++ b/src/ogdf/layered/OptimalHierarchyLayout.cpp
@@ -1,6 +1,6 @@
 /** \file
  * \brief Declaration and implementation of the optimal
-//   third phase of the sugiyama algorithm
+ *        third phase of the sugiyama algorithm
  *
  * \author Carsten Gutwenger
  *

--- a/util/style/indent_comments.py
+++ b/util/style/indent_comments.py
@@ -1,0 +1,56 @@
+import argparse
+import re
+import sys
+
+parser = argparse.ArgumentParser(
+    prog='indent_comments',
+    description='Ensures that Doxygen comments are indented consistently')
+
+parser.add_argument('filename', nargs="+")
+parser.add_argument('-f', '--fix', action='store_true')
+parser.add_argument('-i', '--inplace', action='store_true')
+
+args = parser.parse_args()
+if args.inplace and not args.fix:
+    print("-i requires -f", file=sys.stderr)
+    sys.exit(2)
+
+broken = False
+
+for file in args.filename:
+    with open(file, "a+t" if args.inplace else "rt") as fh:
+        indent = None
+        lines = fh
+        out = sys.stdout
+        if args.inplace:
+            fh.seek(0)
+            lines = fh.readlines()
+            fh.seek(0)
+            fh.truncate()
+            out = fh
+        for nr, line in enumerate(lines, start=1):
+            if indent is not None:
+                m = re.match("^([ \t]*)(\\*.*$)", line)
+                if not m:
+                    print(
+                        f"{file}:{nr} {line!r} should be inside multi-line doxygen comment, but doesn't start with '*'",
+                        file=sys.stderr)
+                    broken = True
+                    if args.fix:
+                        print(line, end="", file=out)
+                elif args.fix:
+                    print(indent, m.group(2), file=out)  # inserts single space between args
+                elif indent + " " != m.group(1):
+                    print(f"{file}:{nr} has indent {m.group(1)!r} but should have {indent + ' '!r}")
+                    broken = True
+                if "*/" in line:
+                    indent = None
+            else:
+                if args.fix:
+                    print(line, end="", file=out)
+                m = re.match("^([ \t]*)/\\*\\*", line)
+                if not m or "*/" in line: continue
+                indent = m.group(1)
+
+if broken:
+    sys.exit(1)

--- a/util/style/test_indent_comments.sh
+++ b/util/style/test_indent_comments.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Output or fix all files where doxygen comments are not indented properly
+#
+# Author: Simon D. Fink
+
+. util/util-functions.sh || exit 123
+
+handle_fix_option 'lists files with doxygen comments with improper indentation' 'fixes indentation of doxygen comments' "$@"
+
+fail_with_info () {
+	echo
+	echo "The files mentioned above have doxygen comments that are not indented properly."
+	echo
+	echo "You can fix that automatically using $0 -f"
+	exit 1
+}
+
+args=""
+if [ "$fixit" = "yes" ]; then
+  args="-fi"
+fi
+
+git ls-files src include test/src |
+  check_filter |
+  grep -e '\.\(c\|h\)\(pp\)\?$' |
+  $OGDF_XARGS -P "$cores" -I{} python util/style/indent_comments.py $args "{}" || fail_with_info


### PR DESCRIPTION
Add an utility that automatically makes doxygen comment indentation consistent. Integration into CI is coming with a separate CI-improvement PR (which also moves all style-related tools to a subfolder).