### PR TITLE
Fix path to test_clang_format.sh

### DIFF
--- a/doc/workflow.md
+++ b/doc/workflow.md
@@ -100,10 +100,10 @@ that the code adheres to a certain code style.
 For this style to be consistent, developers need to format their changes with
 the correct version of (git-)clang-format (the currently used version is given
 by the header of the `.clang-format` file).
-The script `util/test_clang_format.sh` can help to detect formatting errors and
-fix them (when passed the `-f` option). If the correct clang-format version is
-not installed locally, the script can still correctly format the code by using a
-docker image.
+The script `util/style/test_clang_format.sh` can help to detect formatting
+errors and fix them (when passed the `-f` option). If the correct clang-format
+version is not installed locally, the script can still correctly format the code
+by using a docker image.
 
 ### Pull Requests
 

--- a/util/style/test_clang_format.sh
+++ b/util/style/test_clang_format.sh
@@ -60,7 +60,7 @@ if ! command -v "$CLANG_FORMAT_COMMAND" > /dev/null 2>&1; then
     --user "$(id -u "$user")" \
     -v "$repo_dir":"$repo_dir":rw,z \
     "$DOCKER_IMAGE" \
-    ./util/test_clang_format.sh $original_args
+    "$0" $original_args
   exit_code=$?
   exit $exit_code
 fi


### PR DESCRIPTION
When moving it to util/style/, some instances of its use were overlooked.