### PR TITLE
docker: Install tools for static analysis in clang image

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -73,6 +73,9 @@ jobs:
 
   sonar:
     name: "Static Analysis"
+    if: |
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     container: docker.io/ogdf/clang:15
     needs: [style, dirs, self-sufficiency, docs]

--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -100,7 +100,6 @@ jobs:
           CTCACHE_DIR: .ctcache
           # CTCACHE_DUMP: ${{ env.CCACHE_DEBUG }} # defining the var is enough to enable
         run: |
-          PATH="$(pwd):$PATH"
           util/sonar.sh -DOGDF_ARCH=haswell -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           find .ctcache -mtime +7 -delete
           cat sonar/clang-tidy.txt | python3 -m clang_tidy_converter sq > sonar/clang-tidy.json

--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -84,16 +84,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # fetch full history for blame info
-      - name: Install tools
-        run: |
-          apt-get update
-          apt-get install -y curl gcovr
-          pip install git+https://github.com/N-Coder/clang-tidy-converter.git
-          curl https://raw.githubusercontent.com/matus-chochlik/ctcache/main/clang-tidy-cache -sSfo clang-tidy-cache
-          echo -e "#!""/bin/bash\n$(realpath clang-tidy-cache) $(which clang-tidy) \"\$@\"" >> clang-tidy
-          echo -e "#!""/bin/bash\nllvm-cov-15 gcov \"\$@\"" >> gcov
-          chmod +x clang-tidy-cache clang-tidy gcov
-        shell: bash
       - name: Install sonar-scanner
         uses: SonarSource/sonarcloud-github-c-cpp@v2
       - name: Set-up ccache

--- a/util/docker/Dockerfile.template
+++ b/util/docker/Dockerfile.template
@@ -1,5 +1,5 @@
 RUN apt -y update \
- && apt -y install python3-pip graphviz unzip wget git time ccache \
+ && apt -y install graphviz unzip wget git time ccache \
  && apt -y upgrade ca-certificates
 
 # cmake
@@ -17,10 +17,6 @@ RUN [ "$DOXYGEN_INSTALL" = "false" ] || { \
  tar -xzf doxygen.tar.gz -C doxygen --strip-components 1 && \
  DIR=`pwd` && ln -s $DIR/doxygen/bin/doxygen /bin && \
  rm doxygen.tar.gz ;}
-
-# gcovr
-RUN python3 -c 'import sys; sys.exit(int(sys.version_info >= (3,5)))' \
- || pip3 install 'gcovr==4.2'
 
 # cgal
 ARG CGAL_INSTALL=false

--- a/util/docker/build.sh
+++ b/util/docker/build.sh
@@ -54,7 +54,7 @@ fi
 
 # Build and push the image.
 image="$1"/"$2"
-sudo docker build \
+sudo docker buildx build \
   --no-cache \
   --build-arg "CGAL_INSTALL"="$cgal_install" \
   --build-arg "DOXYGEN_INSTALL"="$doxygen_install" \

--- a/util/docker/clang/Dockerfile
+++ b/util/docker/clang/Dockerfile
@@ -9,6 +9,10 @@ RUN apt-get update \
       apt-transport-https \
       ca-certificates \
       wget \
+      curl \
+      python3-pip \
+      git \
+      gcovr \
  && wget https://apt.llvm.org/llvm.sh \
  && chmod +x llvm.sh \
  && ./llvm.sh $llvmver all \
@@ -16,3 +20,15 @@ RUN apt-get update \
  && ln -sf /usr/bin/clang-cpp-$llvmver /usr/bin/clang-cpp \
  && ln -sf /usr/bin/clang-format-$llvmver /usr/bin/clang-format \
  && ln -sf /usr/bin/clang-tidy-$llvmver /usr/bin/clang-tidy
+
+# Bypass pip externally managed warning to install sonar output converter,
+# see https://stackoverflow.com/questions/75608323/
+RUN mkdir -p ~/.config/pip/ \
+ && printf "[global]\nbreak-system-packages = true" > ~/.config/pip/pip.conf
+RUN pip install git+https://github.com/N-Coder/clang-tidy-converter.git
+
+# Enable clang-tidy-cache and gcov
+RUN wget https://raw.githubusercontent.com/matus-chochlik/ctcache/main/clang-tidy-cache \
+ && echo -e "#!""/bin/bash\n$(realpath clang-tidy-cache) $(which clang-tidy) \"\$@\"" >> clang-tidy \
+ && echo -e "#!""/bin/bash\nllvm-cov-15 gcov \"\$@\"" >> gcov \
+ && chmod +x clang-tidy-cache clang-tidy gcov

--- a/util/docker/clang/Dockerfile
+++ b/util/docker/clang/Dockerfile
@@ -19,7 +19,8 @@ RUN apt-get update \
  && ln -sf /usr/bin/clang++-$llvmver /usr/bin/clang++ \
  && ln -sf /usr/bin/clang-cpp-$llvmver /usr/bin/clang-cpp \
  && ln -sf /usr/bin/clang-format-$llvmver /usr/bin/clang-format \
- && ln -sf /usr/bin/clang-tidy-$llvmver /usr/bin/clang-tidy
+ && ln -sf /usr/bin/clang-tidy-$llvmver /usr/bin/clang-tidy \
+ && ln -sf /usr/bin/llvm-cov-$llvmver /usr/bin/llvm-cov
 
 # Bypass pip externally managed warning to install sonar output converter,
 # see https://stackoverflow.com/questions/75608323/
@@ -27,8 +28,7 @@ RUN mkdir -p ~/.config/pip/ \
  && printf "[global]\nbreak-system-packages = true" > ~/.config/pip/pip.conf
 RUN pip install git+https://github.com/N-Coder/clang-tidy-converter.git
 
-# Enable clang-tidy-cache and gcov
+# Install clang-tidy-cache
 RUN wget https://raw.githubusercontent.com/matus-chochlik/ctcache/main/clang-tidy-cache \
- && echo -e "#!""/bin/bash\n$(realpath clang-tidy-cache) $(which clang-tidy) \"\$@\"" >> clang-tidy \
- && echo -e "#!""/bin/bash\nllvm-cov-15 gcov \"\$@\"" >> gcov \
- && chmod +x clang-tidy-cache clang-tidy gcov
+ && mv clang-tidy-cache /usr/bin/clang-tidy-cache \
+ && chmod +x /usr/bin/clang-tidy-cache


### PR DESCRIPTION
Removing gcovr/pip from all gcc images also gets rid of potential problems with building docker images in the future.