### PR TITLE
Use gcc 13 in CI builds

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -132,7 +132,7 @@ jobs:
     strategy:
       matrix:
         mode: [debug, release]
-        compiler: ['gcc:9', 'gcc:10', 'clang:15']
+        compiler: ['gcc:9', 'gcc:13', 'clang:15']
     runs-on: ubuntu-latest
     container: docker.io/ogdf/${{ matrix.compiler }}
     needs: [style, dirs, self-sufficiency, docs]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,10 +76,10 @@ gcc-9-debug:
     - docker
   stage: test-advanced
 
-gcc-10-debug:
+gcc-13-debug:
   except:
     - schedules
-  image: $CI_REGISTRY/gcc:10
+  image: $CI_REGISTRY/gcc:13
   script: util/test_build_and_run.sh static debug gcc gurobi -DOGDF_INCLUDE_GCAL=ON
   tags:
     - docker
@@ -102,10 +102,10 @@ gcc-9-release:
     - docker
   stage: test-advanced
 
-gcc-10-release:
+gcc-13-release:
   except:
     - schedules
-  image: $CI_REGISTRY/gcc:10
+  image: $CI_REGISTRY/gcc:13
   script: util/test_build_and_run.sh static release gcc gurobi -DOGDF_INCLUDE_CGAL=ON
   tags:
     - docker

--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ linear programming or unit testing.
 All files in the OGDF distribution (except for third-party
 software) are copyrighted:
 
-Copyright (C) 1999–2023
+Copyright (C) 1999–2024

--- a/doc/ogdf-footer.html
+++ b/doc/ogdf-footer.html
@@ -3,13 +3,13 @@
 <div id="nav-path" class="navpath"><!-- id is needed for treeview function! -->
  <ul>
   $navpath
-  <li class="footer">&copy; 1999&ndash;2023 <a href="http://ogdf.net/team/">The OGDF Team</a></li>
+  <li class="footer">&copy; 1999&ndash;2024 <a href="http://ogdf.net/team/">The OGDF Team</a></li>
  </ul>
 </div>
 <!--END GENERATE_TREEVIEW-->
 <!--BEGIN !GENERATE_TREEVIEW-->
 <hr class="footer"/><address class="footer"><small>
-&copy; 1999&ndash;2023 <a href="http://ogdf.net/team/">The OGDF Team</a>
+&copy; 1999&ndash;2024 <a href="http://ogdf.net/team/">The OGDF Team</a>
 </small></address>
 <!--END !GENERATE_TREEVIEW-->
 </body>

--- a/include/ogdf/basic/ArrayBuffer.h
+++ b/include/ogdf/basic/ArrayBuffer.h
@@ -336,6 +336,7 @@ public:
 		OGDF_ASSERT(this != &A2);
 		if (num) {
 			A2.init(num);
+			OGDF_ASSERT(sizeof(E) <= size_t(std::numeric_limits<INDEX>::max() / num));
 			memcpy(A2.m_pStart, this->m_pStart, sizeof(E) * num);
 		} else {
 			A2.init(0);

--- a/include/ogdf/basic/ArrayBuffer.h
+++ b/include/ogdf/basic/ArrayBuffer.h
@@ -337,7 +337,11 @@ public:
 		if (num) {
 			A2.init(num);
 			OGDF_ASSERT(sizeof(E) <= size_t(std::numeric_limits<INDEX>::max() / num));
-			memcpy(A2.m_pStart, this->m_pStart, sizeof(E) * num);
+
+			memcpy(A2.m_pStart, this->m_pStart,
+					sizeof(E) <= size_t(std::numeric_limits<INDEX>::max() / num)
+							? sizeof(E) * num
+							: size_t(std::numeric_limits<INDEX>::max()));
 		} else {
 			A2.init(0);
 		}

--- a/include/ogdf/geometric/cr_min/geometry/objects/Polygon.h
+++ b/include/ogdf/geometric/cr_min/geometry/objects/Polygon.h
@@ -176,7 +176,8 @@ inline unsigned int prev(const Polygon_t<kernel>& p, unsigned int i) {
 
 template<typename kernel>
 inline Polygon_t<kernel> reverse(const Polygon_t<kernel>& polygon) {
-	return std::move(Polygon_t<kernel>(polygon.container().rbegin(), polygon.container().rend()));
+	Polygon_t<kernel> revPolygon(polygon.container().rbegin(), polygon.container().rend());
+	return revPolygon;
 }
 
 template<typename kernel>

--- a/include/ogdf/graphalg/MatchingModule.h
+++ b/include/ogdf/graphalg/MatchingModule.h
@@ -271,8 +271,11 @@ private:
 
 		// Calculate the MinimumWeightPerfectMatching on the new graph
 		std::unordered_set<edge> matchingCopy;
-		bool result = doCall(graphCopy, weightsCopy, matchingCopy);
-		OGDF_ASSERT(result == true);
+#ifdef OGDF_DEBUG
+		bool result =
+#endif
+				doCall(graphCopy, weightsCopy, matchingCopy);
+		OGDF_ASSERT(result);
 
 		// Convert the matching to the original graph
 		for (edge e : matchingCopy) {

--- a/include/ogdf/graphalg/SpannerElkinNeiman.h
+++ b/include/ogdf/graphalg/SpannerElkinNeiman.h
@@ -137,7 +137,7 @@ public:
 		}
 		double integralPart;
 		if (std::modf(stretch, &integralPart) != 0.0) {
-			error = "The stretch is required to be an integer, not " + to_string(m_stretch);
+			error = "The stretch is required to be an integer, not " + to_string(stretch);
 			return false;
 		}
 		int intStretch = static_cast<int>(stretch);


### PR DESCRIPTION
Next to actually enabling gcc-13-builds and some miscellaneous changes, this contains a quick fix for a stringop-overflow warning in `ArrayBuffer::compactCopy`. A more long-term fix would be to replace int by size_t as the default INDEX type for `ArrayBuffer`s, see #197.

Close #210 