### PR TITLE
Mark Graph as immovable

### DIFF
--- a/doc/ogdf-doxygen.cfg
+++ b/doc/ogdf-doxygen.cfg
@@ -2226,7 +2226,7 @@ PREDEFINED             = DOXYGEN_IGNORE \
 # definition found in the source code.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-# from include/ogdf/basic/internal/copy_move.h
+# from include/ogdf/basic/internal/copy_move.h, include/ogdf/basic/RegisteredArray.h
 EXPAND_AS_DEFINED      = OGDF_NO_COPY \
                          OGDF_NO_MOVE \
                          OGDF_DEFAULT_COPY \
@@ -2236,7 +2236,9 @@ EXPAND_AS_DEFINED      = OGDF_NO_COPY \
                          OGDF_MOVE_CONSTR \
                          OGDF_MOVE_OP \
                          OGDF_SWAP_OP \
-                         OGDF_COPY_MOVE_BY_SWAP
+                         OGDF_COPY_MOVE_BY_SWAP \
+                         OGDF_DECL_REG_ARRAY \
+                         OGDF_DECL_REG_ARRAY_TYPE
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then doxygen's preprocessor will
 # remove all references to function-like macros that are alone on a line, have

--- a/doc/ogdf-doxygen.cfg
+++ b/doc/ogdf-doxygen.cfg
@@ -2196,7 +2196,7 @@ SEARCH_INCLUDES        = YES
 # preprocessor.
 # This tag requires that the tag SEARCH_INCLUDES is set to YES.
 
-INCLUDE_PATH           =
+INCLUDE_PATH           = ../include/
 
 # You can use the INCLUDE_FILE_PATTERNS tag to specify one or more wildcard
 # patterns (like *.h and *.hpp) to filter out the header-files in the
@@ -2226,7 +2226,17 @@ PREDEFINED             = DOXYGEN_IGNORE \
 # definition found in the source code.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_AS_DEFINED      =
+# from include/ogdf/basic/internal/copy_move.h
+EXPAND_AS_DEFINED      = OGDF_NO_COPY \
+                         OGDF_NO_MOVE \
+                         OGDF_DEFAULT_COPY \
+                         OGDF_DEFAULT_MOVE \
+                         OGDF_COPY_CONSTR \
+                         OGDF_COPY_OP \
+                         OGDF_MOVE_CONSTR \
+                         OGDF_MOVE_OP \
+                         OGDF_SWAP_OP \
+                         OGDF_COPY_MOVE_BY_SWAP
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then doxygen's preprocessor will
 # remove all references to function-like macros that are alone on a line, have

--- a/doc/porting/unreleased.md
+++ b/doc/porting/unreleased.md
@@ -22,8 +22,14 @@ Otherwise, all elements will be [copied when the array grows](https://stackoverf
 ## ClusterSetSimple and ClusterSetPure
 `ClusterSetSimple` was removed in favor of `ClusterArray<bool>` and `ClusterSetPure` in favor of `ClusterSet<false>` (which does not keep track of its size).
 
+## Graph
+The move constructor and assignment operators of `Graph` are now deleted, which especially means that `NodeArray<Graph>` is no longer possible.
+(Previously it compiled, but randomly broke at runtime when adding new nodes.)
+Use `NodeArrayP<Graph>` instead to wrap the `Graph`s in `std::unique_ptr`s and make one pass over all entries to initialize the pointers.
+See the documentation of `NodeArrayP` for usage as member variable on MSVC<=16.
+
 ## GraphCopy
-`GraphCopy::createEmpty()` was deprecated in favor of `setOriginalEmbedding()`.
+`GraphCopy::createEmpty()` was deprecated in favor of `setOriginalGraph()`.
 The same holds for `createEmpty()` of `GraphCopySimple` and `EdgeWeightedGraph`.
 
 ## GraphObserver
@@ -32,6 +38,10 @@ The same holds for `createEmpty()` of `GraphCopySimple` and `EdgeWeightedGraph`.
 `ClusterGraphObserver`s are now notified of their `ClusterGraph` being cleared through `ClusterGraphObserver::clustersCleared()`.
 
 `HypergraphObserver::init()` was deprecated in favor of `reregister()`.
+
+`Observer`s and their `Observable`s now have deleted copy and move constructors and assignment operators.
+Subclasses can instead explicitly declare their copy and move behaviour using the default constructors of `Observer` / `Observable`,
+`Observer::getObservers()`, `Observer::clearObservers()` and `Observable::reregister()`.
 
 ## Graph::insert
 Multiple methods for inserting (parts of) a graph were merged into a single `Graph::insert` implementation.

--- a/doc/porting/unreleased.md
+++ b/doc/porting/unreleased.md
@@ -23,10 +23,11 @@ Otherwise, all elements will be [copied when the array grows](https://stackoverf
 `ClusterSetSimple` was removed in favor of `ClusterArray<bool>` and `ClusterSetPure` in favor of `ClusterSet<false>` (which does not keep track of its size).
 
 ## Graph
-The move constructor and assignment operators of `Graph` are now deleted, which especially means that `NodeArray<Graph>` is no longer possible.
+The move constructor and assignment operators of `Graph` are now deleted, which especially means that `NodeArray<Graph>`, `EdgeArray<Graph>`, `FaceArray<Graph>`, etc. is no longer possible.
 (Previously it compiled, but randomly broke at runtime when adding new nodes.)
-Use `NodeArrayP<Graph>` instead to wrap the `Graph`s in `std::unique_ptr`s and make one pass over all entries to initialize the pointers.
+Use `NodeArrayP<Graph>`, `EdgeArrayP<Graph>`, `FaceArrayP<Graph>`, etc. instead to wrap the `Graph`s in `std::unique_ptr`s and then make one pass over all entries to initialize the pointers.
 See the documentation of `NodeArrayP` for usage as member variable on MSVC<=16.
+For this reason, `SimDraw::getBasicGraph` now returns a `std::unique_ptr<GraphCopy>` instead of copying a `Graph` object on return.
 
 ## GraphCopy
 `GraphCopy::createEmpty()` was deprecated in favor of `setOriginalGraph()`.

--- a/include/ogdf/basic/CombinatorialEmbedding.h
+++ b/include/ogdf/basic/CombinatorialEmbedding.h
@@ -167,7 +167,7 @@ public:
 using CombinatorialEmbeddingRegistry =
 		RegistryBase<face, ConstCombinatorialEmbedding, internal::GraphIterator<face>>;
 
-//! RegisteredArray for faces of a combinatorial embedding.
+//! RegisteredArray for labeling the \ref face "faces" of a CombinatorialEmbedding.
 template<class Value, bool WithDefault>
 class FaceArrayBase : public RegisteredArray<ConstCombinatorialEmbedding, Value, WithDefault> {
 	using RA = RegisteredArray<ConstCombinatorialEmbedding, Value, WithDefault>;

--- a/include/ogdf/basic/DisjointSets.h
+++ b/include/ogdf/basic/DisjointSets.h
@@ -32,6 +32,7 @@
 #pragma once
 
 #include <ogdf/basic/exceptions.h>
+#include <ogdf/basic/internal/copy_move.h>
 
 #include <cstring>
 
@@ -147,15 +148,36 @@ public:
 		init(maxNumberOfElements);
 	}
 
-	DisjointSets(const DisjointSets&) = delete;
-
-	DisjointSets& operator=(const DisjointSets&) = delete;
-
 	~DisjointSets() {
 		delete[] this->m_parents;
 		delete[] this->m_parameters;
 		delete[] this->m_siblings;
 	}
+
+	OGDF_COPY_CONSTR(DisjointSets) : DisjointSets(copy.m_maxNumberOfElements) {
+		m_numberOfSets = copy.m_numberOfSets;
+		m_numberOfElements = copy.m_numberOfElements;
+		if (copy.m_parents) {
+			std::copy_n(copy.m_parents, m_maxNumberOfElements, m_parents);
+		}
+		if (copy.m_parameters) {
+			std::copy_n(copy.m_parameters, m_maxNumberOfElements, m_parameters);
+		}
+		if (copy.m_siblings) {
+			std::copy_n(copy.m_siblings, m_maxNumberOfElements, m_siblings);
+		}
+	}
+
+	OGDF_SWAP_OP(DisjointSets) {
+		std::swap(first.m_numberOfSets, second.m_numberOfSets);
+		std::swap(first.m_numberOfElements, second.m_numberOfElements);
+		std::swap(first.m_maxNumberOfElements, second.m_maxNumberOfElements);
+		std::swap(first.m_parents, second.m_parents);
+		std::swap(first.m_parameters, second.m_parameters);
+		std::swap(first.m_siblings, second.m_siblings);
+	};
+
+	OGDF_COPY_MOVE_BY_SWAP(DisjointSets)
 
 	//! Resets the DisjointSets structure to be empty, also changing the expected number of elements.
 	void init(int maxNumberOfElements) {

--- a/include/ogdf/basic/Graph_d.h
+++ b/include/ogdf/basic/Graph_d.h
@@ -666,6 +666,7 @@ public:
 };
 
 #define OGDF_DECL_REG_ARRAY_TYPE(v, c) GraphRegisteredArray<NodeElement, v, c>
+//! RegisteredArray for labeling the \ref node "nodes" in a Graph with an arbitrary \p Value.
 OGDF_DECL_REG_ARRAY(NodeArray)
 #undef OGDF_DECL_REG_ARRAY_TYPE
 
@@ -706,10 +707,12 @@ public:
 };
 
 #define OGDF_DECL_REG_ARRAY_TYPE(v, c) EdgeArrayBase<v, c>
+//! RegisteredArray for labeling the \ref edge "edges" in a Graph with an arbitrary \p Value.
 OGDF_DECL_REG_ARRAY(EdgeArray)
 #undef OGDF_DECL_REG_ARRAY_TYPE
 
 #define OGDF_DECL_REG_ARRAY_TYPE(v, c) GraphRegisteredArray<AdjElement, v, c, GraphAdjRegistry>
+//! RegisteredArray for labeling the \ref adjEntry "adjEntries" in a Graph with an arbitrary \p Value.
 OGDF_DECL_REG_ARRAY(AdjEntryArray)
 #undef OGDF_DECL_REG_ARRAY_TYPE
 
@@ -908,7 +911,7 @@ public:
 	 * This is in particular important when dealing with embedded graphs.
 	 *
 	 * @param copy is the graph that will be copied.
-	 * @sa insert(...)
+	 * @sa insert()
 	 */
 	OGDF_COPY_CONSTR(Graph);
 
@@ -920,7 +923,7 @@ public:
 	 *
 	 * @param copy is the graph to be copied.
 	 * @return this graph.
-	 * @sa insert(...)
+	 * @sa insert()
 	 */
 	OGDF_COPY_OP(Graph);
 

--- a/include/ogdf/basic/Graph_d.h
+++ b/include/ogdf/basic/Graph_d.h
@@ -908,11 +908,29 @@ public:
 	 * This is in particular important when dealing with embedded graphs.
 	 *
 	 * @param G is the graph that will be copied.
+	 * @sa insert(...)
 	 */
 	Graph(const Graph& G);
 
 	//! Destructor.
 	virtual ~Graph();
+
+	//! Overwrites this graph to be a copy of \p G.
+	/**
+	 * The assignment operator assures that the adjacency lists of nodes in the
+	 * constructed graph are in the same order as the adjacency lists in \p G.
+	 * This is in particular important when dealing with embedded graphs.
+	 *
+	 * @param G is the graph to be copied.
+	 * @return this graph.
+	 * @sa insert(...)
+	 */
+	Graph& operator=(const Graph& G);
+
+	Graph(Graph&& G) = delete;
+	Graph& operator=(Graph&& G) = delete;
+
+	OGDF_MALLOC_NEW_DELETE
 
 	/**
 	 * @name Access methods
@@ -1614,24 +1632,6 @@ public:
 
 	void resetNodeIdCount(int maxId);
 
-
-	//! @}
-	/**
-	 * @name Operators
-	 */
-	//! @{
-	//! Assignment operator.
-	/**
-	 * The assignment operator assures that the adjacency lists of nodes in the
-	 * constructed graph are in the same order as the adjacency lists in \p G.
-	 * This is in particular important when dealing with embedded graphs.
-	 *
-	 * @param G is the graph to be copied.
-	 * @return this graph.
-	 */
-	Graph& operator=(const Graph& G);
-
-	OGDF_MALLOC_NEW_DELETE
 
 	//! @}
 	/**

--- a/include/ogdf/basic/Graph_d.h
+++ b/include/ogdf/basic/Graph_d.h
@@ -907,13 +907,10 @@ public:
 	 * constructed graph are in the same order as the adjacency lists in \p G.
 	 * This is in particular important when dealing with embedded graphs.
 	 *
-	 * @param G is the graph that will be copied.
+	 * @param copy is the graph that will be copied.
 	 * @sa insert(...)
 	 */
-	Graph(const Graph& G);
-
-	//! Destructor.
-	virtual ~Graph();
+	OGDF_COPY_CONSTR(Graph);
 
 	//! Overwrites this graph to be a copy of \p G.
 	/**
@@ -921,14 +918,16 @@ public:
 	 * constructed graph are in the same order as the adjacency lists in \p G.
 	 * This is in particular important when dealing with embedded graphs.
 	 *
-	 * @param G is the graph to be copied.
+	 * @param copy is the graph to be copied.
 	 * @return this graph.
 	 * @sa insert(...)
 	 */
-	Graph& operator=(const Graph& G);
+	OGDF_COPY_OP(Graph);
 
-	Graph(Graph&& G) = delete;
-	Graph& operator=(Graph&& G) = delete;
+	OGDF_NO_MOVE(Graph);
+
+	//! Destructor.
+	virtual ~Graph();
 
 	OGDF_MALLOC_NEW_DELETE
 

--- a/include/ogdf/basic/Observer.h
+++ b/include/ogdf/basic/Observer.h
@@ -94,7 +94,7 @@ private:
 
 /**
  * Base class for an observable object that can be tracked by multiple Observer objects.
- * Will be notified its observers when it is destructed and can be subclassed to provide further callbacks.
+ * Will notify its observers when it is destructed and can be subclassed to provide further callbacks.
  * For compatibility with MSVC, the Observer subclass has to be defined before the Observable subclass.
  *
  * @tparam TObserved The subclass of Observable that will be observed.

--- a/include/ogdf/basic/PQTree.h
+++ b/include/ogdf/basic/PQTree.h
@@ -608,7 +608,7 @@ protected:
 	 * and can only be accessed by inheritance.
 	 *
 	 * <b>This function does not check if \p parent is the parent node of
-	 * \p child</b>. This has to be guaranteed by the user. The reason for
+	 * \p child. </b> This has to be guaranteed by the user. The reason for
 	 * this riscfull approach lies in the details of the powerful data structure
 	 * PQ-tree. In order to reach linear runtime, the internal children
 	 * of a Q-node normally do not have valid parent pointers. So forcing

--- a/include/ogdf/basic/RegisteredArray.h
+++ b/include/ogdf/basic/RegisteredArray.h
@@ -671,6 +671,8 @@ protected:
 	}
 };
 
+class Graph;
+
 //! Dynamic arrays indexed with arbitrary keys.
 /**
  * Registered arrays provide an efficient, constant-time mapping from indexed keys of a \a Registry to elements of
@@ -779,6 +781,10 @@ class RegisteredArray
 			  RegisteredArrayWithoutDefault<Registry, Value>>::type {
 	using RA = typename std::conditional<WithDefault, RegisteredArrayWithDefault<Registry, Value>,
 			RegisteredArrayWithoutDefault<Registry, Value>>::type;
+
+	static_assert(!std::is_base_of_v<ogdf::Graph, Value>,
+			"XYZArray<Graph> is invalid, use XYZArrayP<Graph> or "
+			"XYZArray<unique_ptr<Graph>, false> instead.");
 
 	static inline const Registry* cast(const Base* base) {
 		if (base != nullptr) {

--- a/include/ogdf/basic/RegisteredArray.h
+++ b/include/ogdf/basic/RegisteredArray.h
@@ -919,8 +919,14 @@ public:
 };
 }
 
-#define OGDF_DECL_REG_ARRAY(NAME)                              \
-	template<typename Value, bool WithDefault = true>          \
-	using NAME = OGDF_DECL_REG_ARRAY_TYPE(Value, WithDefault); \
-	template<typename Value>                                   \
+/* The following macro will be expanded in the docs, see doc/ogdf-doxygen.cfg:EXPAND_AS_DEFINED */
+
+#define OGDF_DECL_REG_ARRAY(NAME)                                  \
+	template<typename Value, bool WithDefault = true>              \
+	using NAME = OGDF_DECL_REG_ARRAY_TYPE(Value, WithDefault);     \
+	/*! Shorthand for \ref NAME storing std::unique_ptr<Value>. \n
+	    You may need to be explicitly delete the copy constructor
+	    of classes containing a member of this type for MSVC<=16
+	    (e.g. using OGDF_NO_COPY(MyClass)). */                     \
+	template<typename Value>                                       \
 	using NAME##P = NAME<std::unique_ptr<Value>, false>;

--- a/include/ogdf/basic/RegisteredArray.h
+++ b/include/ogdf/basic/RegisteredArray.h
@@ -615,7 +615,7 @@ class RegisteredArrayWithDefault : public RegisteredArrayWithoutDefault<Registry
 	static_assert(std::is_copy_constructible_v<Value>,
 			"This RegisteredArrayWithDefault<Value> instantiation (e.g. NodeArray<Graph>) is "
 			"invalid because Value is not copy-constructible! "
-			"Use NodeArrayP<Graph> or NodeArray<unique_ptr<Graph>, false> instead.");
+			"Use, e.g., NodeArrayP<Graph> or NodeArray<unique_ptr<Graph>, false> instead.");
 
 public:
 	//! Creates a new registered array associated with no registry and a default-constructed default value.
@@ -925,7 +925,7 @@ public:
 	template<typename Value, bool WithDefault = true>              \
 	using NAME = OGDF_DECL_REG_ARRAY_TYPE(Value, WithDefault);     \
 	/*! Shorthand for \ref NAME storing std::unique_ptr<Value>. \n
-	    You may need to be explicitly delete the copy constructor
+	    You may need to explicitly delete the copy constructor
 	    of classes containing a member of this type for MSVC<=16
 	    (e.g. using OGDF_NO_COPY(MyClass)). */ \
 	template<typename Value>                                       \

--- a/include/ogdf/basic/RegisteredArray.h
+++ b/include/ogdf/basic/RegisteredArray.h
@@ -927,6 +927,6 @@ public:
 	/*! Shorthand for \ref NAME storing std::unique_ptr<Value>. \n
 	    You may need to be explicitly delete the copy constructor
 	    of classes containing a member of this type for MSVC<=16
-	    (e.g. using OGDF_NO_COPY(MyClass)). */                     \
+	    (e.g. using OGDF_NO_COPY(MyClass)). */ \
 	template<typename Value>                                       \
 	using NAME##P = NAME<std::unique_ptr<Value>, false>;

--- a/include/ogdf/basic/RegisteredArray.h
+++ b/include/ogdf/basic/RegisteredArray.h
@@ -612,6 +612,11 @@ class RegisteredArrayWithDefault : public RegisteredArrayWithoutDefault<Registry
 	using RA = RegisteredArrayWithoutDefault<Registry, Value>;
 	Value m_default;
 
+	static_assert(std::is_copy_constructible_v<Value>,
+			"This RegisteredArrayWithDefault<Value> instantiation (e.g. NodeArray<Graph>) is "
+			"invalid because Value is not copy-constructible! "
+			"Use NodeArrayP<Graph> or NodeArray<unique_ptr<Graph>, false> instead.");
+
 public:
 	//! Creates a new registered array associated with no registry and a default-constructed default value.
 	explicit RegisteredArrayWithDefault() : RA(), m_default() {};
@@ -670,8 +675,6 @@ protected:
 		}
 	}
 };
-
-class Graph;
 
 //! Dynamic arrays indexed with arbitrary keys.
 /**
@@ -781,10 +784,6 @@ class RegisteredArray
 			  RegisteredArrayWithoutDefault<Registry, Value>>::type {
 	using RA = typename std::conditional<WithDefault, RegisteredArrayWithDefault<Registry, Value>,
 			RegisteredArrayWithoutDefault<Registry, Value>>::type;
-
-	static_assert(!std::is_base_of_v<ogdf::Graph, Value>,
-			"XYZArray<Graph> is invalid, use XYZArrayP<Graph> or "
-			"XYZArray<unique_ptr<Graph>, false> instead.");
 
 	static inline const Registry* cast(const Base* base) {
 		if (base != nullptr) {

--- a/include/ogdf/basic/internal/copy_move.h
+++ b/include/ogdf/basic/internal/copy_move.h
@@ -71,20 +71,20 @@
  *
  * See https://stackoverflow.com/a/3279550 for more details on this idiom.
  */
-#define OGDF_COPY_MOVE_BY_SWAP(cls) \
+#define OGDF_COPY_MOVE_BY_SWAP(cls)                       \
 	/*! Assign this cls to be a copy of \p copy_by_value.
 	    Internally, this will use the copy constructor to create a temporary copy and then swap
 	    this object instance with the temporary copy using via a std::swap implementation.
 	    See https://stackoverflow.com/a/3279550 for more details on this idiom. */ \
-	cls& operator=(cls copy_by_value) { \
-		using std::swap;                \
-		swap(*this, copy_by_value);     \
-	}                                   \
-	OGDF_MOVE_CONSTR(cls) {             \
-		using std::swap;                \
-		swap(*this, move);              \
-	}                                   \
-	OGDF_MOVE_OP(cls) {                 \
-		using std::swap;                \
-		swap(*this, move);              \
+	cls& operator=(cls copy_by_value) {                   \
+		using std::swap;                                  \
+		swap(*this, copy_by_value);                       \
+	}                                                     \
+	OGDF_MOVE_CONSTR(cls) {                               \
+		using std::swap;                                  \
+		swap(*this, move);                                \
+	}                                                     \
+	OGDF_MOVE_OP(cls) {                                   \
+		using std::swap;                                  \
+		swap(*this, move);                                \
 	}

--- a/include/ogdf/basic/internal/copy_move.h
+++ b/include/ogdf/basic/internal/copy_move.h
@@ -31,6 +31,8 @@
 
 #pragma once
 
+/* This needs to be synchronized with doc/ogdf-doxygen.cfg:EXPAND_AS_DEFINED */
+
 //! Explicitly disables (deletes) copy construction and assignment for class \p cls.
 #define OGDF_NO_COPY(cls)          \
 	cls(const cls& copy) = delete; \
@@ -69,7 +71,11 @@
  *
  * See https://stackoverflow.com/a/3279550 for more details on this idiom.
  */
-#define OGDF_COPY_MOVE_BY_SWAP(cls)     \
+#define OGDF_COPY_MOVE_BY_SWAP(cls) \
+	/*! Assign this cls to be a copy of \p copy_by_value.
+	    Internally, this will use the copy constructor to create a temporary copy and then swap
+	    this object instance with the temporary copy using via a std::swap implementation.
+	    See https://stackoverflow.com/a/3279550 for more details on this idiom. */ \
 	cls& operator=(cls copy_by_value) { \
 		using std::swap;                \
 		swap(*this, copy_by_value);     \

--- a/include/ogdf/basic/internal/copy_move.h
+++ b/include/ogdf/basic/internal/copy_move.h
@@ -1,0 +1,84 @@
+/** \file
+ * \brief Utility macros for declaring copy and move constructors and assignment operations.
+ *
+ * \author Simon D. Fink
+ *
+ * \par License:
+ * This file is part of the Open Graph Drawing Framework (OGDF).
+ *
+ * \par
+ * Copyright (C)<br>
+ * See README.md in the OGDF root directory for details.
+ *
+ * \par
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * Version 2 or 3 as published by the Free Software Foundation;
+ * see the file LICENSE.txt included in the packaging of this file
+ * for details.
+ *
+ * \par
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * \par
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, see
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#pragma once
+
+//! Explicitly disables (deletes) copy construction and assignment for class \p cls.
+#define OGDF_NO_COPY(cls)          \
+	cls(const cls& copy) = delete; \
+	cls& operator=(const cls& copy) = delete;
+
+//! Explicitly disables (deletes) move construction and assignment for class \p cls.
+#define OGDF_NO_MOVE(cls)     \
+	cls(cls&& move) = delete; \
+	cls& operator=(cls&& move) = delete;
+
+//! Explicitly provides default copy construction and assignment for class \p cls.
+#define OGDF_DEFAULT_COPY(cls)      \
+	cls(const cls& copy) = default; \
+	cls& operator=(const cls& copy) = default;
+
+//! Explicitly provides default move construction and assignment for class \p cls.
+#define OGDF_DEFAULT_MOVE(cls) \
+	cls(cls&& move) = default; \
+	cls& operator=(cls&& move) = default;
+
+//! Declares the copy constructor for class \p cls.
+#define OGDF_COPY_CONSTR(cls) cls(const cls& copy)
+//! Declares the copy assignment operation for class \p cls.
+#define OGDF_COPY_OP(cls) cls& operator=(const cls& copy)
+//! Declares the move constructor for class \p cls.
+#define OGDF_MOVE_CONSTR(cls) cls(cls&& move) noexcept : cls()
+//! Declares the move assignment operation for class \p cls.
+#define OGDF_MOVE_OP(cls) cls& operator=(cls&& move) noexcept
+//! Declares the swap function for class \p cls.
+#define OGDF_SWAP_OP(cls) friend void swap(cls& first, cls& second) noexcept
+
+//! Provide move construct/assign and copy assign given there is a copy constructor and swap.
+/**
+ * Only requires custom implementations of OGDF_COPY_CONSTR and OGDF_SWAP_OP
+ * and automatically provides OGDF_COPY_OP, OGDF_MOVE_CONSTR, and OGDF_MOVE_OP.
+ *
+ * See https://stackoverflow.com/a/3279550 for more details on this idiom.
+ */
+#define OGDF_COPY_MOVE_BY_SWAP(cls)     \
+	cls& operator=(cls copy_by_value) { \
+		using std::swap;                \
+		swap(*this, copy_by_value);     \
+	}                                   \
+	OGDF_MOVE_CONSTR(cls) {             \
+		using std::swap;                \
+		swap(*this, move);              \
+	}                                   \
+	OGDF_MOVE_OP(cls) {                 \
+		using std::swap;                \
+		swap(*this, move);              \
+	}

--- a/include/ogdf/cluster/ClusterGraph.h
+++ b/include/ogdf/cluster/ClusterGraph.h
@@ -927,7 +927,7 @@ private:
 	void postOrder(cluster c, SListPure<cluster>& S) const;
 };
 
-//! RegisteredArray for clusters of a cluster graph.
+//! RegisteredArray for labeling the \ref cluster "clusters" of a ClusterGraph.
 template<class Value, bool WithDefault>
 class ClusterArrayBase : public RegisteredArray<ClusterGraph, Value, WithDefault> {
 	using RA = RegisteredArray<ClusterGraph, Value, WithDefault>;

--- a/include/ogdf/graphalg/MinSteinerTreeShore.h
+++ b/include/ogdf/graphalg/MinSteinerTreeShore.h
@@ -271,7 +271,7 @@ T MinSteinerTreeShore<T>::computeSteinerTree(const EdgeWeightedGraph<T>& G,
 	m_originalTerminals = &terminals;
 
 	m_upperBound = MAX_WEIGHT;
-	m_graph = Graph();
+	m_graph.clear();
 	m_mapping.init(m_graph);
 	m_terminals.reset(new NodeSet<>(m_graph));
 	int nodeCount = m_originalGraph->numberOfNodes();

--- a/include/ogdf/hypergraph/Hypergraph.h
+++ b/include/ogdf/hypergraph/Hypergraph.h
@@ -386,10 +386,12 @@ public:
 };
 
 #define OGDF_DECL_REG_ARRAY_TYPE(v, c) HypergraphRegisteredArray<HypernodeElement, v, c>
+//! Array for labeling the \ref hypernode "hypernodes" in a Hypergraph with an arbitrary \p Value.
 OGDF_DECL_REG_ARRAY(HypernodeArray)
 #undef OGDF_DECL_REG_ARRAY_TYPE
 
 #define OGDF_DECL_REG_ARRAY_TYPE(v, c) HypergraphRegisteredArray<HyperedgeElement, v, c>
+//! Array for labeling the \ref hyperedge "hyperedges" in a Hypergraph with an arbitrary \p Value.
 OGDF_DECL_REG_ARRAY(HyperedgeArray)
 #undef OGDF_DECL_REG_ARRAY_TYPE
 

--- a/include/ogdf/planarity/EmbedderMaxFace.h
+++ b/include/ogdf/planarity/EmbedderMaxFace.h
@@ -288,7 +288,7 @@ protected:
 	virtual void embedBlock(const node& bT, const node& cT, ListIterator<adjEntry>& after);
 
 	/** all blocks */
-	NodeArray<Graph> blockG;
+	NodeArrayP<Graph> blockG;
 
 	/** a mapping of nodes in the auxiliaryGraph of the BC-tree to blockG */
 	NodeArray<NodeArray<node>> nH_to_nBlockEmbedding;

--- a/include/ogdf/planarity/EmbedderMaxFace.h
+++ b/include/ogdf/planarity/EmbedderMaxFace.h
@@ -53,6 +53,11 @@ public:
 	 */
 	virtual void doCall(Graph& G, adjEntry& adjExternal) override;
 
+	EmbedderMaxFace() = default;
+
+	/* needs to be deleted explicitly for MSVC<=16 and classes containing a NodeArrayP */
+	OGDF_NO_COPY(EmbedderMaxFace)
+
 protected:
 	//! Calls \p fun for every ingoing edge (\a w,\p v).
 	void forEachIngoingNeighbor(node v, std::function<void(node)> fun) {

--- a/include/ogdf/planarity/EmbedderMinDepth.h
+++ b/include/ogdf/planarity/EmbedderMinDepth.h
@@ -54,6 +54,11 @@ public:
 	 */
 	virtual void doCall(Graph& G, adjEntry& adjExternal) override;
 
+	EmbedderMinDepth() = default;
+
+	/* needs to be deleted explicitly for MSVC<=16 and classes containing a NodeArrayP */
+	OGDF_NO_COPY(EmbedderMinDepth)
+
 private:
 	/**
 	 * \brief Computes recursively the block graph for every block.

--- a/include/ogdf/planarity/EmbedderMinDepth.h
+++ b/include/ogdf/planarity/EmbedderMinDepth.h
@@ -110,7 +110,7 @@ private:
 
 private:
 	/** all blocks */
-	NodeArray<Graph> blockG;
+	NodeArrayP<Graph> blockG;
 
 	/** a mapping of nodes in the auxiliaryGraph of the BC-tree to blockG */
 	NodeArray<NodeArray<node>> nH_to_nBlockEmbedding;

--- a/include/ogdf/planarity/EmbedderMinDepthPiTa.h
+++ b/include/ogdf/planarity/EmbedderMinDepthPiTa.h
@@ -47,6 +47,9 @@ public:
 	//constructor
 	EmbedderMinDepthPiTa() : m_useExtendedDepthDefinition(true), pm_blockCutfaceTree(nullptr) { }
 
+	/* needs to be deleted explicitly for MSVC<=16 and classes containing a NodeArrayP */
+	OGDF_NO_COPY(EmbedderMinDepthPiTa)
+
 	/**
 	 * \brief Computes an embedding of \p G.
 	 *

--- a/include/ogdf/planarity/EmbedderMinDepthPiTa.h
+++ b/include/ogdf/planarity/EmbedderMinDepthPiTa.h
@@ -186,7 +186,7 @@ private:
 	NodeArray<node> npBCTree_to_nBCTree;
 
 	/** all blocks */
-	NodeArray<Graph> blockG;
+	NodeArrayP<Graph> blockG;
 
 	/** a mapping of nodes in the auxiliaryGraph of the BC-tree to blockG */
 	NodeArray<NodeArray<node>> nH_to_nBlockEmbedding;
@@ -288,7 +288,7 @@ private:
 	 * given a node nT (cutvertex or block), G_nT is the subgraph of G
 	 * associated with the subtree of the BC-tree T rooted at nT
 	 */
-	NodeArray<Graph> G_nT;
+	NodeArrayP<Graph> G_nT;
 
 	/** a mapping of nodes in G_nT to nodes in G */
 	NodeArray<NodeArray<node>> nG_nT_to_nPG;

--- a/include/ogdf/simultaneous/SimDraw.h
+++ b/include/ogdf/simultaneous/SimDraw.h
@@ -154,7 +154,7 @@ public:
 	void writeGML(const char* fileName) const;
 
 	//! returns graph consisting of all edges and nodes from SubGraph \p i
-	const Graph getBasicGraph(int i) const;
+	std::unique_ptr<GraphCopy> getBasicGraph(int i) const;
 	//! returns graphattributes associated with basic graph \p i
 	/**
 	 * Supported attributes are:

--- a/include/ogdf/upward/SubgraphUpwardPlanarizer.h
+++ b/include/ogdf/upward/SubgraphUpwardPlanarizer.h
@@ -100,12 +100,12 @@ protected:
 	int m_runs;
 
 private:
-	void constructComponentGraphs(BCTree& BC, NodeArray<GraphCopy>& biComps);
+	void constructComponentGraphs(BCTree& BC, NodeArrayP<GraphCopy>& biComps);
 
 	//! traversion the BTree and merge the component to a common graph
-	void dfsMerge(const GraphCopy& GC, BCTree& BC, NodeArray<GraphCopy>& biComps,
-			NodeArray<UpwardPlanRep>& uprs, UpwardPlanRep& UPR_res, node parent_BC, node current_BC,
-			NodeArray<bool>& nodesDone);
+	void dfsMerge(const GraphCopy& GC, BCTree& BC, NodeArrayP<GraphCopy>& biComps,
+			NodeArrayP<UpwardPlanRep>& uprs, UpwardPlanRep& UPR_res, node parent_BC,
+			node current_BC, NodeArray<bool>& nodesDone);
 
 
 	//! add UPR to UPR_res.

--- a/src/ogdf/planarity/EmbedderMaxFaceLayers.cpp
+++ b/src/ogdf/planarity/EmbedderMaxFaceLayers.cpp
@@ -42,9 +42,9 @@ void EmbedderMaxFaceLayers::embedBlock(const node& bT, const node& cT, ListItera
 		cH = pBCTree->cutVertex(cT, bT);
 	}
 
-	EdgeArray<int> edgeLength(blockG[bT], 1);
+	EdgeArray<int> edgeLength(*blockG[bT], 1);
 
-	internalEmbedBlock(blockG[bT], nodeLength[bT], edgeLength, nBlockEmbedding_to_nH[bT],
+	internalEmbedBlock(*blockG[bT], nodeLength[bT], edgeLength, nBlockEmbedding_to_nH[bT],
 			eBlockEmbedding_to_eH[bT], cH == nullptr ? nullptr : nH_to_nBlockEmbedding[bT][cH], cT,
 			after);
 }

--- a/src/ogdf/simultaneous/SimDraw.cpp
+++ b/src/ogdf/simultaneous/SimDraw.cpp
@@ -134,25 +134,25 @@ int SimDraw::numberOfBasicGraphs() const {
 
 // returns Graph consisting of all edges and nodes from SubGraph i
 //
-const Graph SimDraw::getBasicGraph(int i) const {
+std::unique_ptr<GraphCopy> SimDraw::getBasicGraph(int i) const {
 	//get a copy of m_G
-	GraphCopy GC(m_G);
+	auto GC = std::make_unique<GraphCopy>(m_G);
 
 	//delete all edges that are not in SubGraph i
 	List<edge> LE;
-	GC.allEdges(LE);
+	GC->allEdges(LE);
 	for (edge e : LE) {
-		if (!(m_GA.inSubGraph(GC.original(e), i))) {
-			GC.delEdge(e);
+		if (!(m_GA.inSubGraph(GC->original(e), i))) {
+			GC->delEdge(e);
 		}
 	}
 
 	//delete all Nodes where degree = 0
 	List<node> LN;
-	GC.allNodes(LN);
+	GC->allNodes(LN);
 	for (node v : LN) {
 		if (v->degree() == 0) {
-			GC.delNode(v);
+			GC->delNode(v);
 		}
 	}
 

--- a/test/src/basic/disjointsets.cpp
+++ b/test/src/basic/disjointsets.cpp
@@ -150,6 +150,36 @@ static void registerTestSuite(const string typeName) {
 			AssertThat(disjointSets->getNumberOfSets(), Equals(42 - successfullUnionCounter));
 		});
 
+		it("supports copy and swap", [&]() {
+			DisjointSetsClass empty_copy(*disjointSets);
+
+			disjointSets->quickUnion(sets[1], sets[2]);
+			disjointSets->quickUnion(sets[2], sets[3]);
+			disjointSets->quickUnion(sets[3], sets[4]); // 1,2,3,4
+
+			disjointSets->quickUnion(sets[8], sets[9]);
+			disjointSets->quickUnion(sets[7], sets[8]);
+			disjointSets->quickUnion(sets[6], sets[7]); // 6,7,8,9
+
+			disjointSets->quickUnion(sets[10], sets[11]);
+			disjointSets->quickUnion(sets[12], sets[13]);
+			disjointSets->quickUnion(sets[10], sets[13]); // 10,11,12,13
+
+			DisjointSetsClass exact_copy(*disjointSets);
+
+			for (int i = 0; i < disjointSets->getNumberOfElements(); i++) {
+				AssertThat(empty_copy.find(sets[i]), Equals(sets[i]));
+				AssertThat(exact_copy.find(sets[i]), Equals(disjointSets->find(sets[i])));
+			}
+			swap(empty_copy, exact_copy);
+			for (int i = 0; i < disjointSets->getNumberOfElements(); i++) {
+				AssertThat(exact_copy.find(sets[i]), Equals(sets[i]));
+				AssertThat(empty_copy.find(sets[i]), Equals(disjointSets->find(sets[i])));
+			}
+			AssertThat(disjointSets->find(sets[0]), !Equals(disjointSets->find(sets[1])));
+			AssertThat(disjointSets->find(sets[1]), Equals(disjointSets->find(sets[2])));
+		});
+
 #ifdef OGDF_USE_ASSERT_EXCEPTIONS
 		it("throws an exception, if the user tries to link two non-maximal disjoint sets", [&]() {
 			disjointSets->link(sets[3], sets[4]);

--- a/test/src/graphalg/planar-separator.cpp
+++ b/test/src/graphalg/planar-separator.cpp
@@ -48,10 +48,10 @@
  * @param n number of nodes of the graph
  * @return the graph
  */
-Graph getRandomPlanarGraph(int n) {
-	Graph graph;
+std::unique_ptr<Graph> getRandomPlanarGraph(int n) {
+	auto graph = std::make_unique<Graph>();
 	int edges = randomNumber(n, 3 * n - 6);
-	randomPlanarConnectedGraph(graph, n, edges);
+	randomPlanarConnectedGraph(*graph, n, edges);
 	return graph;
 }
 
@@ -265,8 +265,8 @@ static void describeRandomInstances(PlanarSeparatorModule& sep) {
 	for (int i = 0; i < numInstances; i++) {
 		it("works on a random planar graph number " + std::to_string(i), [&] {
 			setSeed(i);
-			Graph G = getRandomPlanarGraph(size);
-			testGraph(G, sep);
+			auto G = getRandomPlanarGraph(size);
+			testGraph(*G, sep);
 		});
 	}
 }


### PR DESCRIPTION
This rightfully deletes the copy constructor and assignment operators of `Graph` (and actually all `Observable`s and `Observer`s), strictly requiring the use of `NodeArrayP<Graph>` instead of the somewhat broken `NodeArray<Graph>` (which only compiled because the auto-generated move support of `Graph` ignored that a lot of stuff would need updating and is otherwise broken at runtime). It also adds a useful warning to `NodeArray` towards this as well as Macros which help with declaring copy and move support for classes. Note: it seems that on MSVC Versions <17 (we use 16), classes with `NodeArrayP` members need to be explicitly (and rightfully) marked as non-copyable, all other compilers pick this up automatically.