### PR TITLE
Add 4-block tree

### DIFF
--- a/doc/examples/decomposition/decomposition.dox
+++ b/doc/examples/decomposition/decomposition.dox
@@ -1,0 +1,34 @@
+/**
+ * \page ex-decomposition Graph Decomposition
+ *
+ * \section sec-ex-decomposition-1 Generate an acyclic random graph
+ * This example shows how to generate a random plane triangulation, decompose it
+ * into its 4-connected components, and draw each of them from the outside in.
+ *
+ * \include four-block-tree.cpp
+ *
+ * <h3>Step-by-step explanation</h3>
+ *
+ * -# The class FourBlockTree is declared in ogdf/decomposition/FourBlockTree.h
+ * -# We create a random plane graph. Because of its high number of edges, it
+ *    must be maximally planar, i.e., triangulated.
+ * -# We use the function FourBlockTree::construct to build its 4-block tree.
+ *    The 4-block tree is represented by its root, which has members
+ *    - g, the 4-connected component
+ *    - originalNodes, a map from nodes in g to the corresponding nodes in the
+ *      original graph
+ *    - externalFace, an adjEntry to the right of which the externalFace of the
+ *      4-connected component lies
+ *    - parent, a raw pointer to its parent node (or nullptr, if this is the
+ *      root)
+ *    - parentFace, the adjEntry in parent corresponding to externalFace (or
+ *      nullptr, if this is the root)
+ *    - children, a vector of unique_ptrs to the child nodes
+ * -# For our simple application of traversing the 4-block tree bottom-up, we
+ *    can use the method preorder, which calls its argument on each node of the
+ *    4-block tree in preorder. A similar method named postorder exists as well.
+ *    For each node of the 4-block tree, we draw it and save the drawing under a
+ *    unique filename. To this end we use PlanarStraightLayout. We use
+ *    originalNodes to assign multiple occurrences of the same node in the
+ *    4-block tree the same label.
+**/

--- a/doc/examples/decomposition/four-block-tree.cpp
+++ b/doc/examples/decomposition/four-block-tree.cpp
@@ -32,13 +32,13 @@ int main(void) {
 	}
 	int i = 0;
 	fbt.preorder([&](const FourBlockTree& treeNode) -> void {
-		GraphAttributes ga(treeNode.g,
+		GraphAttributes ga(*treeNode.g,
 				ogdf::GraphAttributes::nodeLabel | ogdf::GraphAttributes::nodeGraphics
 						| ogdf::GraphAttributes::nodeStyle | ogdf::GraphAttributes::edgeGraphics
 						| ogdf::GraphAttributes::edgeStyle);
 		ga.directed() = false;
 		layout.callFixEmbed(ga, treeNode.externalFace);
-		for (const node v : treeNode.g.nodes) {
+		for (const node v : treeNode.g->nodes) {
 			ga.label(v) = std::to_string(treeNode.originalNodes[v]->index());
 			ga.fillColor(v) = Color::Name::White;
 		}

--- a/doc/examples/decomposition/four-block-tree.cpp
+++ b/doc/examples/decomposition/four-block-tree.cpp
@@ -14,7 +14,7 @@ int main(void) {
 	randomPlanarConnectedGraph(g, n, 3 * n - 6);
 	const adjEntry externalFace = g.firstNode()->firstAdj()->cyclicSucc();
 
-	const FourBlockTree fbt = FourBlockTree::construct(g, externalFace);
+	const auto fbt = FourBlockTree::construct(g, externalFace);
 
 	PlanarStraightLayout layout;
 	{
@@ -31,7 +31,7 @@ int main(void) {
 		GraphIO::write(ga, "output-g.svg", GraphIO::drawSVG);
 	}
 	int i = 0;
-	fbt.preorder([&](const FourBlockTree& treeNode) -> void {
+	fbt->preorder([&](const FourBlockTree& treeNode) -> void {
 		GraphAttributes ga(*treeNode.g,
 				ogdf::GraphAttributes::nodeLabel | ogdf::GraphAttributes::nodeGraphics
 						| ogdf::GraphAttributes::nodeStyle | ogdf::GraphAttributes::edgeGraphics

--- a/doc/examples/decomposition/four-block-tree.cpp
+++ b/doc/examples/decomposition/four-block-tree.cpp
@@ -1,0 +1,49 @@
+#include <ogdf/basic/graph_generators/randomized.h>
+#include <ogdf/basic/simple_graph_alg.h>
+#include <ogdf/decomposition/FourBlockTree.h>
+#include <ogdf/fileformats/GraphIO.h>
+#include <ogdf/planarlayout/PlanarStraightLayout.h>
+
+#include <string>
+
+using namespace ogdf;
+
+int main(void) {
+	Graph g;
+	constexpr int n = 16;
+	randomPlanarConnectedGraph(g, n, 3 * n - 6);
+	const adjEntry externalFace = g.firstNode()->firstAdj()->cyclicSucc();
+
+	const FourBlockTree fbt = FourBlockTree::construct(g, externalFace);
+
+	PlanarStraightLayout layout;
+	{
+		GraphAttributes ga(g,
+				ogdf::GraphAttributes::nodeLabel | ogdf::GraphAttributes::nodeGraphics
+						| ogdf::GraphAttributes::nodeStyle | ogdf::GraphAttributes::edgeGraphics
+						| ogdf::GraphAttributes::edgeStyle);
+		ga.directed() = false;
+		layout.callFixEmbed(ga, externalFace);
+		for (const node v : g.nodes) {
+			ga.label(v) = std::to_string(v->index());
+			ga.fillColor(v) = Color::Name::White;
+		}
+		GraphIO::write(ga, "output-g.svg", GraphIO::drawSVG);
+	}
+	int i = 0;
+	fbt.preorder([&](const FourBlockTree& treeNode) -> void {
+		GraphAttributes ga(treeNode.g,
+				ogdf::GraphAttributes::nodeLabel | ogdf::GraphAttributes::nodeGraphics
+						| ogdf::GraphAttributes::nodeStyle | ogdf::GraphAttributes::edgeGraphics
+						| ogdf::GraphAttributes::edgeStyle);
+		ga.directed() = false;
+		layout.callFixEmbed(ga, treeNode.externalFace);
+		for (const node v : treeNode.g.nodes) {
+			ga.label(v) = std::to_string(treeNode.originalNodes[v]->index());
+			ga.fillColor(v) = Color::Name::White;
+		}
+		GraphIO::write(ga, std::string("output-node-") + std::to_string(i++) + ".svg",
+				GraphIO::drawSVG);
+	});
+	return 0;
+}

--- a/doc/examples/examples.dox
+++ b/doc/examples/examples.dox
@@ -5,6 +5,7 @@
  * They are grouped into the following categories:
  *
  * - \subpage ex-basic
+ * - \subpage ex-decomposition
  * - \subpage ex-layout
  * - \subpage ex-special
  */

--- a/include/ogdf/decomposition/FourBlockTree.h
+++ b/include/ogdf/decomposition/FourBlockTree.h
@@ -43,8 +43,6 @@
 
 #pragma once
 
-#include <ogdf/basic/AdjEntryArray.h>
-#include <ogdf/basic/EdgeArray.h>
 #include <ogdf/basic/Graph_d.h>
 #include <ogdf/basic/NodeArray.h>
 

--- a/include/ogdf/decomposition/FourBlockTree.h
+++ b/include/ogdf/decomposition/FourBlockTree.h
@@ -58,7 +58,7 @@ namespace ogdf {
  *
  * Since each node contains its children, the root is the entire tree.
  */
-struct FourBlockTree {
+struct OGDF_EXPORT FourBlockTree {
 	/**
 	 * The 4-connected component.
 	 */

--- a/include/ogdf/decomposition/FourBlockTree.h
+++ b/include/ogdf/decomposition/FourBlockTree.h
@@ -140,6 +140,38 @@ struct OGDF_EXPORT FourBlockTree {
 	}
 
 	/**
+	 * Perform a pre-order traversal of the 4-block tree.
+	 *
+	 * Each child is processed after its parent.
+	 *
+	 * @tparam _F The type of callback, something like
+	 *            `void (*)(FourBlockTree&)`.
+	 * @param callback The function to be called for each node of the tree.
+	 */
+	template<typename _F>
+	void preorder(_F callback) {
+		struct stackEntry {
+			FourBlockTree* node;
+			std::vector<std::unique_ptr<FourBlockTree>>::iterator nextChild;
+		};
+
+		std::vector<stackEntry> stack;
+		stack.push_back({this, children.begin()});
+		callback(*this);
+		while (!stack.empty()) {
+			auto& it = stack.back().nextChild;
+			if (it != stack.back().node->children.end()) {
+				FourBlockTree* child = it->get();
+				++it;
+				stack.push_back({child, child->children.begin()});
+				callback(*child);
+			} else {
+				stack.pop_back();
+			}
+		}
+	}
+
+	/**
 	 * Perform a post-order traversal of the 4-block tree.
 	 *
 	 * Each child is processed before its parent.
@@ -161,6 +193,37 @@ struct OGDF_EXPORT FourBlockTree {
 			auto& it = stack.back().nextChild;
 			if (it != stack.back().node->children.end()) {
 				const FourBlockTree* child = it->get();
+				++it;
+				stack.push_back({child, child->children.begin()});
+			} else {
+				callback(*stack.back().node);
+				stack.pop_back();
+			}
+		}
+	}
+
+	/**
+	 * Perform a post-order traversal of the 4-block tree.
+	 *
+	 * Each child is processed before its parent.
+	 *
+	 * @tparam _F The type of callback, something like
+	 *            `void (*)(FourBlockTree&)`.
+	 * @param callback The function to be called for each node of the tree.
+	 */
+	template<typename _F>
+	void postorder(_F callback) {
+		struct stackEntry {
+			FourBlockTree* node;
+			std::vector<std::unique_ptr<FourBlockTree>>::iterator nextChild;
+		};
+
+		std::vector<stackEntry> stack;
+		stack.push_back({this, children.begin()});
+		while (!stack.empty()) {
+			auto& it = stack.back().nextChild;
+			if (it != stack.back().node->children.end()) {
+				FourBlockTree* child = it->get();
 				++it;
 				stack.push_back({child, child->children.begin()});
 			} else {

--- a/include/ogdf/decomposition/FourBlockTree.h
+++ b/include/ogdf/decomposition/FourBlockTree.h
@@ -59,9 +59,9 @@ namespace ogdf {
 struct OGDF_EXPORT FourBlockTree {
 	FourBlockTree() = default;
 	FourBlockTree(const FourBlockTree&) = delete;
-	FourBlockTree(FourBlockTree&&) = default;
+	FourBlockTree(FourBlockTree&&) = delete;
 	FourBlockTree& operator=(const FourBlockTree&) = delete;
-	FourBlockTree& operator=(FourBlockTree&&) = default;
+	FourBlockTree& operator=(FourBlockTree&&) = delete;
 
 	~FourBlockTree() {
 		// free manually bottom-up to avoid stack overflow in case of deep tree
@@ -116,7 +116,7 @@ struct OGDF_EXPORT FourBlockTree {
 	 * @param externalFace A half-edge in g such that the external face of g
 	 *                     lies to its right.
 	 */
-	static FourBlockTree construct(const Graph& g, adjEntry externalFace);
+	static std::unique_ptr<FourBlockTree> construct(const Graph& g, adjEntry externalFace);
 
 	/**
 	 * Perform a pre-order traversal of the 4-block tree.

--- a/include/ogdf/decomposition/FourBlockTree.h
+++ b/include/ogdf/decomposition/FourBlockTree.h
@@ -1,3 +1,34 @@
+/** \file
+ * \brief Declaration of FourBlockTree.
+ *
+ * \author Gregor Diatzko
+ *
+ * \par License:
+ * This file is part of the Open Graph Drawing Framework (OGDF).
+ *
+ * \par
+ * Copyright (C)<br>
+ * See README.md in the OGDF root directory for details.
+ *
+ * \par
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * Version 2 or 3 as published by the Free Software Foundation;
+ * see the file LICENSE.txt included in the packaging of this file
+ * for details.
+ *
+ * \par
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * \par
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, see
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
 #pragma once
 
 #include <ogdf/basic/AdjEntryArray.h>
@@ -22,16 +53,15 @@ struct FourBlockTree {
     Graph g;
 
     /**
-     * The IDs of the vertices in the original graph as specified in the second
-     * argument to the constructor of FourBlockTreeBuilder.
+     * The nodes in the original graph corresponding to the nodes in g.
      *
-     * Since vertices may appear in multiple 4-connected components, these IDs
+     * Since nodes may appear in multiple 4-connected components, these
      * need not be unique across nodes of the 4-block tree.
      */
-    NodeArray<size_t> vertexIds;
+    NodeArray<node> originalNodes;
 
     /**
-     * A half-edge in g such that the external face of g is to its left.
+     * A half-edge in g such that the external face of g is to its right.
      */
     adjEntry externalFace;
 
@@ -53,118 +83,19 @@ struct FourBlockTree {
      * The child nodes of this nodes.
      */
     std::vector<std::unique_ptr<FourBlockTree>> children;
-};
-
-/**
- * A class that constructs the 4-block tree of a given graph.
-
- * For details see https://doi.org/10.48550/arXiv.2308.16020
- */
-class FourBlockTreeBuilder {
-    using triangle_t = std::array<edge, 3>;
-    using returnSide_t = unsigned char;
-    static constexpr returnSide_t LEFT = 0b10, RIGHT = 0b01; // when root is drawn at the top
-
-    Graph& m_g;
-    NodeArray<size_t>& m_vertexIds;
-    adjEntry m_externalFace;
 
     /**
-     * A node in the external face.
-     *
-     * This will be used as the root for DFS.
-     */
-    node m_root;
-
-    /**
-     * Index of every adjEntry in its adjencency list.
-     */
-    AdjEntryArray<size_t> m_indices;
-
-    /**
-     * Populate m_indices.
-     */
-    void populateIndices();
-
-    /**
-     * All separating triangles.
-     */
-    std::vector<triangle_t> m_sepTriangles;
-
-    /**
-     * Populate m_sepTriangles.
-     */
-    void populateSepTriangles();
-
-    /**
-     * The length of the root-v-path along tree edges for each vertex v.
-     */
-    NodeArray<size_t> m_depth;
-
-    /**
-     * The half-edge along which each vertex was found during the first DFS.
-     *
-     * m_parentEdge[v]->theNode() = v
-     */
-    NodeArray<adjEntry> m_parentEdge; // m_parentEdge[v]->theNode() = v
-
-    /**
-     * Whether each edge is a tree edge or a back edge.
-     */
-    EdgeArray<bool> m_isTreeEdge;
-
-    /**
-     * The lowpoint of each edge.
-     */
-    EdgeArray<node> m_lowpoint;
-
-    /**
-     * The return side of each edge.
-     */
-    EdgeArray<returnSide_t> m_returnSide;
-
-    /**
-     * The angular distance of each edge.
-     */
-    EdgeArray<size_t> m_angularDistance;
-
-    /**
-     * Run the first DFS.
-     *
-     * Populate m_depth, m_parentEdge, m_isTreeEdge, m_lowpoint, m_returnSide,
-     * m_angularDistance.
-     */
-    void firstDfs();
-
-    /**
-     * Order the elements of m_sepTriangles inside out.
-     */
-    void orderTriangles();
-
-    /**
-     * Split m_g along the elements of m_sepTriangles and build the resulting
-     * 4-block tree.
-     */
-    FourBlockTree buildTree();
-
-public:
-    /**
-     * Prepares all necessary data structures.
+     * Construct a 4-block tree of the given graph.
      *
      * @param g The plane triangulated graph whose 4-block tree shall be constructed.
      *          This graph will be used destructively.
      *          Edge directions in g are not respected.
-     *          The order of edges at each vertex is used as the combinatorial
+     *          The order of edges at each node is used as the combinatorial
      *          embedding.
      * @param externalFace A half-edge in g such that the external face of g
-     *                     lies to its left.
+     *                     lies to its right.
      */
-    FourBlockTreeBuilder(Graph& g, NodeArray<size_t>& vertexIds, adjEntry externalFace);
-
-    /**
-     * Run the algorithm.
-     */
-    FourBlockTree call();
+    static FourBlockTree construct(const Graph& g, adjEntry externalFace);
 };
 
 } // namespace ogdf

--- a/include/ogdf/decomposition/FourBlockTree.h
+++ b/include/ogdf/decomposition/FourBlockTree.h
@@ -47,117 +47,117 @@ namespace ogdf {
  * Since each node contains its children, the root is the entire tree.
  */
 struct FourBlockTree {
-    /**
-     * The 4-connected component.
-     */
-    Graph g;
+	/**
+	 * The 4-connected component.
+	 */
+	Graph g;
 
-    /**
-     * The nodes in the original graph corresponding to the nodes in g.
-     *
-     * Since nodes may appear in multiple 4-connected components, these
-     * need not be unique across nodes of the 4-block tree.
-     */
-    NodeArray<node> originalNodes;
+	/**
+	 * The nodes in the original graph corresponding to the nodes in g.
+	 *
+	 * Since nodes may appear in multiple 4-connected components, these
+	 * need not be unique across nodes of the 4-block tree.
+	 */
+	NodeArray<node> originalNodes;
 
-    /**
-     * A half-edge in g such that the external face of g is to its right.
-     */
-    adjEntry externalFace;
+	/**
+	 * A half-edge in g such that the external face of g is to its right.
+	 */
+	adjEntry externalFace;
 
-    /**
-     * The parent node of this node in the 4-block tree.
-     *
-     * If this node is the root node, parent is nullptr.
-     */
-    FourBlockTree* parent;
+	/**
+	 * The parent node of this node in the 4-block tree.
+	 *
+	 * If this node is the root node, parent is nullptr.
+	 */
+	FourBlockTree* parent;
 
-    /**
-     * The half-edge in parent->g corresponding to externalFace.
-     *
-     * If this node is the root node, parentFace is nullptr.
-     */
-    adjEntry parentFace;
+	/**
+	 * The half-edge in parent->g corresponding to externalFace.
+	 *
+	 * If this node is the root node, parentFace is nullptr.
+	 */
+	adjEntry parentFace;
 
-    /**
-     * The child nodes of this nodes.
-     */
-    std::vector<std::unique_ptr<FourBlockTree>> children;
+	/**
+	 * The child nodes of this nodes.
+	 */
+	std::vector<std::unique_ptr<FourBlockTree>> children;
 
-    /**
-     * Construct a 4-block tree of the given graph.
-     *
-     * @param g The plane triangulated graph whose 4-block tree shall be constructed.
-     *          This graph will be used destructively.
-     *          Edge directions in g are not respected.
-     *          The order of edges at each node is used as the combinatorial
-     *          embedding.
-     * @param externalFace A half-edge in g such that the external face of g
-     *                     lies to its right.
-     */
-    static FourBlockTree construct(const Graph& g, adjEntry externalFace);
+	/**
+	 * Construct a 4-block tree of the given graph.
+	 *
+	 * @param g The plane triangulated graph whose 4-block tree shall be constructed.
+	 *          This graph will be used destructively.
+	 *          Edge directions in g are not respected.
+	 *          The order of edges at each node is used as the combinatorial
+	 *          embedding.
+	 * @param externalFace A half-edge in g such that the external face of g
+	 *                     lies to its right.
+	 */
+	static FourBlockTree construct(const Graph& g, adjEntry externalFace);
 
-    /**
-     * Perform a pre-order traversal of the 4-block tree.
-     *
-     * Each child is processed after its parent.
-     *
-     * @tparam _F The type of callback, something like
-     *            `void (*)(const FourBlockTree&)`.
-     * @param callback The function to be called for each node of the tree.
-     */
-    template<typename _F>
-    void preorder(_F callback) const {
-        struct stackEntry {
-            const FourBlockTree* node;
-            std::vector<std::unique_ptr<FourBlockTree>>::const_iterator nextChild;
-        };
+	/**
+	 * Perform a pre-order traversal of the 4-block tree.
+	 *
+	 * Each child is processed after its parent.
+	 *
+	 * @tparam _F The type of callback, something like
+	 *            `void (*)(const FourBlockTree&)`.
+	 * @param callback The function to be called for each node of the tree.
+	 */
+	template<typename _F>
+	void preorder(_F callback) const {
+		struct stackEntry {
+			const FourBlockTree* node;
+			std::vector<std::unique_ptr<FourBlockTree>>::const_iterator nextChild;
+		};
 
-        std::vector<stackEntry> stack;
-        stack.push_back({this, children.begin()});
-        while (!stack.empty()) {
-            auto& it = stack.back().nextChild;
-            if (it != stack.back().node->children.end()) {
-                const FourBlockTree* child = it->get();
-                ++it;
-                stack.push_back({child, child->children.begin()});
-                callback(*child);
-            } else {
-                stack.pop_back();
-            }
-        }
-    }
+		std::vector<stackEntry> stack;
+		stack.push_back({this, children.begin()});
+		while (!stack.empty()) {
+			auto& it = stack.back().nextChild;
+			if (it != stack.back().node->children.end()) {
+				const FourBlockTree* child = it->get();
+				++it;
+				stack.push_back({child, child->children.begin()});
+				callback(*child);
+			} else {
+				stack.pop_back();
+			}
+		}
+	}
 
-    /**
-     * Perform a post-order traversal of the 4-block tree.
-     *
-     * Each child is processed before its parent.
-     *
-     * @tparam _F The type of callback, something like
-     *            `void (*)(const FourBlockTree&)`.
-     * @param callback The function to be called for each node of the tree.
-     */
-    template<typename _F>
-    void postorder(_F callback) const {
-        struct stackEntry {
-            const FourBlockTree* node;
-            std::vector<std::unique_ptr<FourBlockTree>>::const_iterator nextChild;
-        };
+	/**
+	 * Perform a post-order traversal of the 4-block tree.
+	 *
+	 * Each child is processed before its parent.
+	 *
+	 * @tparam _F The type of callback, something like
+	 *            `void (*)(const FourBlockTree&)`.
+	 * @param callback The function to be called for each node of the tree.
+	 */
+	template<typename _F>
+	void postorder(_F callback) const {
+		struct stackEntry {
+			const FourBlockTree* node;
+			std::vector<std::unique_ptr<FourBlockTree>>::const_iterator nextChild;
+		};
 
-        std::vector<stackEntry> stack;
-        stack.push_back({this, children.begin()});
-        while (!stack.empty()) {
-            auto& it = stack.back().nextChild;
-            if (it != stack.back().node->children.end()) {
-                const FourBlockTree* child = it->get();
-                ++it;
-                stack.push_back({child, child->children.begin()});
-            } else {
-                callback(**it);
-                stack.pop_back();
-            }
-        }
-    }
+		std::vector<stackEntry> stack;
+		stack.push_back({this, children.begin()});
+		while (!stack.empty()) {
+			auto& it = stack.back().nextChild;
+			if (it != stack.back().node->children.end()) {
+				const FourBlockTree* child = it->get();
+				++it;
+				stack.push_back({child, child->children.begin()});
+			} else {
+				callback(**it);
+				stack.pop_back();
+			}
+		}
+	}
 };
 
 } // namespace ogdf

--- a/include/ogdf/decomposition/FourBlockTree.h
+++ b/include/ogdf/decomposition/FourBlockTree.h
@@ -1,0 +1,170 @@
+#pragma once
+
+#include <ogdf/basic/AdjEntryArray.h>
+#include <ogdf/basic/EdgeArray.h>
+#include <ogdf/basic/Graph_d.h>
+#include <ogdf/basic/NodeArray.h>
+
+#include <memory>
+#include <vector>
+
+namespace ogdf {
+
+/**
+ * A node in a 4-block tree.
+ *
+ * Since each node contains its children, the root is the entire tree.
+ */
+struct FourBlockTree {
+    /**
+     * The 4-connected component.
+     */
+    Graph g;
+
+    /**
+     * The IDs of the vertices in the original graph as specified in the second
+     * argument to the constructor of FourBlockTreeBuilder.
+     *
+     * Since vertices may appear in multiple 4-connected components, these IDs
+     * need not be unique across nodes of the 4-block tree.
+     */
+    NodeArray<size_t> vertexIds;
+
+    /**
+     * A half-edge in g such that the external face of g is to its left.
+     */
+    adjEntry externalFace;
+
+    /**
+     * The parent node of this node in the 4-block tree.
+     *
+     * If this node is the root node, parent is nullptr.
+     */
+    FourBlockTree* parent;
+
+    /**
+     * The half-edge in parent->g corresponding to externalFace.
+     *
+     * If this node is the root node, parentFace is nullptr.
+     */
+    adjEntry parentFace;
+
+    /**
+     * The child nodes of this nodes.
+     */
+    std::vector<std::unique_ptr<FourBlockTree>> children;
+};
+
+/**
+ * A class that constructs the 4-block tree of a given graph.
+
+ * For details see https://doi.org/10.48550/arXiv.2308.16020
+ */
+class FourBlockTreeBuilder {
+    using triangle_t = std::array<edge, 3>;
+    using returnSide_t = unsigned char;
+    static constexpr returnSide_t LEFT = 0b10, RIGHT = 0b01; // when root is drawn at the top
+
+    Graph& m_g;
+    NodeArray<size_t>& m_vertexIds;
+    adjEntry m_externalFace;
+
+    /**
+     * A node in the external face.
+     *
+     * This will be used as the root for DFS.
+     */
+    node m_root;
+
+    /**
+     * Index of every adjEntry in its adjencency list.
+     */
+    AdjEntryArray<size_t> m_indices;
+
+    /**
+     * Populate m_indices.
+     */
+    void populateIndices();
+
+    /**
+     * All separating triangles.
+     */
+    std::vector<triangle_t> m_sepTriangles;
+
+    /**
+     * Populate m_sepTriangles.
+     */
+    void populateSepTriangles();
+
+    /**
+     * The length of the root-v-path along tree edges for each vertex v.
+     */
+    NodeArray<size_t> m_depth;
+
+    /**
+     * The half-edge along which each vertex was found during the first DFS.
+     *
+     * m_parentEdge[v]->theNode() = v
+     */
+    NodeArray<adjEntry> m_parentEdge; // m_parentEdge[v]->theNode() = v
+
+    /**
+     * Whether each edge is a tree edge or a back edge.
+     */
+    EdgeArray<bool> m_isTreeEdge;
+
+    /**
+     * The lowpoint of each edge.
+     */
+    EdgeArray<node> m_lowpoint;
+
+    /**
+     * The return side of each edge.
+     */
+    EdgeArray<returnSide_t> m_returnSide;
+
+    /**
+     * The angular distance of each edge.
+     */
+    EdgeArray<size_t> m_angularDistance;
+
+    /**
+     * Run the first DFS.
+     *
+     * Populate m_depth, m_parentEdge, m_isTreeEdge, m_lowpoint, m_returnSide,
+     * m_angularDistance.
+     */
+    void firstDfs();
+
+    /**
+     * Order the elements of m_sepTriangles inside out.
+     */
+    void orderTriangles();
+
+    /**
+     * Split m_g along the elements of m_sepTriangles and build the resulting
+     * 4-block tree.
+     */
+    FourBlockTree buildTree();
+
+public:
+    /**
+     * Prepares all necessary data structures.
+     *
+     * @param g The plane triangulated graph whose 4-block tree shall be constructed.
+     *          This graph will be used destructively.
+     *          Edge directions in g are not respected.
+     *          The order of edges at each vertex is used as the combinatorial
+     *          embedding.
+     * @param externalFace A half-edge in g such that the external face of g
+     *                     lies to its left.
+     */
+    FourBlockTreeBuilder(Graph& g, NodeArray<size_t>& vertexIds, adjEntry externalFace);
+
+    /**
+     * Run the algorithm.
+     */
+    FourBlockTree call();
+};
+
+} // namespace ogdf

--- a/include/ogdf/decomposition/FourBlockTree.h
+++ b/include/ogdf/decomposition/FourBlockTree.h
@@ -71,7 +71,7 @@ struct OGDF_EXPORT FourBlockTree {
 	/**
 	 * The 4-connected component.
 	 */
-	Graph g;
+	std::unique_ptr<Graph> g = std::make_unique<Graph>();
 
 	/**
 	 * The nodes in the original graph corresponding to the nodes in g.

--- a/include/ogdf/decomposition/FourBlockTree.h
+++ b/include/ogdf/decomposition/FourBlockTree.h
@@ -1,6 +1,18 @@
 /** \file
  * \brief Declaration of FourBlockTree.
  *
+ * Based on the implementation and techiques of the following papers:
+ *
+ * Norishige Chiba, and Takao Nishizeki.
+ * Arboricity and subgraph listing algorithms.
+ * SIAM Journal on computing 14.1 (1985): 210-223.
+ * [doi:10.1137/0214017](https://doi.org/10.1137/0214017).
+ *
+ * Sabine Cornelsen, and Gregor Diatzko.
+ * Decomposing Triangulations into 4-Connected Components.
+ * arXiv [cs.DS], 2023.
+ * [doi:10.48550/arXiv.2308.16020](https://doi.org/10.48550/arXiv.2308.16020).
+ *
  * \author Gregor Diatzko
  *
  * \par License:

--- a/include/ogdf/decomposition/FourBlockTree.h
+++ b/include/ogdf/decomposition/FourBlockTree.h
@@ -57,6 +57,17 @@ namespace ogdf {
  * Since each node contains its children, the root is the entire tree.
  */
 struct OGDF_EXPORT FourBlockTree {
+	FourBlockTree() = default;
+	FourBlockTree(const FourBlockTree&) = delete;
+	FourBlockTree(FourBlockTree&&) = default;
+	FourBlockTree& operator=(const FourBlockTree&) = delete;
+	FourBlockTree& operator=(FourBlockTree&&) = default;
+
+	~FourBlockTree() {
+		// free manually bottom-up to avoid stack overflow in case of deep tree
+		postorder([](FourBlockTree& treeNode) -> void { treeNode.children.clear(); });
+	}
+
 	/**
 	 * The 4-connected component.
 	 */

--- a/include/ogdf/decomposition/FourBlockTree.h
+++ b/include/ogdf/decomposition/FourBlockTree.h
@@ -96,6 +96,68 @@ struct FourBlockTree {
      *                     lies to its right.
      */
     static FourBlockTree construct(const Graph& g, adjEntry externalFace);
+
+    /**
+     * Perform a pre-order traversal of the 4-block tree.
+     *
+     * Each child is processed after its parent.
+     *
+     * @tparam _F The type of callback, something like
+     *            `void (*)(const FourBlockTree&)`.
+     * @param callback The function to be called for each node of the tree.
+     */
+    template<typename _F>
+    void preorder(_F callback) const {
+        struct stackEntry {
+            const FourBlockTree* node;
+            std::vector<std::unique_ptr<FourBlockTree>>::const_iterator nextChild;
+        };
+
+        std::vector<stackEntry> stack;
+        stack.push_back({this, children.begin()});
+        while (!stack.empty()) {
+            auto& it = stack.back().nextChild;
+            if (it != stack.back().node->children.end()) {
+                const FourBlockTree* child = it->get();
+                ++it;
+                stack.push_back({child, child->children.begin()});
+                callback(*child);
+            } else {
+                stack.pop_back();
+            }
+        }
+    }
+
+    /**
+     * Perform a post-order traversal of the 4-block tree.
+     *
+     * Each child is processed before its parent.
+     *
+     * @tparam _F The type of callback, something like
+     *            `void (*)(const FourBlockTree&)`.
+     * @param callback The function to be called for each node of the tree.
+     */
+    template<typename _F>
+    void postorder(_F callback) const {
+        struct stackEntry {
+            const FourBlockTree* node;
+            std::vector<std::unique_ptr<FourBlockTree>>::const_iterator nextChild;
+        };
+
+        std::vector<stackEntry> stack;
+        stack.push_back({this, children.begin()});
+        while (!stack.empty()) {
+            auto& it = stack.back().nextChild;
+            if (it != stack.back().node->children.end()) {
+                const FourBlockTree* child = it->get();
+                ++it;
+                stack.push_back({child, child->children.begin()});
+            } else {
+                callback(**it);
+                stack.pop_back();
+            }
+        }
+    }
 };
 
 } // namespace ogdf

--- a/include/ogdf/decomposition/FourBlockTree.h
+++ b/include/ogdf/decomposition/FourBlockTree.h
@@ -127,6 +127,7 @@ struct FourBlockTree {
 
 		std::vector<stackEntry> stack;
 		stack.push_back({this, children.begin()});
+		callback(*this);
 		while (!stack.empty()) {
 			auto& it = stack.back().nextChild;
 			if (it != stack.back().node->children.end()) {
@@ -165,7 +166,7 @@ struct FourBlockTree {
 				++it;
 				stack.push_back({child, child->children.begin()});
 			} else {
-				callback(**it);
+				callback(*stack.back().node);
 				stack.pop_back();
 			}
 		}

--- a/src/ogdf/decomposition/FourBlockTree.cpp
+++ b/src/ogdf/decomposition/FourBlockTree.cpp
@@ -553,26 +553,26 @@ FourBlockTree FourBlockTreeBuilder::buildTree() {
 		}
 
 		/* copy innerNodes with their edges to b */
-		b.originalNodes.init(b.g);
+		b.originalNodes.init(*b.g);
 		b.parent = nullptr;
 		b.parentFace = nullptr;
-		const auto bDummy = b.g.newNode();
+		const auto bDummy = b.g->newNode();
 		std::vector<edge> bEdges;
 		for (size_t i = 0; i < b_m; ++i) {
-			bEdges.push_back(b.g.newEdge(bDummy, bDummy));
+			bEdges.push_back(b.g->newEdge(bDummy, bDummy));
 		}
 		for (const auto x : innerNodes) {
 			/* copy node */
-			const auto b_v = b.g.newNode();
+			const auto b_v = b.g->newNode();
 			b.originalNodes[b_v] = m_originalNodes[x];
 
 			for (const auto a : x->adjEntries) {
 				/* copy adjEntry */
 				const auto b_e = bEdges[edgeIdsForB[a]];
 				if (a->isSource()) {
-					b.g.moveSource(b_e, b_v);
+					b.g->moveSource(b_e, b_v);
 				} else {
-					b.g.moveTarget(b_e, b_v);
+					b.g->moveTarget(b_e, b_v);
 				}
 
 				/* set c.parent and c.parentFace for children c of b */
@@ -588,7 +588,7 @@ FourBlockTree FourBlockTreeBuilder::buildTree() {
 				b.externalFace = b_v->lastAdj();
 			}
 		}
-		b.g.delNode(bDummy);
+		b.g->delNode(bDummy);
 	}
 
 	/* root of 4-block tree */
@@ -617,26 +617,26 @@ FourBlockTree FourBlockTreeBuilder::buildTree() {
 		}
 
 		/* copy innerNodes with their edges to res */
-		res.originalNodes.init(res.g);
+		res.originalNodes.init(*res.g);
 		res.parent = nullptr;
 		res.parentFace = nullptr;
-		const auto bDummy = res.g.newNode();
+		const auto bDummy = res.g->newNode();
 		std::vector<edge> bEdges;
 		for (size_t i = 0; i < b_m; ++i) {
-			bEdges.push_back(res.g.newEdge(bDummy, bDummy));
+			bEdges.push_back(res.g->newEdge(bDummy, bDummy));
 		}
 		for (const auto v : innerNodes) {
 			/* copy node */
-			const auto b_v = res.g.newNode();
+			const auto b_v = res.g->newNode();
 			res.originalNodes[b_v] = m_originalNodes[v];
 
 			for (const auto a : v->adjEntries) {
 				/* copy adjEntry */
 				const auto b_e = bEdges[edgeIdsForB[a]];
 				if (a->isSource()) {
-					res.g.moveSource(b_e, b_v);
+					res.g->moveSource(b_e, b_v);
 				} else {
-					res.g.moveTarget(b_e, b_v);
+					res.g->moveTarget(b_e, b_v);
 				}
 
 				/* set res.externalFace */
@@ -653,7 +653,7 @@ FourBlockTree FourBlockTreeBuilder::buildTree() {
 				}
 			}
 		}
-		res.g.delNode(bDummy);
+		res.g->delNode(bDummy);
 	}
 
 	/* move inner blocks to their parents */

--- a/src/ogdf/decomposition/FourBlockTree.cpp
+++ b/src/ogdf/decomposition/FourBlockTree.cpp
@@ -34,8 +34,6 @@
 #ifdef OGDF_DEBUG
 #	include <ogdf/basic/extended_graph_alg.h>
 #	include <ogdf/basic/simple_graph_alg.h>
-
-#	include <algorithm>
 #endif // OGDF_DEBUG
 
 using namespace ogdf;

--- a/src/ogdf/decomposition/FourBlockTree.cpp
+++ b/src/ogdf/decomposition/FourBlockTree.cpp
@@ -58,8 +58,6 @@ std::vector<_T> countingSort(const _C& input, _L key) {
 
 /**
  * A class that constructs the 4-block tree of a given graph.
-
- * For details see https://doi.org/10.48550/arXiv.2308.16020
  */
 class FourBlockTreeBuilder {
 	using triangle_t = std::array<edge, 3>;

--- a/src/ogdf/decomposition/FourBlockTree.cpp
+++ b/src/ogdf/decomposition/FourBlockTree.cpp
@@ -1,0 +1,527 @@
+#include <ogdf/decomposition/FourBlockTree.h>
+
+template<typename _C, typename _L, typename _T = typename _C::value_type>
+std::vector<_T> countingSort(const _C& input, _L key) {
+    std::vector<size_t> counts;
+    std::vector<std::vector<_T>> buckets;
+    for (const auto& x : input) {
+        const size_t k = key(x);
+        if (k >= counts.size()) {
+            counts.resize(k + 1, 0);
+        }
+        ++counts[k];
+    }
+    for (size_t i = 1; i < counts.size(); ++i) {
+        counts[i] += counts[i - 1];
+    }
+    std::vector<_T> res(input.size());
+    for (auto it = input.rbegin(); it != input.rend(); ++it) {
+        res[--counts[key(*it)]] = *it;
+    }
+    return res;
+}
+
+void ogdf::FourBlockTreeBuilder::populateIndices() {
+    for (const auto v : m_g.nodes) {
+        size_t i = 0;
+        for (const auto a : v->adjEntries) {
+            m_indices[a] = i++;
+        }
+    }
+}
+
+void ogdf::FourBlockTreeBuilder::populateSepTriangles() {
+    /* find all triangles [Chiba, Nishizeki] */
+
+    /* sort vertices by degree using CountingSort */
+    const auto byDescDegree =
+            countingSort(m_g.nodes, [&](ogdf::node v) { return m_g.numberOfNodes() - v->degree(); });
+
+    ogdf::NodeArray<bool> marked(m_g, false);
+    ogdf::NodeArray<bool> deleted(m_g, false);
+    ogdf::NodeArray<ogdf::adjEntry> a_vw(m_g, nullptr); // a_vw[w]->theEdge() = {v,w} for all w adj to v
+
+    /* for all vertices ordered by non-ascending degree */
+    for (const auto v : byDescDegree) {
+        /* mark all neighbors of v */
+        for (const auto a_vw_ : v->adjEntries) {
+            const auto w = a_vw_->twinNode();
+            marked[w] = true;
+            a_vw[w] = a_vw_;
+        }
+
+        for (const auto a_vu : v->adjEntries) // for each marked vertex u
+        {
+            const auto u = a_vu->twinNode();
+            if (deleted[u]) {
+                continue;
+            }
+            for (const auto a_uw : u->adjEntries) // for each vertex w adj to u
+            {
+                const auto w = a_uw->twinNode();
+                if (deleted[w]) {
+                    continue;
+                }
+                if (marked[w]) {
+                    /* {u,v,w} is a triangle */
+
+                    const auto ix_vu = m_indices[a_vu];
+                    const auto ix_vw = m_indices[a_vw[w]];
+                    if ((v->degree() + ix_vu - ix_vw + 1) % v->degree() > 2) { // <=> |ix_vu - ix_vw| > 1
+                        /* {u,v,w} is separating */
+                        m_sepTriangles.push_back(
+                                {a_vu->theEdge(), a_vw[w]->theEdge(), a_uw->theEdge()});
+                    }
+                }
+            }
+
+            marked[u] = false;
+        }
+
+        deleted[v] = true;
+    }
+}
+
+void ogdf::FourBlockTreeBuilder::firstDfs() {
+    ogdf::NodeArray<bool> visited(m_g, false);
+    ogdf::EdgeArray<bool> traversed(m_g, false);
+    std::vector<ogdf::adjEntry> stack = {m_externalFace};
+    visited[m_root] = traversed[m_externalFace->theEdge()] = true;
+    m_parentEdge[m_root] = m_externalFace;
+
+    /* if stack.back() = nullptr, we are done with the most recently visited node on level stack.size() */
+    /* otherwise we are always in the subtree rooted at stack.back()->theNode(), traversing stack.back()->theEdge() */
+    /* stack[m_depth[v]]->theNode() = v forall v on currently active path from root */
+
+    while (!stack.empty()) {
+        const auto adj = stack.back();
+        if (adj) {
+            const auto w = adj->twinNode();
+            const auto e = adj->theEdge();
+            if (!visited[w]) {
+                /* e is tree edge */
+                m_depth[w] = stack.size(); // = m_depth[v] + 1
+                m_parentEdge[w] = adj->twin();
+                visited[w] = true;
+                traversed[e] = true;
+                m_isTreeEdge[e] = true;
+                if (!adj->isSource()) {
+                    m_g.reverseEdge(e);
+                }
+                stack.push_back(w->firstAdj());
+            } else if (!traversed[e]) {
+                /* e is tree edge */
+                traversed[e] = true;
+                m_isTreeEdge[e] = false;
+                m_lowpoint[e] = w;
+                if (!adj->isSource()) {
+                    m_g.reverseEdge(e);
+                }
+
+                /* indices at w */
+                const auto ix_e = m_indices[adj->twin()];
+                const auto ix_p = m_indices[m_parentEdge[w]];
+                const auto ix_d = m_indices[stack[m_depth[w]]];
+
+                const size_t ang_e_d = (w->degree() + ix_d - ix_e) % w->degree();
+                const size_t ang_e_p = (w->degree() + ix_p - ix_e) % w->degree();
+                if (ang_e_d < ang_e_p) {
+                    /* in clockwise order around w: e, active tree edge = stack[m_depth[w]], m_parentEdge[w] */
+                    m_returnSide[e] = RIGHT;
+                    m_angularDistance[e] = ang_e_d;
+                } else {
+                    m_returnSide[e] = LEFT;
+                    m_angularDistance[e] = w->degree() - ang_e_d;
+                }
+
+                /* go to next edge of v */
+                stack.back() = adj->succ();
+            } else {
+                /* go to next edge of v */
+                stack.back() = adj->succ();
+            }
+        } else {
+            stack.pop_back();
+
+            if (!stack.empty()) {
+                /* w is done now, m_parentEdge[w] inherits properties of outgoing edges of w */
+                const auto w = stack.back()->twinNode();
+                const auto p = stack.back()->theEdge(); // = m_parentEdge[w]->theEdge()
+
+                m_lowpoint[p] = w;
+                m_returnSide[p] = 0;
+                m_angularDistance[p] = 0;
+                for (const auto a : w->adjEntries) {
+                    /* only consider outgoing edges of w */
+                    if (!a->isSource()) {
+                        continue;
+                    }
+                    const auto e = a->theEdge();
+
+                    if (m_depth[m_lowpoint[e]] < m_depth[m_lowpoint[p]]) {
+                        m_lowpoint[p] = m_lowpoint[e];
+                        m_returnSide[p] = m_returnSide[e];
+                        m_angularDistance[p] = m_angularDistance[e];
+                    } else if (m_depth[m_lowpoint[e]] == m_depth[m_lowpoint[p]]) {
+                        m_returnSide[p] |= m_returnSide[e];
+                        m_angularDistance[p] = std::max(m_angularDistance[e], m_angularDistance[e]);
+                    }
+                }
+
+                /* go to next edge of v */
+                stack.back() = stack.back()->succ();
+            }
+        }
+    }
+}
+
+void ogdf::FourBlockTreeBuilder::orderTriangles() {
+    /* sort edges e using Counting-/RadixSort on */
+    /* 1. e->source() */
+    /* 2. -m_depth[m_lowpoint[e]] */
+    /* 3. m_angularDistance[e] */
+    const auto byAngularDistance =
+            countingSort(m_g.edges, [&](ogdf::edge e) { return m_angularDistance[e]; });
+    const auto byDepthLowpoint = countingSort(byAngularDistance,
+            [&](ogdf::edge e) { return m_g.numberOfNodes() - m_depth[m_lowpoint[e]]; });
+    ogdf::NodeArray<std::vector<ogdf::edge>> edge_order(m_g);
+    for (const auto e : byDepthLowpoint) {
+        edge_order[e->source()].push_back(e);
+    }
+
+    std::vector<unsigned char> untraversedEdges(m_sepTriangles.size(),
+            3); // number of edges for each triangle that have not yet been traversed
+    ogdf::EdgeArray<std::vector<size_t>> triangleIndices(
+            m_g); // indices into untraversedEdges and m_sepTriangles
+    for (size_t i = 0; i < m_sepTriangles.size(); ++i) {
+        const auto& t = m_sepTriangles[i];
+        for (const auto e : t) {
+            triangleIndices[e].push_back(i);
+        }
+    }
+
+    /* find order of triangles */
+    /* indices into m_sepTriangles are also indices into these two arrays */
+    std::vector<size_t> internalAngle(m_sepTriangles.size(), 0);
+    std::vector<size_t> foundWithEdge(m_sepTriangles.size(), 0);
+
+    /* second DFS */
+    std::vector<std::pair<ogdf::node, std::vector<ogdf::edge>::const_iterator>> stack = {
+            {m_root, edge_order[m_root].cbegin()}};
+    size_t edge_id = 0;
+    while (!stack.empty()) {
+        auto& [v, it] = stack.back();
+        if (it == edge_order[v].cend()) {
+            stack.pop_back();
+        } else {
+            ++edge_id;
+            const auto e = *it++;
+            const auto w = e->target();
+            if (m_isTreeEdge[e]) {
+                stack.emplace_back(w, edge_order[w].cbegin());
+            }
+
+            std::vector<size_t> completeTriangles; // elements are indices into m_sepTriangles
+            for (const auto i : triangleIndices[e]) {
+                if (--untraversedEdges[i] == 0) {
+                    completeTriangles.push_back(i);
+                    foundWithEdge[i] = edge_id;
+
+                    /* make e first edge in triangle */
+                    auto& t = m_sepTriangles[i];
+                    if (e == t[1]) {
+                        std::swap(t[0], t[1]);
+                    } else if (e == t[2]) {
+                        std::swap(t[0], t[2]);
+                    }
+
+                    /* "direct" t clockwise */
+                    if (t[1]->isIncident(w) ^ (m_returnSide[e] == LEFT)) {
+                        std::swap(t[1], t[2]);
+                    }
+                }
+            }
+            if (completeTriangles.size() > 1) {
+                /* e must be a back edge, and all triangles are on the same side of e */
+                const bool trianglesRight = m_returnSide[e] == LEFT;
+
+                const auto ix_e = m_indices[e->adjTarget()];
+
+                for (const auto i : completeTriangles) {
+                    const auto& t = m_sepTriangles[i];
+                    const auto a = [&]() {
+                        /* find adjEntry a on t with a->theNode() == w and a->twinNode() != v */
+                        for (const auto side : t) {
+                            for (const auto adj : {side->adjSource(), side->adjTarget()}) {
+                                if (adj->theNode() == w && adj->twinNode() != v) {
+                                    return adj;
+                                }
+                            }
+                        }
+                        /* unreachable */
+                        std::terminate();
+                    }();
+                    const auto ang_a_e = (w->degree() + ix_e - m_indices[a]) % w->degree();
+                    if (trianglesRight) {
+                        internalAngle[i] = ang_a_e;
+                    } else {
+                        internalAngle[i] = w->degree() - ang_a_e;
+                    }
+                }
+            }
+        }
+    }
+
+    std::vector<size_t> tmp;
+    tmp.reserve(m_sepTriangles.size());
+    for (size_t i = 0; i < m_sepTriangles.size(); ++i) {
+        tmp.push_back(i);
+    }
+    const auto byInternalAngle = countingSort(tmp, [&](size_t i) { return internalAngle[i]; });
+    const auto byFoundWithEdge =
+            countingSort(byInternalAngle, [&](size_t i) { return foundWithEdge[i]; });
+    std::vector<triangle_t> res;
+    for (const size_t i : byFoundWithEdge) {
+        res.push_back(m_sepTriangles[i]);
+    }
+
+    m_sepTriangles = std::move(res);
+}
+
+ogdf::FourBlockTree ogdf::FourBlockTreeBuilder::buildTree() {
+    std::vector<std::unique_ptr<ogdf::FourBlockTree>> blocks;
+
+    /* used to set FourBlockTree.parent */
+    ogdf::AdjEntryArray<ogdf::FourBlockTree*> parentInv(m_g, nullptr);
+
+    /* isInner[v] => v is part of an inner block that is about to be copied from m_g */
+    /* initialized once to avoid linear cost for each block */
+    ogdf::NodeArray<bool> isInner(m_g, false);
+
+    /* the ID the edge will have in b */
+    /* initialized once to avoid linear cost for each block */
+    ogdf::EdgeArray<size_t> edgeIdsForB(m_g, 0);
+
+    for (const auto& t : m_sepTriangles) {
+        /* u,v,w in clockwise order around t */
+        const auto [uv, vw, wu] = t;
+        const auto v = uv->commonNode(vw);
+        const auto w = vw->commonNode(wu);
+        const auto u = wu->commonNode(uv);
+
+        /* create new block b */
+        blocks.push_back(std::make_unique<ogdf::FourBlockTree>());
+        auto& b = *blocks.back();
+
+        /* split m_g at t */
+        const auto u_ = m_g.newNode();
+        const auto v_ = m_g.newNode();
+        const auto w_ = m_g.newNode();
+        const auto vw_ = m_g.newEdge(v_, w_);
+        const auto wu_ = m_g.newEdge(w_, u_);
+        const auto uv_ = m_g.newEdge(u_, v_);
+        m_vertexIds[u_] = m_vertexIds[u];
+        m_vertexIds[v_] = m_vertexIds[v];
+        m_vertexIds[w_] = m_vertexIds[w];
+
+        /* move edges incident to v */
+        auto adj = vw->getAdj(v)->cyclicSucc();
+        while (adj != uv->getAdj(v)) {
+            const auto tmp = adj->cyclicSucc();
+            if (adj->isSource()) {
+                m_g.moveSource(adj->theEdge(), uv_->adjTarget(), ogdf::Direction::before);
+            } else {
+                m_g.moveTarget(adj->theEdge(), uv_->adjTarget(), ogdf::Direction::before);
+            }
+            adj = tmp;
+        }
+
+        /* move edges incident to w */
+        adj = wu->getAdj(w)->cyclicSucc();
+        while (adj != vw->getAdj(w)) {
+            const auto tmp = adj->cyclicSucc();
+            if (adj->isSource()) {
+                m_g.moveSource(adj->theEdge(), vw_->adjTarget(), ogdf::Direction::before);
+            } else {
+                m_g.moveTarget(adj->theEdge(), vw_->adjTarget(), ogdf::Direction::before);
+            }
+            adj = tmp;
+        }
+
+        /* move edges incident to u */
+        adj = uv->getAdj(u)->cyclicSucc();
+        while (adj != wu->getAdj(u)) {
+            const auto tmp = adj->cyclicSucc();
+            if (adj->isSource()) {
+                m_g.moveSource(adj->theEdge(), wu_->adjTarget(), ogdf::Direction::before);
+            } else {
+                m_g.moveTarget(adj->theEdge(), wu_->adjTarget(), ogdf::Direction::before);
+            }
+            adj = tmp;
+        }
+
+        /* set parent pointers to b */
+        for (const auto a : {uv->getAdj(v), vw->getAdj(w), wu->getAdj(u)}) {
+            auto& c = parentInv[a];
+            if (c) {
+                c->parent = &b;
+            }
+            c = &b;
+        }
+
+        /* list all vertices to be copied to b */
+        std::vector<ogdf::node> innerVertices = {u_, v_, w_}; // vertices in inner block
+        isInner[u_] = isInner[v_] = isInner[w_] = true;
+        size_t b_m = 0; // number of edges in inner block
+        size_t nextEdgeIdForB = 0;
+        for (size_t i = 0; i < innerVertices.size(); ++i) {
+            for (const auto a : innerVertices[i]->adjEntries) {
+                /* count edges */
+                if (a->isSource()) {
+                    ++b_m;
+                    edgeIdsForB[a] = nextEdgeIdForB++;
+                }
+
+                /* add neighbor x if not already added */
+                const auto x = a->twinNode();
+                if (!isInner[x]) {
+                    isInner[x] = true;
+                    innerVertices.push_back(x);
+                }
+            }
+        }
+
+        /* copy innerVertices with their edges to b */
+        b.vertexIds.init(b.g);
+        b.parent = nullptr;
+        b.parentFace = nullptr;
+        const auto bDummy = b.g.newNode();
+        std::vector<ogdf::edge> bEdges;
+        for (size_t i = 0; i < b_m; ++i) {
+            bEdges.push_back(b.g.newEdge(bDummy, bDummy));
+        }
+        for (const auto x : innerVertices) {
+            /* copy vertex */
+            const auto b_v = b.g.newNode();
+            b.vertexIds[b_v] = m_vertexIds[x];
+
+            for (const auto a : x->adjEntries) {
+                /* copy adjEntry */
+                const auto b_e = bEdges[edgeIdsForB[a]];
+                if (a->isSource()) {
+                    b.g.moveSource(b_e, b_v);
+                } else {
+                    b.g.moveTarget(b_e, b_v);
+                }
+
+                /* set c.parent and c.parentFace for children c of b */
+                const auto c = parentInv[a];
+                if (c) {
+                    const auto b_a = a->isSource() ? b_e->adjSource() : b_e->adjTarget();
+                    c->parent = &b;
+                    c->parentFace = b_a;
+                }
+            }
+
+            if (x == v_) {
+                b.externalFace = b_v->firstAdj();
+            }
+        }
+        b.g.delNode(bDummy);
+    }
+
+    /* root of 4-block tree */
+    ogdf::FourBlockTree res;
+    {
+        /* list all vertices to be copied to res */
+        std::vector<ogdf::node> innerVertices = {m_root}; // vertices in outermost block
+        isInner[m_root] = true;
+        size_t b_m = 0; // number of edges in outermost block
+        size_t nextEdgeIdForB = 0;
+        for (size_t i = 0; i < innerVertices.size(); ++i) {
+            for (const auto a : innerVertices[i]->adjEntries) {
+                /* count edges */
+                if (a->isSource()) {
+                    ++b_m;
+                    edgeIdsForB[a] = nextEdgeIdForB++;
+                }
+
+                /* add neighbor w if not already added */
+                const auto w = a->twinNode();
+                if (!isInner[w]) {
+                    isInner[w] = true;
+                    innerVertices.push_back(w);
+                }
+            }
+        }
+
+        /* copy innerVertices with their edges to res */
+        res.vertexIds.init(res.g);
+        res.parent = nullptr;
+        res.parentFace = nullptr;
+        const auto bDummy = res.g.newNode();
+        std::vector<ogdf::edge> bEdges;
+        for (size_t i = 0; i < b_m; ++i) {
+            bEdges.push_back(res.g.newEdge(bDummy, bDummy));
+        }
+        for (const auto v : innerVertices) {
+            /* copy vertex */
+            const auto b_v = res.g.newNode();
+            res.vertexIds[b_v] = m_vertexIds[v];
+
+            for (const auto a : v->adjEntries) {
+                /* copy adjEntry */
+                const auto b_e = bEdges[edgeIdsForB[a]];
+                if (a->isSource()) {
+                    res.g.moveSource(b_e, b_v);
+                } else {
+                    res.g.moveTarget(b_e, b_v);
+                }
+
+                /* set res.externalFace */
+                if (a == m_externalFace) {
+                    res.externalFace = a->isSource() ? b_e->adjSource() : b_e->adjTarget();
+                }
+
+                /* set c.parent and c.parentFace for children c of res */
+                const auto c = parentInv[a];
+                if (c) {
+                    const auto b_a = a->isSource() ? b_e->adjSource() : b_e->adjTarget();
+                    c->parent = &res;
+                    c->parentFace = b_a;
+                }
+            }
+        }
+        res.g.delNode(bDummy);
+    }
+
+    /* move inner blocks to their parents */
+    for (auto& b : blocks) {
+        auto& p = *b->parent;
+        p.children.push_back(std::move(b));
+    }
+
+    return res;
+}
+
+ogdf::FourBlockTreeBuilder::FourBlockTreeBuilder(ogdf::Graph& g, ogdf::NodeArray<size_t>& vertexIds,
+        ogdf::adjEntry externalFace)
+    : m_g(g)
+    , m_vertexIds(vertexIds)
+    , m_externalFace(externalFace)
+    , m_root(externalFace->theNode())
+    , m_indices(g, 0)
+    , m_depth(g, 0)
+    , m_parentEdge(g, nullptr)
+    , m_isTreeEdge(g, false)
+    , m_lowpoint(g, nullptr)
+    , m_returnSide(g, 0)
+    , m_angularDistance(g, 0) { }
+
+ogdf::FourBlockTree ogdf::FourBlockTreeBuilder::call() {
+    populateIndices();
+    populateSepTriangles();
+    firstDfs();
+    orderTriangles();
+    return buildTree();
+}

--- a/src/ogdf/decomposition/FourBlockTree.cpp
+++ b/src/ogdf/decomposition/FourBlockTree.cpp
@@ -29,31 +29,31 @@
  * http://www.gnu.org/copyleft/gpl.html
  */
 
-#include <ogdf/decomposition/FourBlockTree.h>
-#include <ogdf/basic/simple_graph_alg.h>
 #include <ogdf/basic/extended_graph_alg.h>
+#include <ogdf/basic/simple_graph_alg.h>
+#include <ogdf/decomposition/FourBlockTree.h>
 
 using namespace ogdf;
 
 template<typename _C, typename _L, typename _T = typename _C::value_type>
 std::vector<_T> countingSort(const _C& input, _L key) {
-    std::vector<size_t> counts;
-    std::vector<std::vector<_T>> buckets;
-    for (const auto& x : input) {
-        const size_t k = key(x);
-        if (k >= counts.size()) {
-            counts.resize(k + 1, 0);
-        }
-        ++counts[k];
-    }
-    for (size_t i = 1; i < counts.size(); ++i) {
-        counts[i] += counts[i - 1];
-    }
-    std::vector<_T> res(input.size());
-    for (auto it = input.rbegin(); it != input.rend(); ++it) {
-        res[--counts[key(*it)]] = *it;
-    }
-    return res;
+	std::vector<size_t> counts;
+	std::vector<std::vector<_T>> buckets;
+	for (const auto& x : input) {
+		const size_t k = key(x);
+		if (k >= counts.size()) {
+			counts.resize(k + 1, 0);
+		}
+		++counts[k];
+	}
+	for (size_t i = 1; i < counts.size(); ++i) {
+		counts[i] += counts[i - 1];
+	}
+	std::vector<_T> res(input.size());
+	for (auto it = input.rbegin(); it != input.rend(); ++it) {
+		res[--counts[key(*it)]] = *it;
+	}
+	return res;
 }
 
 /**
@@ -62,653 +62,653 @@ std::vector<_T> countingSort(const _C& input, _L key) {
  * For details see https://doi.org/10.48550/arXiv.2308.16020
  */
 class FourBlockTreeBuilder {
-    using triangle_t = std::array<edge, 3>;
-    using returnSide_t = unsigned char;
-    static constexpr returnSide_t LEFT = 0b10, RIGHT = 0b01; // when root is drawn at the top
+	using triangle_t = std::array<edge, 3>;
+	using returnSide_t = unsigned char;
+	static constexpr returnSide_t LEFT = 0b10, RIGHT = 0b01; // when root is drawn at the top
 
-    Graph& m_g;
-    NodeArray<node>& m_originalNodes;
+	Graph& m_g;
+	NodeArray<node>& m_originalNodes;
 
-    /**
-     * A half-edge in g such that the external face of g lies to its left.
-     */
-    adjEntry m_externalFace;
+	/**
+	 * A half-edge in g such that the external face of g lies to its left.
+	 */
+	adjEntry m_externalFace;
 
-    /**
-     * A node in the external face.
-     *
-     * This will be used as the root for DFS.
-     */
-    node m_root;
+	/**
+	 * A node in the external face.
+	 *
+	 * This will be used as the root for DFS.
+	 */
+	node m_root;
 
-    /**
-     * Index of every adjEntry in its adjencency list.
-     */
-    AdjEntryArray<size_t> m_indices;
+	/**
+	 * Index of every adjEntry in its adjencency list.
+	 */
+	AdjEntryArray<size_t> m_indices;
 
-    /**
-     * Populate m_indices.
-     */
-    void populateIndices();
+	/**
+	 * Populate m_indices.
+	 */
+	void populateIndices();
 
-    /**
-     * All separating triangles.
-     */
-    std::vector<triangle_t> m_sepTriangles;
+	/**
+	 * All separating triangles.
+	 */
+	std::vector<triangle_t> m_sepTriangles;
 
-    /**
-     * Populate m_sepTriangles.
-     */
-    void populateSepTriangles();
+	/**
+	 * Populate m_sepTriangles.
+	 */
+	void populateSepTriangles();
 
-    /**
-     * The length of the root-v-path along tree edges for each node v.
-     */
-    NodeArray<size_t> m_depth;
+	/**
+	 * The length of the root-v-path along tree edges for each node v.
+	 */
+	NodeArray<size_t> m_depth;
 
-    /**
-     * The half-edge along which each node was found during the first DFS.
-     *
-     * m_parentEdge[v]->theNode() = v
-     */
-    NodeArray<adjEntry> m_parentEdge; // m_parentEdge[v]->theNode() = v
+	/**
+	 * The half-edge along which each node was found during the first DFS.
+	 *
+	 * m_parentEdge[v]->theNode() = v
+	 */
+	NodeArray<adjEntry> m_parentEdge; // m_parentEdge[v]->theNode() = v
 
-    /**
-     * Whether each edge is a tree edge or a back edge.
-     */
-    EdgeArray<bool> m_isTreeEdge;
+	/**
+	 * Whether each edge is a tree edge or a back edge.
+	 */
+	EdgeArray<bool> m_isTreeEdge;
 
-    /**
-     * The lowpoint of each edge.
-     */
-    EdgeArray<node> m_lowpoint;
+	/**
+	 * The lowpoint of each edge.
+	 */
+	EdgeArray<node> m_lowpoint;
 
-    /**
-     * The return side of each edge.
-     */
-    EdgeArray<returnSide_t> m_returnSide;
+	/**
+	 * The return side of each edge.
+	 */
+	EdgeArray<returnSide_t> m_returnSide;
 
-    /**
-     * The angular distance of each edge.
-     */
-    EdgeArray<size_t> m_angularDistance;
+	/**
+	 * The angular distance of each edge.
+	 */
+	EdgeArray<size_t> m_angularDistance;
 
-    /**
-     * Run the first DFS.
-     *
-     * Populate m_depth, m_parentEdge, m_isTreeEdge, m_lowpoint, m_returnSide,
-     * m_angularDistance.
-     */
-    void firstDfs();
+	/**
+	 * Run the first DFS.
+	 *
+	 * Populate m_depth, m_parentEdge, m_isTreeEdge, m_lowpoint, m_returnSide,
+	 * m_angularDistance.
+	 */
+	void firstDfs();
 
-    /**
-     * Order the elements of m_sepTriangles inside out.
-     */
-    void orderTriangles();
+	/**
+	 * Order the elements of m_sepTriangles inside out.
+	 */
+	void orderTriangles();
 
-    /**
-     * Split m_g along the elements of m_sepTriangles and build the resulting
-     * 4-block tree.
-     */
-    FourBlockTree buildTree();
+	/**
+	 * Split m_g along the elements of m_sepTriangles and build the resulting
+	 * 4-block tree.
+	 */
+	FourBlockTree buildTree();
 
 public:
-    /**
-     * Prepares all necessary data structures.
-     *
-     * @param g The plane triangulated graph whose 4-block tree shall be constructed.
-     *          This graph will be used destructively.
-     *          Edge directions in g are not respected.
-     *          The order of edges at each node is used as the combinatorial
-     *          embedding.
-     * @param originalNodes The nodes in the original graph corresponding
-     *                      to those in g. This will be used to populate
-     *                      FourBlockTree::originalNodes.
-     * @param externalFace A half-edge in g such that the external face of g
-     *                     lies to its right.
-     */
-    FourBlockTreeBuilder(Graph& g, NodeArray<node>& originalNodes, adjEntry externalFace);
+	/**
+	 * Prepares all necessary data structures.
+	 *
+	 * @param g The plane triangulated graph whose 4-block tree shall be constructed.
+	 *          This graph will be used destructively.
+	 *          Edge directions in g are not respected.
+	 *          The order of edges at each node is used as the combinatorial
+	 *          embedding.
+	 * @param originalNodes The nodes in the original graph corresponding
+	 *                      to those in g. This will be used to populate
+	 *                      FourBlockTree::originalNodes.
+	 * @param externalFace A half-edge in g such that the external face of g
+	 *                     lies to its right.
+	 */
+	FourBlockTreeBuilder(Graph& g, NodeArray<node>& originalNodes, adjEntry externalFace);
 
-    /**
-     * Run the algorithm.
-     */
-    FourBlockTree call();
+	/**
+	 * Run the algorithm.
+	 */
+	FourBlockTree call();
 };
 
 void FourBlockTreeBuilder::populateIndices() {
-    for (const auto v : m_g.nodes) {
-        size_t i = 0;
-        for (const auto a : v->adjEntries) {
-            m_indices[a] = i++;
-        }
-    }
+	for (const auto v : m_g.nodes) {
+		size_t i = 0;
+		for (const auto a : v->adjEntries) {
+			m_indices[a] = i++;
+		}
+	}
 }
 
 void FourBlockTreeBuilder::populateSepTriangles() {
-    /* find all triangles [Chiba, Nishizeki] */
+	/* find all triangles [Chiba, Nishizeki] */
 
-    /* sort nodes by degree using CountingSort */
-    const auto byDescDegree =
-            countingSort(m_g.nodes, [&](node v) { return m_g.numberOfNodes() - v->degree(); });
+	/* sort nodes by degree using CountingSort */
+	const auto byDescDegree =
+			countingSort(m_g.nodes, [&](node v) { return m_g.numberOfNodes() - v->degree(); });
 
-    NodeArray<bool> marked(m_g, false);
-    NodeArray<bool> deleted(m_g, false);
-    NodeArray<adjEntry> a_vw(m_g, nullptr); // a_vw[w]->theEdge() = {v,w} for all w adj to v
+	NodeArray<bool> marked(m_g, false);
+	NodeArray<bool> deleted(m_g, false);
+	NodeArray<adjEntry> a_vw(m_g, nullptr); // a_vw[w]->theEdge() = {v,w} for all w adj to v
 
-    /* for all nodes ordered by non-ascending degree */
-    for (const auto v : byDescDegree) {
-        /* mark all neighbors of v */
-        for (const auto a_vw_ : v->adjEntries) {
-            const auto w = a_vw_->twinNode();
-            marked[w] = true;
-            a_vw[w] = a_vw_;
-        }
+	/* for all nodes ordered by non-ascending degree */
+	for (const auto v : byDescDegree) {
+		/* mark all neighbors of v */
+		for (const auto a_vw_ : v->adjEntries) {
+			const auto w = a_vw_->twinNode();
+			marked[w] = true;
+			a_vw[w] = a_vw_;
+		}
 
-        for (const auto a_vu : v->adjEntries) // for each marked node u
-        {
-            const auto u = a_vu->twinNode();
-            if (deleted[u]) {
-                continue;
-            }
-            for (const auto a_uw : u->adjEntries) // for each node w adj to u
-            {
-                const auto w = a_uw->twinNode();
-                if (deleted[w]) {
-                    continue;
-                }
-                if (marked[w]) {
-                    /* {u,v,w} is a triangle */
+		for (const auto a_vu : v->adjEntries) // for each marked node u
+		{
+			const auto u = a_vu->twinNode();
+			if (deleted[u]) {
+				continue;
+			}
+			for (const auto a_uw : u->adjEntries) // for each node w adj to u
+			{
+				const auto w = a_uw->twinNode();
+				if (deleted[w]) {
+					continue;
+				}
+				if (marked[w]) {
+					/* {u,v,w} is a triangle */
 
-                    const auto ix_vu = m_indices[a_vu];
-                    const auto ix_vw = m_indices[a_vw[w]];
-                    if ((v->degree() + ix_vu - ix_vw + 1) % v->degree() > 2) { // <=> |ix_vu - ix_vw| > 1
-                        /* {u,v,w} is separating */
-                        m_sepTriangles.push_back(
-                                {a_vu->theEdge(), a_vw[w]->theEdge(), a_uw->theEdge()});
-                    }
-                }
-            }
+					const auto ix_vu = m_indices[a_vu];
+					const auto ix_vw = m_indices[a_vw[w]];
+					if ((v->degree() + ix_vu - ix_vw + 1) % v->degree() > 2) { // <=> |ix_vu - ix_vw| > 1
+						/* {u,v,w} is separating */
+						m_sepTriangles.push_back(
+								{a_vu->theEdge(), a_vw[w]->theEdge(), a_uw->theEdge()});
+					}
+				}
+			}
 
-            marked[u] = false;
-        }
+			marked[u] = false;
+		}
 
-        deleted[v] = true;
-    }
+		deleted[v] = true;
+	}
 }
 
 void FourBlockTreeBuilder::firstDfs() {
-    NodeArray<bool> visited(m_g, false);
-    EdgeArray<bool> traversed(m_g, false);
-    std::vector<adjEntry> stack = {m_externalFace};
-    visited[m_root] = traversed[m_externalFace->theEdge()] = true;
-    m_parentEdge[m_root] = m_externalFace;
+	NodeArray<bool> visited(m_g, false);
+	EdgeArray<bool> traversed(m_g, false);
+	std::vector<adjEntry> stack = {m_externalFace};
+	visited[m_root] = traversed[m_externalFace->theEdge()] = true;
+	m_parentEdge[m_root] = m_externalFace;
 
-    /* if stack.back() = nullptr, we are done with the most recently visited node on level stack.size() */
-    /* otherwise we are always in the subtree rooted at stack.back()->theNode(), traversing stack.back()->theEdge() */
-    /* stack[m_depth[v]]->theNode() = v forall v on currently active path from root */
+	/* if stack.back() = nullptr, we are done with the most recently visited node on level stack.size() */
+	/* otherwise we are always in the subtree rooted at stack.back()->theNode(), traversing stack.back()->theEdge() */
+	/* stack[m_depth[v]]->theNode() = v forall v on currently active path from root */
 
-    while (!stack.empty()) {
-        const auto adj = stack.back();
-        if (adj) {
-            const auto w = adj->twinNode();
-            const auto e = adj->theEdge();
-            if (!visited[w]) {
-                /* e is tree edge */
-                m_depth[w] = stack.size(); // = m_depth[v] + 1
-                m_parentEdge[w] = adj->twin();
-                visited[w] = true;
-                traversed[e] = true;
-                m_isTreeEdge[e] = true;
-                if (!adj->isSource()) {
-                    m_g.reverseEdge(e);
-                }
-                stack.push_back(w->firstAdj());
-            } else if (!traversed[e]) {
-                /* e is tree edge */
-                traversed[e] = true;
-                m_isTreeEdge[e] = false;
-                m_lowpoint[e] = w;
-                if (!adj->isSource()) {
-                    m_g.reverseEdge(e);
-                }
+	while (!stack.empty()) {
+		const auto adj = stack.back();
+		if (adj) {
+			const auto w = adj->twinNode();
+			const auto e = adj->theEdge();
+			if (!visited[w]) {
+				/* e is tree edge */
+				m_depth[w] = stack.size(); // = m_depth[v] + 1
+				m_parentEdge[w] = adj->twin();
+				visited[w] = true;
+				traversed[e] = true;
+				m_isTreeEdge[e] = true;
+				if (!adj->isSource()) {
+					m_g.reverseEdge(e);
+				}
+				stack.push_back(w->firstAdj());
+			} else if (!traversed[e]) {
+				/* e is tree edge */
+				traversed[e] = true;
+				m_isTreeEdge[e] = false;
+				m_lowpoint[e] = w;
+				if (!adj->isSource()) {
+					m_g.reverseEdge(e);
+				}
 
-                /* indices at w */
-                const auto ix_e = m_indices[adj->twin()];
-                const auto ix_p = m_indices[m_parentEdge[w]];
-                const auto ix_d = m_indices[stack[m_depth[w]]];
+				/* indices at w */
+				const auto ix_e = m_indices[adj->twin()];
+				const auto ix_p = m_indices[m_parentEdge[w]];
+				const auto ix_d = m_indices[stack[m_depth[w]]];
 
-                const size_t ang_e_d = (w->degree() + ix_d - ix_e) % w->degree();
-                const size_t ang_e_p = (w->degree() + ix_p - ix_e) % w->degree();
-                if (ang_e_d < ang_e_p) {
-                    /* in clockwise order around w: e, active tree edge = stack[m_depth[w]], m_parentEdge[w] */
-                    m_returnSide[e] = RIGHT;
-                    m_angularDistance[e] = ang_e_d;
-                } else {
-                    m_returnSide[e] = LEFT;
-                    m_angularDistance[e] = w->degree() - ang_e_d;
-                }
+				const size_t ang_e_d = (w->degree() + ix_d - ix_e) % w->degree();
+				const size_t ang_e_p = (w->degree() + ix_p - ix_e) % w->degree();
+				if (ang_e_d < ang_e_p) {
+					/* in clockwise order around w: e, active tree edge = stack[m_depth[w]], m_parentEdge[w] */
+					m_returnSide[e] = RIGHT;
+					m_angularDistance[e] = ang_e_d;
+				} else {
+					m_returnSide[e] = LEFT;
+					m_angularDistance[e] = w->degree() - ang_e_d;
+				}
 
-                /* go to next edge of v */
-                stack.back() = adj->succ();
-            } else {
-                /* go to next edge of v */
-                stack.back() = adj->succ();
-            }
-        } else {
-            stack.pop_back();
+				/* go to next edge of v */
+				stack.back() = adj->succ();
+			} else {
+				/* go to next edge of v */
+				stack.back() = adj->succ();
+			}
+		} else {
+			stack.pop_back();
 
-            if (!stack.empty()) {
-                /* w is done now, m_parentEdge[w] inherits properties of outgoing edges of w */
-                const auto w = stack.back()->twinNode();
-                const auto p = stack.back()->theEdge(); // = m_parentEdge[w]->theEdge()
+			if (!stack.empty()) {
+				/* w is done now, m_parentEdge[w] inherits properties of outgoing edges of w */
+				const auto w = stack.back()->twinNode();
+				const auto p = stack.back()->theEdge(); // = m_parentEdge[w]->theEdge()
 
-                m_lowpoint[p] = w;
-                m_returnSide[p] = 0;
-                m_angularDistance[p] = 0;
-                for (const auto a : w->adjEntries) {
-                    /* only consider outgoing edges of w */
-                    if (!a->isSource()) {
-                        continue;
-                    }
-                    const auto e = a->theEdge();
+				m_lowpoint[p] = w;
+				m_returnSide[p] = 0;
+				m_angularDistance[p] = 0;
+				for (const auto a : w->adjEntries) {
+					/* only consider outgoing edges of w */
+					if (!a->isSource()) {
+						continue;
+					}
+					const auto e = a->theEdge();
 
-                    if (m_depth[m_lowpoint[e]] < m_depth[m_lowpoint[p]]) {
-                        m_lowpoint[p] = m_lowpoint[e];
-                        m_returnSide[p] = m_returnSide[e];
-                        m_angularDistance[p] = m_angularDistance[e];
-                    } else if (m_depth[m_lowpoint[e]] == m_depth[m_lowpoint[p]]) {
-                        m_returnSide[p] |= m_returnSide[e];
-                        m_angularDistance[p] = std::max(m_angularDistance[e], m_angularDistance[e]);
-                    }
-                }
+					if (m_depth[m_lowpoint[e]] < m_depth[m_lowpoint[p]]) {
+						m_lowpoint[p] = m_lowpoint[e];
+						m_returnSide[p] = m_returnSide[e];
+						m_angularDistance[p] = m_angularDistance[e];
+					} else if (m_depth[m_lowpoint[e]] == m_depth[m_lowpoint[p]]) {
+						m_returnSide[p] |= m_returnSide[e];
+						m_angularDistance[p] = std::max(m_angularDistance[e], m_angularDistance[e]);
+					}
+				}
 
-                /* go to next edge of v */
-                stack.back() = stack.back()->succ();
-            }
-        }
-    }
+				/* go to next edge of v */
+				stack.back() = stack.back()->succ();
+			}
+		}
+	}
 }
 
 void FourBlockTreeBuilder::orderTriangles() {
-    /* sort edges e using Counting-/RadixSort on */
-    /* 1. e->source() */
-    /* 2. -m_depth[m_lowpoint[e]] */
-    /* 3. m_angularDistance[e] */
-    const auto byAngularDistance =
-            countingSort(m_g.edges, [&](edge e) { return m_angularDistance[e]; });
-    const auto byDepthLowpoint = countingSort(byAngularDistance,
-            [&](edge e) { return m_g.numberOfNodes() - m_depth[m_lowpoint[e]]; });
-    NodeArray<std::vector<edge>> edge_order(m_g);
-    for (const auto e : byDepthLowpoint) {
-        edge_order[e->source()].push_back(e);
-    }
+	/* sort edges e using Counting-/RadixSort on */
+	/* 1. e->source() */
+	/* 2. -m_depth[m_lowpoint[e]] */
+	/* 3. m_angularDistance[e] */
+	const auto byAngularDistance =
+			countingSort(m_g.edges, [&](edge e) { return m_angularDistance[e]; });
+	const auto byDepthLowpoint = countingSort(byAngularDistance,
+			[&](edge e) { return m_g.numberOfNodes() - m_depth[m_lowpoint[e]]; });
+	NodeArray<std::vector<edge>> edge_order(m_g);
+	for (const auto e : byDepthLowpoint) {
+		edge_order[e->source()].push_back(e);
+	}
 
-    std::vector<unsigned char> untraversedEdges(m_sepTriangles.size(),
-            3); // number of edges for each triangle that have not yet been traversed
-    EdgeArray<std::vector<size_t>> triangleIndices(
-            m_g); // indices into untraversedEdges and m_sepTriangles
-    for (size_t i = 0; i < m_sepTriangles.size(); ++i) {
-        const auto& t = m_sepTriangles[i];
-        for (const auto e : t) {
-            triangleIndices[e].push_back(i);
-        }
-    }
+	std::vector<unsigned char> untraversedEdges(m_sepTriangles.size(),
+			3); // number of edges for each triangle that have not yet been traversed
+	EdgeArray<std::vector<size_t>> triangleIndices(
+			m_g); // indices into untraversedEdges and m_sepTriangles
+	for (size_t i = 0; i < m_sepTriangles.size(); ++i) {
+		const auto& t = m_sepTriangles[i];
+		for (const auto e : t) {
+			triangleIndices[e].push_back(i);
+		}
+	}
 
-    /* find order of triangles */
-    /* indices into m_sepTriangles are also indices into these two arrays */
-    std::vector<size_t> internalAngle(m_sepTriangles.size(), 0);
-    std::vector<size_t> foundWithEdge(m_sepTriangles.size(), 0);
+	/* find order of triangles */
+	/* indices into m_sepTriangles are also indices into these two arrays */
+	std::vector<size_t> internalAngle(m_sepTriangles.size(), 0);
+	std::vector<size_t> foundWithEdge(m_sepTriangles.size(), 0);
 
-    /* second DFS */
-    std::vector<std::pair<node, std::vector<edge>::const_iterator>> stack = {
-            {m_root, edge_order[m_root].cbegin()}};
-    size_t edge_id = 0;
-    while (!stack.empty()) {
-        auto& [v, it] = stack.back();
-        if (it == edge_order[v].cend()) {
-            stack.pop_back();
-        } else {
-            ++edge_id;
-            const auto e = *it++;
-            const auto w = e->target();
-            if (m_isTreeEdge[e]) {
-                stack.emplace_back(w, edge_order[w].cbegin());
-            }
+	/* second DFS */
+	std::vector<std::pair<node, std::vector<edge>::const_iterator>> stack = {
+			{m_root, edge_order[m_root].cbegin()}};
+	size_t edge_id = 0;
+	while (!stack.empty()) {
+		auto& [v, it] = stack.back();
+		if (it == edge_order[v].cend()) {
+			stack.pop_back();
+		} else {
+			++edge_id;
+			const auto e = *it++;
+			const auto w = e->target();
+			if (m_isTreeEdge[e]) {
+				stack.emplace_back(w, edge_order[w].cbegin());
+			}
 
-            std::vector<size_t> completeTriangles; // elements are indices into m_sepTriangles
-            for (const auto i : triangleIndices[e]) {
-                if (--untraversedEdges[i] == 0) {
-                    completeTriangles.push_back(i);
-                    foundWithEdge[i] = edge_id;
+			std::vector<size_t> completeTriangles; // elements are indices into m_sepTriangles
+			for (const auto i : triangleIndices[e]) {
+				if (--untraversedEdges[i] == 0) {
+					completeTriangles.push_back(i);
+					foundWithEdge[i] = edge_id;
 
-                    /* make e first edge in triangle */
-                    auto& t = m_sepTriangles[i];
-                    if (e == t[1]) {
-                        std::swap(t[0], t[1]);
-                    } else if (e == t[2]) {
-                        std::swap(t[0], t[2]);
-                    }
+					/* make e first edge in triangle */
+					auto& t = m_sepTriangles[i];
+					if (e == t[1]) {
+						std::swap(t[0], t[1]);
+					} else if (e == t[2]) {
+						std::swap(t[0], t[2]);
+					}
 
-                    /* "direct" t clockwise */
-                    if (t[1]->isIncident(w) ^ (m_returnSide[e] == LEFT)) {
-                        std::swap(t[1], t[2]);
-                    }
-                }
-            }
-            if (completeTriangles.size() > 1) {
-                /* e must be a back edge, and all triangles are on the same side of e */
-                const bool trianglesRight = m_returnSide[e] == LEFT;
+					/* "direct" t clockwise */
+					if (t[1]->isIncident(w) ^ (m_returnSide[e] == LEFT)) {
+						std::swap(t[1], t[2]);
+					}
+				}
+			}
+			if (completeTriangles.size() > 1) {
+				/* e must be a back edge, and all triangles are on the same side of e */
+				const bool trianglesRight = m_returnSide[e] == LEFT;
 
-                const auto ix_e = m_indices[e->adjTarget()];
+				const auto ix_e = m_indices[e->adjTarget()];
 
-                for (const auto i : completeTriangles) {
-                    const auto& t = m_sepTriangles[i];
-                    const auto a = [&]() {
-                        /* find adjEntry a on t with a->theNode() == w and a->twinNode() != v */
-                        for (const auto side : t) {
-                            for (const auto adj : {side->adjSource(), side->adjTarget()}) {
-                                if (adj->theNode() == w && adj->twinNode() != v) {
-                                    return adj;
-                                }
-                            }
-                        }
-                        /* unreachable */
-                        std::terminate();
-                    }();
-                    const auto ang_a_e = (w->degree() + ix_e - m_indices[a]) % w->degree();
-                    if (trianglesRight) {
-                        internalAngle[i] = ang_a_e;
-                    } else {
-                        internalAngle[i] = w->degree() - ang_a_e;
-                    }
-                }
-            }
-        }
-    }
+				for (const auto i : completeTriangles) {
+					const auto& t = m_sepTriangles[i];
+					const auto a = [&]() {
+						/* find adjEntry a on t with a->theNode() == w and a->twinNode() != v */
+						for (const auto side : t) {
+							for (const auto adj : {side->adjSource(), side->adjTarget()}) {
+								if (adj->theNode() == w && adj->twinNode() != v) {
+									return adj;
+								}
+							}
+						}
+						/* unreachable */
+						std::terminate();
+					}();
+					const auto ang_a_e = (w->degree() + ix_e - m_indices[a]) % w->degree();
+					if (trianglesRight) {
+						internalAngle[i] = ang_a_e;
+					} else {
+						internalAngle[i] = w->degree() - ang_a_e;
+					}
+				}
+			}
+		}
+	}
 
-    std::vector<size_t> tmp;
-    tmp.reserve(m_sepTriangles.size());
-    for (size_t i = 0; i < m_sepTriangles.size(); ++i) {
-        tmp.push_back(i);
-    }
-    const auto byInternalAngle = countingSort(tmp, [&](size_t i) { return internalAngle[i]; });
-    const auto byFoundWithEdge =
-            countingSort(byInternalAngle, [&](size_t i) { return foundWithEdge[i]; });
-    std::vector<triangle_t> res;
-    for (const size_t i : byFoundWithEdge) {
-        res.push_back(m_sepTriangles[i]);
-    }
+	std::vector<size_t> tmp;
+	tmp.reserve(m_sepTriangles.size());
+	for (size_t i = 0; i < m_sepTriangles.size(); ++i) {
+		tmp.push_back(i);
+	}
+	const auto byInternalAngle = countingSort(tmp, [&](size_t i) { return internalAngle[i]; });
+	const auto byFoundWithEdge =
+			countingSort(byInternalAngle, [&](size_t i) { return foundWithEdge[i]; });
+	std::vector<triangle_t> res;
+	for (const size_t i : byFoundWithEdge) {
+		res.push_back(m_sepTriangles[i]);
+	}
 
-    m_sepTriangles = std::move(res);
+	m_sepTriangles = std::move(res);
 }
 
 FourBlockTree FourBlockTreeBuilder::buildTree() {
-    std::vector<std::unique_ptr<FourBlockTree>> blocks;
+	std::vector<std::unique_ptr<FourBlockTree>> blocks;
 
-    /* used to set FourBlockTree.parent */
-    AdjEntryArray<FourBlockTree*> parentInv(m_g, nullptr);
+	/* used to set FourBlockTree.parent */
+	AdjEntryArray<FourBlockTree*> parentInv(m_g, nullptr);
 
-    /* isInner[v] => v is part of an inner block that is about to be copied from m_g */
-    /* initialized once to avoid linear cost for each block */
-    NodeArray<bool> isInner(m_g, false);
+	/* isInner[v] => v is part of an inner block that is about to be copied from m_g */
+	/* initialized once to avoid linear cost for each block */
+	NodeArray<bool> isInner(m_g, false);
 
-    /* the ID the edge will have in b */
-    /* initialized once to avoid linear cost for each block */
-    EdgeArray<size_t> edgeIdsForB(m_g, 0);
+	/* the ID the edge will have in b */
+	/* initialized once to avoid linear cost for each block */
+	EdgeArray<size_t> edgeIdsForB(m_g, 0);
 
-    for (const auto& t : m_sepTriangles) {
-        /* u,v,w in clockwise order around t */
-        const auto [uv, vw, wu] = t;
-        const auto v = uv->commonNode(vw);
-        const auto w = vw->commonNode(wu);
-        const auto u = wu->commonNode(uv);
+	for (const auto& t : m_sepTriangles) {
+		/* u,v,w in clockwise order around t */
+		const auto [uv, vw, wu] = t;
+		const auto v = uv->commonNode(vw);
+		const auto w = vw->commonNode(wu);
+		const auto u = wu->commonNode(uv);
 
-        /* create new block b */
-        blocks.push_back(std::make_unique<FourBlockTree>());
-        auto& b = *blocks.back();
+		/* create new block b */
+		blocks.push_back(std::make_unique<FourBlockTree>());
+		auto& b = *blocks.back();
 
-        /* split m_g at t */
-        const auto u_ = m_g.newNode();
-        const auto v_ = m_g.newNode();
-        const auto w_ = m_g.newNode();
-        const auto vw_ = m_g.newEdge(v_, w_);
-        const auto wu_ = m_g.newEdge(w_, u_);
-        const auto uv_ = m_g.newEdge(u_, v_);
-        m_originalNodes[u_] = m_originalNodes[u];
-        m_originalNodes[v_] = m_originalNodes[v];
-        m_originalNodes[w_] = m_originalNodes[w];
+		/* split m_g at t */
+		const auto u_ = m_g.newNode();
+		const auto v_ = m_g.newNode();
+		const auto w_ = m_g.newNode();
+		const auto vw_ = m_g.newEdge(v_, w_);
+		const auto wu_ = m_g.newEdge(w_, u_);
+		const auto uv_ = m_g.newEdge(u_, v_);
+		m_originalNodes[u_] = m_originalNodes[u];
+		m_originalNodes[v_] = m_originalNodes[v];
+		m_originalNodes[w_] = m_originalNodes[w];
 
-        /* move edges incident to v */
-        auto adj = vw->getAdj(v)->cyclicSucc();
-        while (adj != uv->getAdj(v)) {
-            const auto tmp = adj->cyclicSucc();
-            if (adj->isSource()) {
-                m_g.moveSource(adj->theEdge(), uv_->adjTarget(), Direction::before);
-            } else {
-                m_g.moveTarget(adj->theEdge(), uv_->adjTarget(), Direction::before);
-            }
-            adj = tmp;
-        }
+		/* move edges incident to v */
+		auto adj = vw->getAdj(v)->cyclicSucc();
+		while (adj != uv->getAdj(v)) {
+			const auto tmp = adj->cyclicSucc();
+			if (adj->isSource()) {
+				m_g.moveSource(adj->theEdge(), uv_->adjTarget(), Direction::before);
+			} else {
+				m_g.moveTarget(adj->theEdge(), uv_->adjTarget(), Direction::before);
+			}
+			adj = tmp;
+		}
 
-        /* move edges incident to w */
-        adj = wu->getAdj(w)->cyclicSucc();
-        while (adj != vw->getAdj(w)) {
-            const auto tmp = adj->cyclicSucc();
-            if (adj->isSource()) {
-                m_g.moveSource(adj->theEdge(), vw_->adjTarget(), Direction::before);
-            } else {
-                m_g.moveTarget(adj->theEdge(), vw_->adjTarget(), Direction::before);
-            }
-            adj = tmp;
-        }
+		/* move edges incident to w */
+		adj = wu->getAdj(w)->cyclicSucc();
+		while (adj != vw->getAdj(w)) {
+			const auto tmp = adj->cyclicSucc();
+			if (adj->isSource()) {
+				m_g.moveSource(adj->theEdge(), vw_->adjTarget(), Direction::before);
+			} else {
+				m_g.moveTarget(adj->theEdge(), vw_->adjTarget(), Direction::before);
+			}
+			adj = tmp;
+		}
 
-        /* move edges incident to u */
-        adj = uv->getAdj(u)->cyclicSucc();
-        while (adj != wu->getAdj(u)) {
-            const auto tmp = adj->cyclicSucc();
-            if (adj->isSource()) {
-                m_g.moveSource(adj->theEdge(), wu_->adjTarget(), Direction::before);
-            } else {
-                m_g.moveTarget(adj->theEdge(), wu_->adjTarget(), Direction::before);
-            }
-            adj = tmp;
-        }
+		/* move edges incident to u */
+		adj = uv->getAdj(u)->cyclicSucc();
+		while (adj != wu->getAdj(u)) {
+			const auto tmp = adj->cyclicSucc();
+			if (adj->isSource()) {
+				m_g.moveSource(adj->theEdge(), wu_->adjTarget(), Direction::before);
+			} else {
+				m_g.moveTarget(adj->theEdge(), wu_->adjTarget(), Direction::before);
+			}
+			adj = tmp;
+		}
 
-        /* set parent pointers to b */
-        for (const auto a : {uv->getAdj(v), vw->getAdj(w), wu->getAdj(u)}) {
-            auto& c = parentInv[a];
-            if (c) {
-                c->parent = &b;
-            }
-            c = &b;
-        }
+		/* set parent pointers to b */
+		for (const auto a : {uv->getAdj(v), vw->getAdj(w), wu->getAdj(u)}) {
+			auto& c = parentInv[a];
+			if (c) {
+				c->parent = &b;
+			}
+			c = &b;
+		}
 
-        /* list all nodes to be copied to b */
-        std::vector<node> innerNodes = {u_, v_, w_}; // nodes in inner block
-        isInner[u_] = isInner[v_] = isInner[w_] = true;
-        size_t b_m = 0; // number of edges in inner block
-        size_t nextEdgeIdForB = 0;
-        for (size_t i = 0; i < innerNodes.size(); ++i) {
-            for (const auto a : innerNodes[i]->adjEntries) {
-                /* count edges */
-                if (a->isSource()) {
-                    ++b_m;
-                    edgeIdsForB[a] = nextEdgeIdForB++;
-                }
+		/* list all nodes to be copied to b */
+		std::vector<node> innerNodes = {u_, v_, w_}; // nodes in inner block
+		isInner[u_] = isInner[v_] = isInner[w_] = true;
+		size_t b_m = 0; // number of edges in inner block
+		size_t nextEdgeIdForB = 0;
+		for (size_t i = 0; i < innerNodes.size(); ++i) {
+			for (const auto a : innerNodes[i]->adjEntries) {
+				/* count edges */
+				if (a->isSource()) {
+					++b_m;
+					edgeIdsForB[a] = nextEdgeIdForB++;
+				}
 
-                /* add neighbor x if not already added */
-                const auto x = a->twinNode();
-                if (!isInner[x]) {
-                    isInner[x] = true;
-                    innerNodes.push_back(x);
-                }
-            }
-        }
+				/* add neighbor x if not already added */
+				const auto x = a->twinNode();
+				if (!isInner[x]) {
+					isInner[x] = true;
+					innerNodes.push_back(x);
+				}
+			}
+		}
 
-        /* copy innerNodes with their edges to b */
-        b.originalNodes.init(b.g);
-        b.parent = nullptr;
-        b.parentFace = nullptr;
-        const auto bDummy = b.g.newNode();
-        std::vector<edge> bEdges;
-        for (size_t i = 0; i < b_m; ++i) {
-            bEdges.push_back(b.g.newEdge(bDummy, bDummy));
-        }
-        for (const auto x : innerNodes) {
-            /* copy node */
-            const auto b_v = b.g.newNode();
-            b.originalNodes[b_v] = m_originalNodes[x];
+		/* copy innerNodes with their edges to b */
+		b.originalNodes.init(b.g);
+		b.parent = nullptr;
+		b.parentFace = nullptr;
+		const auto bDummy = b.g.newNode();
+		std::vector<edge> bEdges;
+		for (size_t i = 0; i < b_m; ++i) {
+			bEdges.push_back(b.g.newEdge(bDummy, bDummy));
+		}
+		for (const auto x : innerNodes) {
+			/* copy node */
+			const auto b_v = b.g.newNode();
+			b.originalNodes[b_v] = m_originalNodes[x];
 
-            for (const auto a : x->adjEntries) {
-                /* copy adjEntry */
-                const auto b_e = bEdges[edgeIdsForB[a]];
-                if (a->isSource()) {
-                    b.g.moveSource(b_e, b_v);
-                } else {
-                    b.g.moveTarget(b_e, b_v);
-                }
+			for (const auto a : x->adjEntries) {
+				/* copy adjEntry */
+				const auto b_e = bEdges[edgeIdsForB[a]];
+				if (a->isSource()) {
+					b.g.moveSource(b_e, b_v);
+				} else {
+					b.g.moveTarget(b_e, b_v);
+				}
 
-                /* set c.parent and c.parentFace for children c of b */
-                const auto c = parentInv[a];
-                if (c) {
-                    const auto b_a = a->isSource() ? b_e->adjSource() : b_e->adjTarget();
-                    c->parent = &b;
-                    c->parentFace = b_a;
-                }
-            }
+				/* set c.parent and c.parentFace for children c of b */
+				const auto c = parentInv[a];
+				if (c) {
+					const auto b_a = a->isSource() ? b_e->adjSource() : b_e->adjTarget();
+					c->parent = &b;
+					c->parentFace = b_a;
+				}
+			}
 
-            if (x == v_) {
-                b.externalFace = b_v->lastAdj();
-            }
-        }
-        b.g.delNode(bDummy);
-    }
+			if (x == v_) {
+				b.externalFace = b_v->lastAdj();
+			}
+		}
+		b.g.delNode(bDummy);
+	}
 
-    /* root of 4-block tree */
-    FourBlockTree res;
-    {
-        /* list all nodes to be copied to res */
-        std::vector<node> innerNodes = {m_root}; // nodes in outermost block
-        isInner[m_root] = true;
-        size_t b_m = 0; // number of edges in outermost block
-        size_t nextEdgeIdForB = 0;
-        for (size_t i = 0; i < innerNodes.size(); ++i) {
-            for (const auto a : innerNodes[i]->adjEntries) {
-                /* count edges */
-                if (a->isSource()) {
-                    ++b_m;
-                    edgeIdsForB[a] = nextEdgeIdForB++;
-                }
+	/* root of 4-block tree */
+	FourBlockTree res;
+	{
+		/* list all nodes to be copied to res */
+		std::vector<node> innerNodes = {m_root}; // nodes in outermost block
+		isInner[m_root] = true;
+		size_t b_m = 0; // number of edges in outermost block
+		size_t nextEdgeIdForB = 0;
+		for (size_t i = 0; i < innerNodes.size(); ++i) {
+			for (const auto a : innerNodes[i]->adjEntries) {
+				/* count edges */
+				if (a->isSource()) {
+					++b_m;
+					edgeIdsForB[a] = nextEdgeIdForB++;
+				}
 
-                /* add neighbor w if not already added */
-                const auto w = a->twinNode();
-                if (!isInner[w]) {
-                    isInner[w] = true;
-                    innerNodes.push_back(w);
-                }
-            }
-        }
+				/* add neighbor w if not already added */
+				const auto w = a->twinNode();
+				if (!isInner[w]) {
+					isInner[w] = true;
+					innerNodes.push_back(w);
+				}
+			}
+		}
 
-        /* copy innerNodes with their edges to res */
-        res.originalNodes.init(res.g);
-        res.parent = nullptr;
-        res.parentFace = nullptr;
-        const auto bDummy = res.g.newNode();
-        std::vector<edge> bEdges;
-        for (size_t i = 0; i < b_m; ++i) {
-            bEdges.push_back(res.g.newEdge(bDummy, bDummy));
-        }
-        for (const auto v : innerNodes) {
-            /* copy node */
-            const auto b_v = res.g.newNode();
-            res.originalNodes[b_v] = m_originalNodes[v];
+		/* copy innerNodes with their edges to res */
+		res.originalNodes.init(res.g);
+		res.parent = nullptr;
+		res.parentFace = nullptr;
+		const auto bDummy = res.g.newNode();
+		std::vector<edge> bEdges;
+		for (size_t i = 0; i < b_m; ++i) {
+			bEdges.push_back(res.g.newEdge(bDummy, bDummy));
+		}
+		for (const auto v : innerNodes) {
+			/* copy node */
+			const auto b_v = res.g.newNode();
+			res.originalNodes[b_v] = m_originalNodes[v];
 
-            for (const auto a : v->adjEntries) {
-                /* copy adjEntry */
-                const auto b_e = bEdges[edgeIdsForB[a]];
-                if (a->isSource()) {
-                    res.g.moveSource(b_e, b_v);
-                } else {
-                    res.g.moveTarget(b_e, b_v);
-                }
+			for (const auto a : v->adjEntries) {
+				/* copy adjEntry */
+				const auto b_e = bEdges[edgeIdsForB[a]];
+				if (a->isSource()) {
+					res.g.moveSource(b_e, b_v);
+				} else {
+					res.g.moveTarget(b_e, b_v);
+				}
 
-                /* set res.externalFace */
-                if (a == m_externalFace) {
-                    res.externalFace = a->isSource() ? b_e->adjTarget() : b_e->adjSource();
-                }
+				/* set res.externalFace */
+				if (a == m_externalFace) {
+					res.externalFace = a->isSource() ? b_e->adjTarget() : b_e->adjSource();
+				}
 
-                /* set c.parent and c.parentFace for children c of res */
-                const auto c = parentInv[a];
-                if (c) {
-                    const auto b_a = a->isSource() ? b_e->adjSource() : b_e->adjTarget();
-                    c->parent = &res;
-                    c->parentFace = b_a;
-                }
-            }
-        }
-        res.g.delNode(bDummy);
-    }
+				/* set c.parent and c.parentFace for children c of res */
+				const auto c = parentInv[a];
+				if (c) {
+					const auto b_a = a->isSource() ? b_e->adjSource() : b_e->adjTarget();
+					c->parent = &res;
+					c->parentFace = b_a;
+				}
+			}
+		}
+		res.g.delNode(bDummy);
+	}
 
-    /* move inner blocks to their parents */
-    for (auto& b : blocks) {
-        auto& p = *b->parent;
-        p.children.push_back(std::move(b));
-    }
+	/* move inner blocks to their parents */
+	for (auto& b : blocks) {
+		auto& p = *b->parent;
+		p.children.push_back(std::move(b));
+	}
 
-    return res;
+	return res;
 }
 
 FourBlockTreeBuilder::FourBlockTreeBuilder(Graph& g, NodeArray<node>& originalNodes,
-        adjEntry externalFace)
-    : m_g(g)
-    , m_originalNodes(originalNodes)
-    , m_externalFace(externalFace->twin())
-    , m_root(externalFace->theNode())
-    , m_indices(g, 0)
-    , m_depth(g, 0)
-    , m_parentEdge(g, nullptr)
-    , m_isTreeEdge(g, false)
-    , m_lowpoint(g, nullptr)
-    , m_returnSide(g, 0)
-    , m_angularDistance(g, 0) { }
+		adjEntry externalFace)
+	: m_g(g)
+	, m_originalNodes(originalNodes)
+	, m_externalFace(externalFace->twin())
+	, m_root(externalFace->theNode())
+	, m_indices(g, 0)
+	, m_depth(g, 0)
+	, m_parentEdge(g, nullptr)
+	, m_isTreeEdge(g, false)
+	, m_lowpoint(g, nullptr)
+	, m_returnSide(g, 0)
+	, m_angularDistance(g, 0) { }
 
 FourBlockTree FourBlockTreeBuilder::call() {
-    populateIndices();
-    populateSepTriangles();
-    firstDfs();
-    orderTriangles();
-    return buildTree();
+	populateIndices();
+	populateSepTriangles();
+	firstDfs();
+	orderTriangles();
+	return buildTree();
 }
 
 FourBlockTree FourBlockTree::construct(const Graph& g, adjEntry externalFace) {
-    OGDF_ASSERT(g.numberOfNodes() * 3 == g.numberOfEdges() + 6 && "g must be triangulated");
-    OGDF_ASSERT(isSimpleUndirected(g));
-    OGDF_ASSERT(isPlanar(g));
+	OGDF_ASSERT(g.numberOfNodes() * 3 == g.numberOfEdges() + 6 && "g must be triangulated");
+	OGDF_ASSERT(isSimpleUndirected(g));
+	OGDF_ASSERT(isPlanar(g));
 
-    Graph copy;
-    NodeArray<node> originalNodes(copy, nullptr);
+	Graph copy;
+	NodeArray<node> originalNodes(copy, nullptr);
 
-    /* copy g into copy and populate originalNodes */
-    EdgeArray<edge> edgeCopies(g, nullptr);
-    const node dummySource = copy.newNode();
-    const node dummyTarget = copy.newNode();
-    for (const edge e : g.edges) {
-        edgeCopies[e] = copy.newEdge(dummySource, dummyTarget);
-    }
-    for (const node v : g.nodes) {
-        const node v_ = copy.newNode();
-        originalNodes[v_] = v;
-        for (const adjEntry a : v->adjEntries) {
-            if (a->isSource()) {
-                copy.moveSource(edgeCopies[a->theEdge()], v_);
-            } else {
-                copy.moveTarget(edgeCopies[a->theEdge()], v_);
-            }
-        }
-    }
-    copy.delNode(dummySource);
-    copy.delNode(dummyTarget);
+	/* copy g into copy and populate originalNodes */
+	EdgeArray<edge> edgeCopies(g, nullptr);
+	const node dummySource = copy.newNode();
+	const node dummyTarget = copy.newNode();
+	for (const edge e : g.edges) {
+		edgeCopies[e] = copy.newEdge(dummySource, dummyTarget);
+	}
+	for (const node v : g.nodes) {
+		const node v_ = copy.newNode();
+		originalNodes[v_] = v;
+		for (const adjEntry a : v->adjEntries) {
+			if (a->isSource()) {
+				copy.moveSource(edgeCopies[a->theEdge()], v_);
+			} else {
+				copy.moveTarget(edgeCopies[a->theEdge()], v_);
+			}
+		}
+	}
+	copy.delNode(dummySource);
+	copy.delNode(dummyTarget);
 
-    FourBlockTreeBuilder builder(copy, originalNodes, externalFace);
-    return builder.call();
+	FourBlockTreeBuilder builder(copy, originalNodes, externalFace);
+	return builder.call();
 }

--- a/src/ogdf/decomposition/FourBlockTree.cpp
+++ b/src/ogdf/decomposition/FourBlockTree.cpp
@@ -29,6 +29,8 @@
  * http://www.gnu.org/copyleft/gpl.html
  */
 
+#include <ogdf/basic/AdjEntryArray.h>
+#include <ogdf/basic/EdgeArray.h>
 #include <ogdf/decomposition/FourBlockTree.h>
 
 #ifdef OGDF_DEBUG

--- a/src/ogdf/decomposition/FourBlockTree.cpp
+++ b/src/ogdf/decomposition/FourBlockTree.cpp
@@ -154,7 +154,7 @@ class FourBlockTreeBuilder {
 	 * Split m_g along the elements of m_sepTriangles and build the resulting
 	 * 4-block tree.
 	 */
-	FourBlockTree buildTree();
+	std::unique_ptr<FourBlockTree> buildTree();
 
 public:
 	/**
@@ -178,7 +178,7 @@ public:
 	/**
 	 * Run the algorithm.
 	 */
-	FourBlockTree call();
+	std::unique_ptr<FourBlockTree> call();
 };
 
 void FourBlockTreeBuilder::populateIndices() {
@@ -449,7 +449,7 @@ void FourBlockTreeBuilder::orderTriangles() {
 	m_sepTriangles = std::move(res);
 }
 
-FourBlockTree FourBlockTreeBuilder::buildTree() {
+std::unique_ptr<FourBlockTree> FourBlockTreeBuilder::buildTree() {
 	std::vector<std::unique_ptr<FourBlockTree>> blocks;
 
 	/* used to set FourBlockTree.parent */
@@ -592,8 +592,9 @@ FourBlockTree FourBlockTreeBuilder::buildTree() {
 	}
 
 	/* root of 4-block tree */
-	FourBlockTree res;
+	auto resP = std::make_unique<FourBlockTree>();
 	{
+		auto& res = *resP;
 		/* list all nodes to be copied to res */
 		std::vector<node> innerNodes = {m_root}; // nodes in outermost block
 		isInner[m_root] = true;
@@ -662,7 +663,7 @@ FourBlockTree FourBlockTreeBuilder::buildTree() {
 		p.children.push_back(std::move(b));
 	}
 
-	return res;
+	return resP;
 }
 
 FourBlockTreeBuilder::FourBlockTreeBuilder(Graph& g, NodeArray<node>& originalNodes,
@@ -679,7 +680,7 @@ FourBlockTreeBuilder::FourBlockTreeBuilder(Graph& g, NodeArray<node>& originalNo
 	, m_returnSide(g, 0)
 	, m_angularDistance(g, 0) { }
 
-FourBlockTree FourBlockTreeBuilder::call() {
+std::unique_ptr<FourBlockTree> FourBlockTreeBuilder::call() {
 	populateIndices();
 	populateSepTriangles();
 	firstDfs();
@@ -687,7 +688,7 @@ FourBlockTree FourBlockTreeBuilder::call() {
 	return buildTree();
 }
 
-FourBlockTree FourBlockTree::construct(const Graph& g, adjEntry externalFace) {
+std::unique_ptr<FourBlockTree> FourBlockTree::construct(const Graph& g, adjEntry externalFace) {
 	OGDF_ASSERT(externalFace != nullptr);
 	OGDF_ASSERT(externalFace->graphOf() == &g);
 	OGDF_ASSERT(g.numberOfNodes() * 3 == g.numberOfEdges() + 6 && "g must be triangulated");

--- a/src/ogdf/decomposition/FourBlockTree.cpp
+++ b/src/ogdf/decomposition/FourBlockTree.cpp
@@ -362,7 +362,8 @@ void FourBlockTreeBuilder::orderTriangles() {
 			{m_root, edge_order[m_root].cbegin()}};
 	size_t edge_id = 0;
 	while (!stack.empty()) {
-		auto& [v, it] = stack.back();
+		const auto v = stack.back().first;
+		auto& it = stack.back().second;
 		if (it == edge_order[v].cend()) {
 			stack.pop_back();
 		} else {

--- a/src/ogdf/decomposition/FourBlockTree.cpp
+++ b/src/ogdf/decomposition/FourBlockTree.cpp
@@ -689,8 +689,7 @@ FourBlockTree FourBlockTreeBuilder::call() {
 
 FourBlockTree FourBlockTree::construct(const Graph& g, adjEntry externalFace) {
 	OGDF_ASSERT(externalFace != nullptr);
-	OGDF_ASSERT(std::any_of(g.nodes.begin(), g.nodes.end(),
-			[externalFace](node v) { return v == externalFace->theNode(); }));
+	OGDF_ASSERT(externalFace->graphOf() == &g);
 	OGDF_ASSERT(g.numberOfNodes() * 3 == g.numberOfEdges() + 6 && "g must be triangulated");
 	OGDF_ASSERT(isSimpleUndirected(g));
 	OGDF_ASSERT(isPlanar(g));

--- a/src/ogdf/decomposition/FourBlockTree.cpp
+++ b/src/ogdf/decomposition/FourBlockTree.cpp
@@ -30,6 +30,8 @@
  */
 
 #include <ogdf/decomposition/FourBlockTree.h>
+#include <ogdf/basic/simple_graph_alg.h>
+#include <ogdf/basic/extended_graph_alg.h>
 
 using namespace ogdf;
 
@@ -679,6 +681,10 @@ FourBlockTree FourBlockTreeBuilder::call() {
 }
 
 FourBlockTree FourBlockTree::construct(const Graph& g, adjEntry externalFace) {
+    OGDF_ASSERT(g.numberOfNodes() * 3 == g.numberOfEdges() + 6 && "g must be triangulated");
+    OGDF_ASSERT(isSimpleUndirected(g));
+    OGDF_ASSERT(isPlanar(g));
+
     Graph copy;
     NodeArray<node> originalNodes(copy, nullptr);
 

--- a/src/ogdf/decomposition/FourBlockTree.cpp
+++ b/src/ogdf/decomposition/FourBlockTree.cpp
@@ -29,9 +29,14 @@
  * http://www.gnu.org/copyleft/gpl.html
  */
 
-#include <ogdf/basic/extended_graph_alg.h>
-#include <ogdf/basic/simple_graph_alg.h>
 #include <ogdf/decomposition/FourBlockTree.h>
+
+#ifdef OGDF_DEBUG
+#	include <ogdf/basic/extended_graph_alg.h>
+#	include <ogdf/basic/simple_graph_alg.h>
+
+#	include <algorithm>
+#endif // OGDF_DEBUG
 
 using namespace ogdf;
 
@@ -683,6 +688,9 @@ FourBlockTree FourBlockTreeBuilder::call() {
 }
 
 FourBlockTree FourBlockTree::construct(const Graph& g, adjEntry externalFace) {
+	OGDF_ASSERT(externalFace != nullptr);
+	OGDF_ASSERT(std::any_of(g.nodes.begin(), g.nodes.end(),
+			[externalFace](node v) { return v == externalFace->theNode(); }));
 	OGDF_ASSERT(g.numberOfNodes() * 3 == g.numberOfEdges() + 6 && "g must be triangulated");
 	OGDF_ASSERT(isSimpleUndirected(g));
 	OGDF_ASSERT(isPlanar(g));

--- a/test/src/decomposition/four-block-tree.cpp
+++ b/test/src/decomposition/four-block-tree.cpp
@@ -1,0 +1,298 @@
+#include <ogdf/basic/AdjEntryArray.h>
+#include <ogdf/basic/EdgeArray.h>
+#include <ogdf/basic/Graph_d.h>
+#include <ogdf/basic/simple_graph_alg.h>
+#include <ogdf/decomposition/FourBlockTree.h>
+
+#include <algorithm>
+#include <array>
+#include <random>
+#include <unordered_set>
+#include <vector>
+
+#include <testing.h>
+
+constexpr size_t N = 16;
+
+/**
+ * Generate a random 4-connected plane triangulation.
+ *
+ * Generates a random (3,1)-ordering, construct the corresponding irreducible
+ * triangulation, add one edge.
+ *
+ * We take care not to add any paths of length 2 between east and west (other
+ * than those via north and south), such that adding an edge {east,west} in the
+ * external face creates no separating triangle.
+ *
+ * Invariant: nodes incident to the external face have the external face between
+ * their firstAdj() and their lastAdj().
+ */
+template<typename RANDOM_ENGINE>
+void generateFourConnectedPlaneTriangulation(Graph& g, adjEntry& externalFace, int n,
+		RANDOM_ENGINE& eng) {
+	const node south = g.newNode();
+	const node east = g.newNode();
+	const node west = g.newNode();
+	g.newEdge(east, south);
+	g.newEdge(south->lastAdj(), Direction::after, west, Direction::after, -1);
+	externalFace =
+			g.newEdge(west->lastAdj(), Direction::after, east->firstAdj(), Direction::before, -1)
+					->adjTarget();
+	const node left = g.newNode();
+	const node right = g.newNode();
+	g.newEdge(east->lastAdj(), Direction::after, right, Direction::after, -1);
+	g.newEdge(south->firstAdj(), Direction::before, right->lastAdj(), Direction::after, -1);
+	g.newEdge(right->lastAdj(), Direction::after, left, Direction::after, -1);
+	g.newEdge(south->firstAdj(), Direction::before, left->lastAdj(), Direction::after, -1);
+	g.newEdge(west->firstAdj(), Direction::before, left->lastAdj(), Direction::after, -1);
+	size_t maxCoveredNodes = 0; // the number of nodes we may cover in the next step
+	n -= 6; // we already count the node north here
+	std::normal_distribution<double> normDist;
+	using uniformDist = std::uniform_int_distribution<size_t>;
+	while (n > 0) {
+		const double randomValue = normDist(eng);
+		if (randomValue < 0) {
+			// we decrease the number of nodes on the external face by
+			const size_t numCoveredNodes = double(maxCoveredNodes) * std::min(1.0, -randomValue / 2);
+			// we pick a random spot on the external face
+			node rightmostAdjacent = east;
+			for (size_t i = uniformDist(0, maxCoveredNodes + 1 - numCoveredNodes)(eng); i > 0; --i) {
+				rightmostAdjacent = rightmostAdjacent->lastAdj()->twinNode();
+			}
+			node nextAdjacent = rightmostAdjacent->lastAdj()->twinNode();
+			// we add a singleton with numCoveredNodes + 3 neighbors
+			const node v = g.newNode();
+			g.newEdge(rightmostAdjacent->lastAdj(), Direction::after, v, Direction::after, -1);
+			for (size_t i = 0; i < numCoveredNodes + 2; ++i) {
+				g.newEdge(nextAdjacent->firstAdj(), Direction::before, v->lastAdj(),
+						Direction::after, -1);
+				nextAdjacent = nextAdjacent->lastAdj()->twinNode();
+			}
+			// we update the number of nodes on the external face
+			maxCoveredNodes -= numCoveredNodes;
+			// and the number of nodes we still have to create
+			--n;
+		} else {
+			// we increase the number of nodes on the external face by
+			const size_t numNewNodes = double(n) * std::min(1.0, randomValue / 3);
+			// we pick a random spot on the external face where the singleton fits
+			node rightAdjacent = east;
+			for (size_t i = uniformDist(0, maxCoveredNodes + 1)(eng); i > 0; --i) {
+				rightAdjacent = rightAdjacent->lastAdj()->twinNode();
+			}
+			const node middleAdjacent = rightAdjacent->lastAdj()->twinNode();
+			const node leftAdjacent = middleAdjacent->lastAdj()->twinNode();
+			// we add a fan with numNewNodes + 1 nodes
+			node v = g.newNode();
+			g.newEdge(rightAdjacent->lastAdj(), Direction::after, v, Direction::after, -1);
+			g.newEdge(middleAdjacent->firstAdj(), Direction::before, v->lastAdj(), Direction::after,
+					-1);
+			for (size_t i = 0; i < numNewNodes; ++i) {
+				const node w = g.newNode();
+				g.newEdge(v->lastAdj(), Direction::after, w, Direction::after, -1);
+				g.newEdge(middleAdjacent->firstAdj(), Direction::before, w->lastAdj(),
+						Direction::after, -1);
+				v = w;
+			}
+			g.newEdge(leftAdjacent->firstAdj(), Direction::before, v->lastAdj(), Direction::after,
+					-1);
+			// we update the number of nodes on the external face
+			maxCoveredNodes += numNewNodes;
+			// and the number of nodes we still have to create
+			n -= numNewNodes + 1;
+		}
+	}
+	const node north = g.newNode();
+	g.newEdge(east->firstAdj(), Direction::before, north, Direction::after, -1);
+	for (node v = east->lastAdj()->twinNode(); v != east; v = v->lastAdj()->twinNode()) {
+		g.newEdge(v->firstAdj(), Direction::before, north->lastAdj(), Direction::after, -1);
+	}
+}
+
+/**
+ * Contains a decent amount of info about how the 4-block tree should look.
+ */
+struct FourBlockTreeStructure {
+	Array<int> degDist; // as a surrogate for testing isomorphism
+	std::vector<FourBlockTreeStructure> children;
+};
+
+template<typename RANDOM_ENGINE>
+void generatePlaneTriangulation(Graph& g, adjEntry& externalFace, FourBlockTreeStructure& ref,
+		int n, int d, RANDOM_ENGINE& eng) {
+	n = std::max(n, d / 2 + 3); // so that there are enough faces for the number of children we want
+	g.clear();
+
+	std::vector<adjEntry> externalFaces;
+	externalFaces.reserve(1 << d);
+	std::vector<std::unordered_set<adjEntry>> originalFaces;
+	originalFaces.reserve(1 << d);
+	std::vector<FourBlockTreeStructure> nodes;
+	nodes.reserve(1 << d);
+
+	// generate 4-connected components
+	const node dummySrc = g.newNode();
+	const node dummyTgt = g.newNode();
+	for (int i = 0; i < 1 << d; ++i) {
+		Graph tempGraph;
+		adjEntry tempExtFace;
+		generateFourConnectedPlaneTriangulation(tempGraph, tempExtFace, n, eng);
+
+		originalFaces.emplace_back();
+		EdgeArray<edge> copies(tempGraph, nullptr);
+		for (const edge e : tempGraph.edges) {
+			const edge c = g.newEdge(dummySrc, dummyTgt);
+			copies[e] = c;
+			originalFaces.back().insert({c->adjSource(), c->adjTarget()});
+		}
+		for (const node v : tempGraph.nodes) {
+			const node nodeCopy = g.newNode();
+			for (const adjEntry a : v->adjEntries) {
+				adjEntry adjEntryCopy;
+				const edge edgeCopy = copies[a->theEdge()];
+				if (a->isSource()) {
+					adjEntryCopy = edgeCopy->adjSource();
+					g.moveSource(edgeCopy, nodeCopy);
+				} else {
+					adjEntryCopy = edgeCopy->adjTarget();
+					g.moveTarget(edgeCopy, nodeCopy);
+				}
+				if (a == tempExtFace) {
+					externalFaces.push_back(adjEntryCopy);
+				}
+			}
+		}
+		const adjEntry e = externalFaces.back();
+		originalFaces.back().erase(e);
+		originalFaces.back().erase(e->faceCyclePred());
+		originalFaces.back().erase(e->faceCycleSucc());
+
+		nodes.emplace_back();
+		degreeDistribution(tempGraph, nodes.back().degDist);
+	}
+	g.delNode(dummySrc);
+	g.delNode(dummyTgt);
+
+	// assemble final graph
+	while (d-- > 0) {
+		for (int i = 0; i < 1 << d; ++i) {
+			nodes[i].children.push_back(std::move(nodes.back()));
+
+			const auto it = originalFaces[i].begin();
+			const adjEntry targetFace = *it;
+			originalFaces[i].erase(it);
+			originalFaces[i].erase(targetFace->faceCyclePred());
+			originalFaces[i].erase(targetFace->faceCycleSucc());
+
+			const adjEntry ext = externalFaces.back();
+			std::array<adjEntry, 3> outerAdjEntries = {targetFace, targetFace->faceCycleSucc(),
+											targetFace->faceCyclePred()},
+									innerAdjEntries = {
+											ext, ext->faceCyclePred(), ext->faceCycleSucc()};
+			std::array<node, 3> innerNodes = {innerAdjEntries[0]->theNode(),
+					innerAdjEntries[1]->theNode(), innerAdjEntries[2]->theNode()};
+			for (const size_t j : {0, 1, 2}) {
+				const node v = innerNodes[j];
+				const adjEntry ao = outerAdjEntries[j];
+				adjEntry ai = innerAdjEntries[j];
+				while (v->degree() > 0) {
+					const adjEntry tmp = ai->cyclicPred();
+					if (ai->isSource()) {
+						g.moveSource(ai->theEdge(), ao, Direction::after);
+					} else {
+						g.moveTarget(ai->theEdge(), ao, Direction::after);
+					}
+					ai = tmp;
+				}
+				g.delNode(v);
+			}
+			for (const adjEntry a : innerAdjEntries) {
+				g.delEdge(a->theEdge());
+			}
+
+			externalFaces.pop_back();
+			originalFaces.pop_back();
+			nodes.pop_back();
+		}
+	}
+
+	externalFace = externalFaces.front();
+	ref = std::move(nodes.front());
+}
+
+void orderChildren(FourBlockTree& fbt) {
+	fbt.preorder([](FourBlockTree& n) -> void {
+		std::sort(n.children.begin(), n.children.end(), [](const auto& lhs, const auto& rhs) -> bool {
+			return lhs->children.size() < rhs->children.size();
+		});
+	});
+}
+
+void validateTreeStructure(const FourBlockTree& fbt, const FourBlockTreeStructure& ref) {
+	Array<int> degDist;
+	degreeDistribution(*fbt.g, degDist);
+	AssertThat(degDist, Equals(ref.degDist));
+	const size_t numChildren = ref.children.size();
+	AssertThat(fbt.children.size(), Equals(numChildren));
+	for (size_t i = 0; i < numChildren; ++i) {
+		validateTreeStructure(*fbt.children[i], ref.children[i]);
+	}
+}
+
+void validateParentPointers(const FourBlockTree& fbt) {
+	AssertThat(fbt.parent, Equals(nullptr));
+	AssertThat(fbt.parentFace, Equals(nullptr));
+	fbt.preorder([](const FourBlockTree& n) -> void {
+		for (const auto& child : n.children) {
+			AssertThat(child->parent, Equals(&n));
+			AssertThat(child->parentFace->graphOf(), Equals(n.g.get()));
+		}
+	});
+}
+
+void validateFourConnectedComponents(const FourBlockTree& fbt, const Graph* g) {
+	fbt.preorder([g](const FourBlockTree& n) -> void {
+		AssertThat(isSimpleUndirected(*n.g), Equals(true));
+		AssertThat(3 * n.g->numberOfNodes(), Equals(n.g->numberOfEdges() + 6));
+		AssertThat(n.g->representsCombEmbedding(), Equals(true));
+		AssertThat(n.externalFace->graphOf(), Equals(n.g.get()));
+		for (const node v : n.g->nodes) {
+			AssertThat(n.originalNodes[v]->graphOf(), Equals(g));
+		}
+	});
+}
+
+go_bandit([]() {
+	describe("FourBlockTree", []() {
+		std::mt19937_64 eng(std::random_device {}());
+		it("works for 4-connected graphs", [&eng]() {
+			for (int n : {10, 32, 100, 320}) {
+				for (size_t i = 0; i < N; ++i) {
+					Graph g;
+					adjEntry externalFace = nullptr;
+					generateFourConnectedPlaneTriangulation(g, externalFace, n, eng);
+					const auto fbt = FourBlockTree::construct(g, externalFace);
+					validateFourConnectedComponents(*fbt, &g);
+					AssertThat(fbt->children, IsEmpty());
+				}
+			}
+		});
+		it("works for graphs with separating triangles", [&eng]() {
+			std::uniform_int_distribution<int> nDist(6, 50);
+			for (int d : {1, 3, 5}) {
+				for (size_t i = 0; i < N; ++i) {
+					Graph g;
+					adjEntry externalFace = nullptr;
+					FourBlockTreeStructure ref;
+					const int n = nDist(eng);
+					generatePlaneTriangulation(g, externalFace, ref, n, d, eng);
+					auto fbt = FourBlockTree::construct(g, externalFace);
+					validateFourConnectedComponents(*fbt, &g);
+					validateParentPointers(*fbt);
+					orderChildren(*fbt);
+					validateTreeStructure(*fbt, ref);
+				}
+			}
+		});
+	});
+});

--- a/test/src/decomposition/four-block-tree.cpp
+++ b/test/src/decomposition/four-block-tree.cpp
@@ -285,7 +285,7 @@ void validateParentPointers(const FourBlockTree& fbt) {
 }
 
 void validateFourConnectedComponents(const FourBlockTree& fbt, const Graph* g) {
-	fbt.preorder([g](const FourBlockTree& n) -> void {
+	fbt.preorder([=](const FourBlockTree& n) -> void {
 		AssertThat(isSimpleUndirected(*n.g), Equals(true));
 		AssertThat(3 * n.g->numberOfNodes(), Equals(n.g->numberOfEdges() + 6));
 		AssertThat(n.g->representsCombEmbedding(), Equals(true));

--- a/test/src/decomposition/four-block-tree.cpp
+++ b/test/src/decomposition/four-block-tree.cpp
@@ -277,7 +277,9 @@ void validateParentPointers(const FourBlockTree& fbt) {
 	fbt.preorder([](const FourBlockTree& n) -> void {
 		for (const auto& child : n.children) {
 			AssertThat(child->parent, Equals(&n));
+#ifdef OGDF_DEBUG
 			AssertThat(child->parentFace->graphOf(), Equals(n.g.get()));
+#endif
 		}
 	});
 }
@@ -287,10 +289,12 @@ void validateFourConnectedComponents(const FourBlockTree& fbt, const Graph* g) {
 		AssertThat(isSimpleUndirected(*n.g), Equals(true));
 		AssertThat(3 * n.g->numberOfNodes(), Equals(n.g->numberOfEdges() + 6));
 		AssertThat(n.g->representsCombEmbedding(), Equals(true));
+#ifdef OGDF_DEBUG
 		AssertThat(n.externalFace->graphOf(), Equals(n.g.get()));
 		for (const node v : n.g->nodes) {
 			AssertThat(n.originalNodes[v]->graphOf(), Equals(g));
 		}
+#endif
 	});
 }
 

--- a/test/src/decomposition/four-block-tree.cpp
+++ b/test/src/decomposition/four-block-tree.cpp
@@ -1,3 +1,34 @@
+/** \file
+ * \brief Tests for functionality from ogdf/decomposition/FourBlockTree.h
+ *
+ * \author Gregor Diatzko
+ *
+ * \par License:
+ * This file is part of the Open Graph Drawing Framework (OGDF).
+ *
+ * \par
+ * Copyright (C)<br>
+ * See README.md in the OGDF root directory for details.
+ *
+ * \par
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * Version 2 or 3 as published by the Free Software Foundation;
+ * see the file LICENSE.txt included in the packaging of this file
+ * for details.
+ *
+ * \par
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * \par
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, see
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
 #include <ogdf/basic/AdjEntryArray.h>
 #include <ogdf/basic/EdgeArray.h>
 #include <ogdf/basic/Graph_d.h>


### PR DESCRIPTION
This is an implementation of [10.48550/arXiv.2308.16020](https://doi.org/10.48550/arXiv.2308.16020).
I've taken the code linked there and refactored it slightly to conform to OGDF's coding standards.

As far as I can tell, OGDF *usually* lets an `adjEntry` designate the face to its *right*.
Is that the convention, or is that only the case for `ConstCombinatorialEmbedding`?
If the former, I'll change it in the interface of `FourBlockTree` and `FourBlockTreeBuilder` as well.