### PR TITLE
CI and Triconnectivity fixes

### DIFF
--- a/.github/prune-all-caches.sh
+++ b/.github/prune-all-caches.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+KEYS=(
+  "ccache-self-sufficiency"
+  "ccache-coverage"
+  "clang-tidy-cache"
+  "ccache-static-analysis"
+  "ccache-build-linux-gcc:9-debug"
+  "ccache-build-linux-gcc:9-release"
+  "ccache-build-linux-gcc:13-debug"
+  "ccache-build-linux-gcc:13-release"
+  "ccache-build-linux-clang:15-debug"
+  "ccache-build-linux-clang:15-release"
+  "ccache-build-macos-13-debug"
+  "ccache-build-macos-13-release"
+  "ccache-build-macos-14-debug"
+  "ccache-build-macos-14-release"
+  "ccache-build-windows-debug"
+  "ccache-build-windows-release"
+)
+
+cd $(dirname "$0")
+
+for ref in $(gh cache list --json ref --jq ".[].ref" | sort | uniq); do
+  echo "Pruning ref $ref..."
+  for key in ${KEYS[@]}; do
+    ./prune-caches.sh "$key" "$ref"
+  done
+done

--- a/.github/prune-caches.sh
+++ b/.github/prune-caches.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# use CLI args or default from env
+# use CLI args or default from env / working dir
 KEY="$1"
-REF="${2:-${WORKFLOW_REF:-${GITHUB_REF:-refs/heads/master}}}"
-REPO="${3:-${GITHUB_REPOSITORY:-ogdf/ogdf}}"
+REF="${2:-${WORKFLOW_REF:-${GITHUB_REF:-$(git symbolic-ref HEAD)}}}"
+REPO="${3:-${GITHUB_REPOSITORY:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}}"
 
 if [[ -z "$KEY" ]]; then
     echo "Need to specify a cache key as first arg!"

--- a/.github/prune-caches.sh
+++ b/.github/prune-caches.sh
@@ -1,13 +1,23 @@
 #!/bin/bash
 
-caches=$(gh cache list --key "$1" --ref "$GITHUB_REF" --repo "$GITHUB_REPOSITORY" --sort created_at --order desc --json id --jq ".[].id")
+# use CLI args or default from env
+KEY="$1"
+REF="${2:-${WORKFLOW_REF:-${GITHUB_REF:-refs/heads/master}}}"
+REPO="${3:-${GITHUB_REPOSITORY:-ogdf/ogdf}}"
+
+if [[ -z "$KEY" ]]; then
+    echo "Need to specify a cache key as first arg!"
+    exit 1
+fi
+
+caches=$(gh cache list --key "$KEY" --ref "$REF" --repo "$REPO" --sort created_at --order desc --json id --jq ".[].id")
 count=$(echo "$caches" | grep -v ^$ | wc -l)
 if [ "$count" -eq 0 ]; then
-    echo "Found no caches for $GITHUB_REPOSITORY:$GITHUB_REF:$1 to prune."
+    echo "Found no caches for $REPO:$REF:$KEY to prune."
 elif [ "$count" -eq 1 ]; then
-    echo "Found 1 cache entry ($caches) for $GITHUB_REPOSITORY:$GITHUB_REF:$1, keeping it."
+    echo "Found 1 cache entry ($caches) for $REPO:$REF:$KEY, keeping it."
 else
-    echo "Found $count cache entries for $GITHUB_REPOSITORY:$GITHUB_REF:$1:"
+    echo "Found $count cache entries for $REPO:$REF:$KEY:"
     echo $caches
     echo "Only retaining the latest (first) one."
     echo "$caches" | tail -n +2 | xargs -L 1 -P 4 --no-run-if-empty --verbose -exec gh cache delete

--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -294,11 +294,12 @@ jobs:
           system_profiler system_profiler SPSoftwareDataType SPHardwareDataType
           echo "Hard limits"
           ulimit -Ha
+          echo
           echo "Soft limits"
           ulimit -Sa
       - name: Test ${{ matrix.mode }} build and run
         run: |
-          ulimit -Ss 16384 # increase stack limit for test-planarization
+          ulimit -Ss 65532 # increase stack limit for test-planarization
           util/test_build_and_run.sh \
             static \
             ${{ matrix.mode }} \

--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -134,7 +134,8 @@ jobs:
           cat static-analysis/clang-tidy.txt | python3 -m clang_tidy_converter sq > static-analysis/clang-tidy.json
           clang-tidy-cache --show-stats
           du -sh $CTCACHE_DIR
-          find .ctcache -mtime +7 -exec rm -rv \{} \;
+          find .ctcache -mindepth 1 -type f -atime +7 -delete
+          find .ctcache -mindepth 1 -type d -empty -delete
           du -sh $CTCACHE_DIR
         shell: bash
       - name: Report unused files

--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -242,6 +242,7 @@ jobs:
           lscpu
           echo "Hard limits"
           ulimit -Ha
+          echo
           echo "Soft limits"
           ulimit -Sa
       - name: Test ${{ matrix.mode }} build with ${{ matrix.compiler }} and run
@@ -299,7 +300,6 @@ jobs:
           ulimit -Sa
       - name: Test ${{ matrix.mode }} build and run
         run: |
-          ulimit -Ss 65532 # increase stack limit for test-planarization
           util/test_build_and_run.sh \
             static \
             ${{ matrix.mode }} \

--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -211,7 +211,7 @@ jobs:
   build-linux:
     name: "Test ${{ matrix.mode }} build on Linux with ${{ matrix.compiler }}"
     strategy:
-      matrix: # when updating compilers, also update the prune-caches job
+      matrix: # when updating compilers, also update the prune-all-caches script
         mode: [ debug, release ]
         compiler: [ 'gcc:9', 'gcc:13', 'clang:15' ]
     runs-on: ubuntu-latest
@@ -275,7 +275,7 @@ jobs:
   build-macos:
     name: "Test ${{ matrix.mode }} build on ${{ matrix.os }}"
     strategy:
-      matrix: # when updating macos versions, also update the prune-caches job
+      matrix: # when updating macos versions, also update the prune-all-caches script
         mode: [ debug, release ]
         os: [ macos-13 ] # latest/14 is with M1, while macos-13 is intel
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/prune-caches.yml
+++ b/.github/workflows/prune-caches.yml
@@ -20,19 +20,4 @@ jobs:
           [${{ github.event.workflow_run.event }}
           ${{ github.event.workflow_run.head_branch }}]](
           ${{ github.event.workflow_run.html_url }})' >> $GITHUB_STEP_SUMMARY
-      - run: .github/prune-caches.sh ccache-self-sufficiency
-      - run: .github/prune-caches.sh ccache-coverage
-      - run: .github/prune-caches.sh clang-tidy-cache
-      - run: .github/prune-caches.sh ccache-static-analysis
-      - run: .github/prune-caches.sh ccache-build-linux-gcc:9-debug
-      - run: .github/prune-caches.sh ccache-build-linux-gcc:9-release
-      - run: .github/prune-caches.sh ccache-build-linux-gcc:13-debug
-      - run: .github/prune-caches.sh ccache-build-linux-gcc:13-release
-      - run: .github/prune-caches.sh ccache-build-linux-clang:15-debug
-      - run: .github/prune-caches.sh ccache-build-linux-clang:15-release
-      - run: .github/prune-caches.sh ccache-build-macos-13-debug
-      - run: .github/prune-caches.sh ccache-build-macos-13-release
-      - run: .github/prune-caches.sh ccache-build-macos-14-debug
-      - run: .github/prune-caches.sh ccache-build-macos-14-release
-      - run: .github/prune-caches.sh ccache-build-windows-debug
-      - run: .github/prune-caches.sh ccache-build-windows-release
+      - run: .github/prune-all-caches.sh

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -82,7 +82,7 @@ jobs:
           git checkout upstream/${{ steps.pr-info.outputs.base-ref }} -- sonar-project.properties
 
       - name: Install sonar-scanner
-        uses: SonarSource/sonarcloud-github-c-cpp@v2
+        uses: SonarSource/sonarcloud-github-c-cpp@v3
         with:
           cache-binaries: false
 

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,4 +1,4 @@
-name: Sonarcloud Scan
+name: SonarCloud Scan
 run-name: "${{ github.event.workflow_run.display_title }} [${{ github.event.workflow_run.event }} ${{ github.event.workflow_run.head_branch }}]"
 
 on:
@@ -8,6 +8,7 @@ on:
 
 jobs:
   sonar:
+    name: SonarCloud Scan
     runs-on: ubuntu-latest
     container: docker.io/ogdf/clang:15
     if: github.event.workflow_run.conclusion == 'success'
@@ -29,12 +30,6 @@ jobs:
 
       - name: "Add workspace as a safe directory in containers"
         run: git config --system --add safe.directory $GITHUB_WORKSPACE
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event.workflow_run.head_repository.full_name }}
-          ref: ${{ github.event.workflow_run.head_branch }}
-          fetch-depth: 0
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
@@ -72,36 +67,40 @@ jobs:
           STRATEGY_CONTEXT: ${{ toJson(strategy) }}
         run: |
           env
-      - name: Checkout PR base branch
+
+      # PR runs are against a synthetic merge commit *ontop* of the to-be-merged branch's head
+      # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+      - name: Checkout repository at PR base branch
         if: github.event.workflow_run.event == 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ steps.pr-info.outputs.pr-number }}/merge
+          fetch-depth: 0
+          path: 'checkout'
+      - name: Checkout repository branch
+        if: github.event.workflow_run.event != 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+          path: 'checkout'
+      - name: Ensure sonar config from master is used
+        shell: bash
         run: |
-          git remote add upstream ${{ github.event.repository.clone_url }}
-          git fetch upstream
-          git checkout -B ${{ steps.pr-info.outputs.base-ref }} upstream/${{ steps.pr-info.outputs.base-ref }}
-          git checkout ${{ github.event.workflow_run.head_branch }}
-          git checkout upstream/${{ steps.pr-info.outputs.base-ref }} -- sonar-project.properties
+          shopt -s dotglob
+          mv checkout/* .
+          rmdir checkout
+          git checkout origin/${{ github.ref_name }} -- sonar-project.properties
+          git status
+          echo
+          ls -al *
 
       - name: Install sonar-scanner
         uses: SonarSource/sonarcloud-github-c-cpp@v3
         with:
           cache-binaries: false
 
-      - name: SonarCloud PR Scan
-        if: github.event.workflow_run.event == 'pull_request'
-        run: >
-          sonar-scanner
-          -Dsonar.links.ci=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
-          -Dsonar.pullrequest.key=${{ steps.pr-info.outputs.pr-number }}
-          -Dsonar.pullrequest.branch=${{ github.event.workflow_run.head_branch }}
-          -Dsonar.pullrequest.base=${{ steps.pr-info.outputs.base-ref }}
-          -Dproject.settings=sonar-project.properties
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: SonarCloud non-PR Scan
-        if: github.event.workflow_run.event != 'pull_request'
+      - name: SonarCloud Scan
         run: >
           sonar-scanner
           -Dsonar.links.ci=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ doxygen.stamp
 *.profdata
 /coverage
 /static-analysis
+/iwyu-stats
 
 # Created by https://www.toptal.com/developers/gitignore/api/c++,c,cmake,ninja,sonarqube,eclipse,visualstudio,xcode,windows,macos,linux
 # Edit at https://www.toptal.com/developers/gitignore?templates=c++,c,cmake,ninja,sonarqube,eclipse,visualstudio,xcode,windows,macos,linux

--- a/include/ogdf/graphalg/Triconnectivity.h
+++ b/include/ogdf/graphalg/Triconnectivity.h
@@ -166,6 +166,8 @@ private:
 
 	//! finding of split components
 	void pathSearch(node v);
+	void afterRecursivePathSearch(const node v, const int vnum, int& outv,
+			const ListIterator<edge> it, const edge e, const node w, int wnum);
 	//! special version for triconnectivity test
 	bool pathSearch(node v, node& s1, node& s2);
 

--- a/include/ogdf/graphalg/Triconnectivity.h
+++ b/include/ogdf/graphalg/Triconnectivity.h
@@ -167,11 +167,17 @@ private:
 	void pathFinder(node v);
 
 	//! finding of split components
-	void pathSearch(node v);
-	void afterRecursivePathSearch(const node v, const int vnum, int& outv,
+	/**
+	 * If fail_fast is true, the search will be aborted after finding the first split pair,
+	 * which will be assigned to s1 and s2. Otherwise, s1 and s2 are unused.
+	 */
+	bool pathSearch(node init_v, bool fail_fast, node& s1, node& s2);
+	//! pathSearch() helper for the non-fail-fast version
+	void afterRecursivePathSearch(const node v, const int vnum, const int outv,
 			const ListIterator<edge> it, const edge e, const node w, int wnum);
-	//! special version for triconnectivity test
-	bool pathSearch(node v, node& s1, node& s2);
+	//! pathSearch() helper for the fail-fast version
+	bool afterRecursivePathSearch(const node v, const int vnum, const int outv, const edge e,
+			const node w, const int wnum, node& s1, node& s2);
 
 	//! merges split-components into triconnected components
 	void assembleTriconnectedComponents();

--- a/include/ogdf/graphalg/Triconnectivity.h
+++ b/include/ogdf/graphalg/Triconnectivity.h
@@ -38,6 +38,8 @@
 #include <ogdf/basic/GraphCopy.h>
 #include <ogdf/basic/NodeArray.h>
 
+#include <ostream>
+
 namespace ogdf {
 
 //! realizes Hopcroft/Tarjan algorithm for finding the triconnected
@@ -102,16 +104,20 @@ public:
 	//! array of components
 	Array<CompStruct> m_component;
 	//! number of components
+	/**
+	 * Note that m_component may have size bigger than m_numComp, in which case all later components should be ignored.
+	 * Additionally, all components before m_numComp that have zero edges shall be ignored.
+	 */
 	int m_numComp;
 
 	/**
-	 * Checks if computed triconnected componets are correct.
+	 * Checks if computed triconnected components are correct.
 	 * \pre checkComp() assumes that the graph is simple
 	 */
-	bool checkComp();
+	bool checkComp() const;
 
 private:
-	bool checkSepPair(edge eVirt);
+	bool checkSepPair(edge eVirt) const;
 
 	//! splits bundles of multi-edges into bonds and creates
 	//! a new virtual edge in GC.
@@ -167,8 +173,8 @@ private:
 	void assembleTriconnectedComponents();
 
 	//! debugging stuff
-	void printOs(edge e);
-	void printStacks();
+	void printOs(edge e) const;
+	void printStacks() const;
 
 	//! returns high(v) value
 	int high(node v) { return (m_HIGHPT[v].empty()) ? 0 : m_HIGHPT[v].front(); }
@@ -214,5 +220,7 @@ private:
 	bool m_newPath; //!< true iff we start a new path
 	bool m_deleteGraph; //!< whether the Graph(Copy) was created by us and should thus be deleted in the destructor
 };
+
+std::ostream& operator<<(std::ostream& os, Triconnectivity::CompType type);
 
 }

--- a/include/ogdf/graphalg/Triconnectivity.h
+++ b/include/ogdf/graphalg/Triconnectivity.h
@@ -119,6 +119,8 @@ public:
 private:
 	bool checkSepPair(edge eVirt) const;
 
+	void clearStructures();
+
 	//! splits bundles of multi-edges into bonds and creates
 	//! a new virtual edge in GC.
 	void splitMultiEdges();

--- a/include/ogdf/graphalg/Triconnectivity.h
+++ b/include/ogdf/graphalg/Triconnectivity.h
@@ -223,6 +223,6 @@ private:
 	bool m_deleteGraph; //!< whether the Graph(Copy) was created by us and should thus be deleted in the destructor
 };
 
-std::ostream& operator<<(std::ostream& os, Triconnectivity::CompType type);
+OGDF_EXPORT std::ostream& operator<<(std::ostream& os, Triconnectivity::CompType type);
 
 }

--- a/src/ogdf/graphalg/Triconnectivity.cpp
+++ b/src/ogdf/graphalg/Triconnectivity.cpp
@@ -35,7 +35,7 @@
 #include <ogdf/basic/simple_graph_alg.h>
 #include <ogdf/graphalg/Triconnectivity.h>
 
-//#define OGDF_TRICONNECTIVITY_OUTPUT
+// #define OGDF_TRICONNECTIVITY_OUTPUT
 
 
 namespace ogdf {
@@ -349,7 +349,7 @@ void Triconnectivity::splitMultiEdges() {
 }
 
 // Checks if computed triconnected components are correct.
-bool Triconnectivity::checkSepPair(edge eVirt) {
+bool Triconnectivity::checkSepPair(edge eVirt) const {
 	GraphCopySimple G(*m_pG);
 
 	G.delNode(G.copy(eVirt->source()));
@@ -358,7 +358,7 @@ bool Triconnectivity::checkSepPair(edge eVirt) {
 	return !isConnected(G);
 }
 
-bool Triconnectivity::checkComp() {
+bool Triconnectivity::checkComp() const {
 	bool ok = true;
 
 	if (!isLoopFree(*m_pG)) {
@@ -393,7 +393,7 @@ bool Triconnectivity::checkComp() {
 	NodeArray<node> map(*m_pG);
 
 	for (int i = 0; i < m_numComp; i++) {
-		CompStruct& C = m_component[i];
+		const CompStruct& C = m_component[i];
 		const List<edge>& L = C.m_edges;
 		if (L.size() == 0) {
 			continue;
@@ -1113,7 +1113,7 @@ bool isTriconnected(const Graph& G, node& s1, node& s2) {
 }
 
 // debugging stuff
-void Triconnectivity::printOs(edge e) {
+void Triconnectivity::printOs(edge e) const {
 #ifdef OGDF_TRICONNECTIVITY_OUTPUT
 	std::cout << " (" << GCoriginal(e->source()) << "," << GCoriginal(e->target()) << ","
 			  << e->index() << ")";
@@ -1123,20 +1123,37 @@ void Triconnectivity::printOs(edge e) {
 #endif
 }
 
-void Triconnectivity::printStacks() {
+void Triconnectivity::printStacks() const {
 #ifdef OGDF_TRICONNECTIVITY_OUTPUT
 	std::cout << "\n\nTSTACK:" << std::endl;
-
 	for (int i = m_top; i >= 0; i--) {
 		std::cout << "(" << m_TSTACK_h[i] << "," << m_TSTACK_a[i] << "," << m_TSTACK_b[i] << ")\n";
 	}
 
 	std::cout << "\nESTACK\n";
-	while (!m_ESTACK.empty()) {
-		printOs(m_ESTACK.popRet());
+	for (int i = m_ESTACK.size()-1; i >= 0; i--) {
+		printOs(m_ESTACK[i]);
 		std::cout << std::endl;
 	}
 #endif
+}
+
+std::ostream& operator<<(std::ostream& os, Triconnectivity::CompType type) {
+	switch (type) {
+	case Triconnectivity::CompType::bond:
+		os << "bond";
+		break;
+	case Triconnectivity::CompType::polygon:
+		os << "polygon";
+		break;
+	case Triconnectivity::CompType::triconnected:
+		os << "triconnected";
+		break;
+	default:
+		os << "???";
+		break;
+	}
+	return os;
 }
 
 }

--- a/src/ogdf/graphalg/Triconnectivity.cpp
+++ b/src/ogdf/graphalg/Triconnectivity.cpp
@@ -167,27 +167,7 @@ Triconnectivity::Triconnectivity(Graph* G)
 	printStacks();
 #endif
 
-	delete[] m_TSTACK_h;
-	delete[] m_TSTACK_a;
-	delete[] m_TSTACK_b;
-
-	// free resources
-	m_NUMBER.init();
-	m_LOWPT1.init();
-	m_LOWPT2.init();
-	m_FATHER.init();
-	m_ND.init();
-	m_TYPE.init();
-	m_A.init();
-	m_NEWNUM.init();
-	m_HIGHPT.init();
-	m_START.init();
-	m_DEGREE.init();
-	m_TREE_ARC.init();
-	m_IN_ADJ.init();
-	m_IN_HIGH.init();
-	m_NODEAT.init();
-	m_ESTACK.clear();
+	clearStructures();
 
 	assembleTriconnectedComponents();
 
@@ -222,6 +202,29 @@ Triconnectivity::Triconnectivity(Graph* G)
 		std::cout << "\n";
 	}
 #endif
+}
+
+void Triconnectivity::clearStructures() {
+	delete[] m_TSTACK_h;
+	delete[] m_TSTACK_a;
+	delete[] m_TSTACK_b;
+
+	// free resources
+	m_NUMBER.init();
+	m_LOWPT1.init();
+	m_LOWPT2.init();
+	m_FATHER.init();
+	m_ND.init();
+	m_TYPE.init();
+	m_A.init();
+	m_NEWNUM.init();
+	m_HIGHPT.init();
+	m_START.init();
+	m_DEGREE.init();
+	m_TREE_ARC.init();
+	m_IN_ADJ.init();
+	m_IN_HIGH.init();
+	m_NODEAT.init();
 }
 
 // Tests G for triconnectivity and returns a cut vertex in
@@ -301,26 +304,7 @@ Triconnectivity::Triconnectivity(const Graph& G, bool& isTric, node& s1, node& s
 		s2 = GCoriginal(s2);
 	}
 
-	delete[] m_TSTACK_h;
-	delete[] m_TSTACK_a;
-	delete[] m_TSTACK_b;
-
-	// free resources
-	m_NUMBER.init();
-	m_LOWPT1.init();
-	m_LOWPT2.init();
-	m_FATHER.init();
-	m_ND.init();
-	m_TYPE.init();
-	m_A.init();
-	m_NEWNUM.init();
-	m_HIGHPT.init();
-	m_START.init();
-	m_DEGREE.init();
-	m_TREE_ARC.init();
-	m_IN_ADJ.init();
-	m_IN_HIGH.init();
-	m_NODEAT.init();
+	clearStructures();
 }
 
 // Splits bundles of multi-edges into bonds and creates

--- a/test/src/decomposition/triconnectivity.cpp
+++ b/test/src/decomposition/triconnectivity.cpp
@@ -1,0 +1,481 @@
+/** \file
+ * \brief Tests for functionality from ogdf/graphalg/Triconnectivity.h
+ *
+ * \author Simon D. Fink <ogdf@niko.fink.bayern>
+ *
+ * \par License:
+ * This file is part of the Open Graph Drawing Framework (OGDF).
+ *
+ * \par
+ * Copyright (C)<br>
+ * See README.md in the OGDF root directory for details.
+ *
+ * \par
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * Version 2 or 3 as published by the Free Software Foundation;
+ * see the file LICENSE.txt included in the packaging of this file
+ * for details.
+ *
+ * \par
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * \par
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, see
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#include <ogdf/basic/Graph_d.h>
+#include <ogdf/basic/simple_graph_alg.h>
+#include <ogdf/graphalg/Triconnectivity.h>
+
+#include <algorithm>
+#include <array>
+#include <random>
+#include <unordered_set>
+#include <vector>
+
+#include <graphs.h>
+#include <testing.h>
+
+struct RandomSkeleton : public Graph {
+	RandomSkeleton* m_parent = nullptr;
+	edge m_parent_edge = nullptr;
+	EdgeArrayP<RandomSkeleton> m_virtual_edges;
+
+	RandomSkeleton() : m_virtual_edges(*this) { }
+
+	RandomSkeleton(Triconnectivity::CompType type, int edge_cnt, RandomSkeleton* parent,
+			double virt_prob, double size_fact)
+		: m_parent(parent), m_virtual_edges(*this) {
+		OGDF_ASSERT(edge_cnt >= 3);
+		if (type == ogdf::Triconnectivity::CompType::triconnected) {
+			randomPlanarTriconnectedGraph(*this, edge_cnt / 3, edge_cnt);
+		} else if (type == ogdf::Triconnectivity::CompType::bond) {
+			node n1 = newNode();
+			node n2 = newNode();
+			for (int i = 0; i < edge_cnt; ++i) {
+				newEdge(n1, n2);
+			}
+		} else {
+			OGDF_ASSERT(type == ogdf::Triconnectivity::CompType::polygon);
+			node n1 = newNode();
+			node n = n1;
+			for (int i = 0; i < edge_cnt - 1; ++i) {
+				n = newEdge(n, newNode())->target();
+			}
+			newEdge(n, n1);
+		}
+		if (m_parent != nullptr) {
+			m_parent_edge = chooseEdge();
+		}
+		for (edge e : edges) {
+			if (e == m_parent_edge || randomDouble(0, 1) >= virt_prob) {
+				continue;
+			}
+			int cnt = (int)(edge_cnt * size_fact * randomDouble(0.8, 1.2));
+			if (cnt < 3) {
+				continue;
+			}
+			m_virtual_edges[e] = std::make_unique<RandomSkeleton>(
+					static_cast<Triconnectivity::CompType>(randomNumber(0, 2)), cnt, this,
+					virt_prob * 0.8, size_fact);
+		}
+	}
+
+	void createGraph(Graph& G, edge parent = nullptr) {
+		NodeArray<node> copyN(*this);
+		EdgeArray<edge> copyE(*this);
+		G.insert(*this, copyN, copyE);
+		for (edge e : this->edges) {
+			if (m_virtual_edges[e]) {
+				m_virtual_edges[e]->createGraph(G, copyE[e]);
+			}
+		}
+		if (parent) {
+			G.contract(G.newEdge(parent->source(), copyN[m_parent_edge->source()]));
+			G.contract(G.newEdge(parent->target(), copyN[m_parent_edge->target()]));
+			G.delEdge(copyE[m_parent_edge]);
+			G.delEdge(parent);
+		}
+	}
+
+	RandomSkeleton& makeVirtual(edge e) {
+		auto& ptr = m_virtual_edges[e];
+		OGDF_ASSERT(!ptr);
+		OGDF_ASSERT(e != m_parent_edge);
+		ptr = std::make_unique<RandomSkeleton>();
+		ptr->m_parent = this;
+		return *ptr;
+	}
+};
+
+void assertSameUndirected(const GraphCopySimple& GC, edge e, node orig_source, node orig_target) {
+	if (GC.original(e->source()) == orig_source) {
+		AssertThat(GC.original(e->target()), Equals(orig_target));
+	} else {
+		AssertThat(GC.original(e->source()), Equals(orig_target));
+		AssertThat(GC.original(e->target()), Equals(orig_source));
+	}
+}
+
+void assertSameUndirected(const GraphCopySimple& GC, edge e, edge orig) {
+	assertSameUndirected(GC, e, orig->source(), orig->target());
+}
+
+int checkEdgeCounts(const Graph& G, const Triconnectivity& T) {
+	AssertThat(T.checkComp(), IsTrue());
+	const GraphCopySimple& GC = *dynamic_cast<const GraphCopySimple*>(T.m_pG);
+	AssertThat(GC.numberOfNodes(), Equals(G.numberOfNodes()));
+	for (edge e : G.edges) {
+		assertSameUndirected(GC, GC.copy(e), e);
+	}
+	int virt_edges = 0, real_edges = 0, comps = 0;
+	for (int i = 0; i < T.m_numComp; ++i) {
+		using namespace std;
+		auto& comp = T.m_component[i];
+		if (comp.m_edges.empty()) {
+			continue;
+		}
+		comps++;
+		// cout << endl << "Comp " << i << " " << comp.m_type << endl;
+		for (edge e : comp.m_edges) {
+			if (GC.isDummy(e)) {
+				// cout << "\tvirt (";
+				virt_edges++;
+			} else {
+				// cout << "\treal (";
+				real_edges++;
+				assertSameUndirected(GC, e, GC.original(e));
+			}
+			// cout << GC.original(e->source()) << " " << GC.original(e->target()) << ")";
+			// cout << endl;
+		}
+		// cout << endl;
+		{
+			GraphCopySimple GCcomp;
+			GCcomp.setOriginalGraph(GC);
+			NodeArray<node> nodeMap(GC);
+			EdgeArray<edge> edgeMap(GC);
+			GCcomp.insert(GC.nodes, comp.m_edges, nodeMap, edgeMap);
+			for (node n : std::vector<node> {GCcomp.nodes.begin(), GCcomp.nodes.end()}) {
+				if (n->degree() < 1) {
+					GCcomp.delNode(n);
+				}
+			}
+			// for (edge e : GCcomp.edges) {
+			// 	cout << "(" << GC.original(GCcomp.original(e->source())) << " "
+			// 		 << GC.original(GCcomp.original(e->target())) << ") ";
+			// }
+			// cout << endl;
+			AssertThat(GCcomp.numberOfEdges(), Equals(comp.m_edges.size()));
+			if (GCcomp.numberOfNodes() > 3) {
+				AssertThat(isBiconnected(GCcomp), IsTrue());
+			} else {
+				AssertThat(isConnected(GCcomp), IsTrue());
+			}
+			if (comp.m_type == ogdf::Triconnectivity::CompType::bond) {
+				AssertThat(GCcomp.numberOfNodes(), Equals(2));
+				AssertThat(isRegular(GCcomp, comp.m_edges.size()), IsTrue());
+
+				node s = GC.original(comp.m_edges.front()->source());
+				node t = GC.original(comp.m_edges.front()->target());
+				for (edge e : comp.m_edges) {
+					assertSameUndirected(GC, e, s, t);
+				}
+			} else if (comp.m_type == ogdf::Triconnectivity::CompType::triconnected) {
+				AssertThat(isTriconnectedPrimitive(GCcomp), IsTrue());
+			} else {
+				AssertThat(comp.m_type, Equals(ogdf::Triconnectivity::CompType::polygon));
+				AssertThat(isRegular(GCcomp, 2), IsTrue());
+			}
+		}
+	}
+	AssertThat(real_edges, Equals(G.numberOfEdges()));
+	AssertThat(virt_edges, Equals(comps * 2 - 2));
+	AssertThat(T.m_pG->numberOfEdges(), Equals(G.numberOfEdges() + comps - 1));
+	return comps;
+}
+
+void checkBicon(const Graph& G, const string& graphName, bool checkIsTric) {
+	it("computes components", [&G, checkIsTric, graphName]() {
+		Triconnectivity T(G);
+		int comps = checkEdgeCounts(G, T);
+		if (checkIsTric) {
+			AssertThat(comps, Equals(1));
+		} else {
+			AssertThat(comps, IsGreaterThan(1));
+		}
+	});
+
+	it("computes split pairs", [&G, checkIsTric]() {
+		bool isTric = true;
+		node s1 = nullptr;
+		node s2 = nullptr;
+		Triconnectivity(G, isTric, s1, s2);
+		AssertThat(isTric, Equals(checkIsTric));
+		if (checkIsTric) {
+			AssertThat(s1, IsNull());
+			AssertThat(s2, IsNull());
+		} else {
+			AssertThat(s1, !IsNull());
+			AssertThat(s2, !IsNull());
+			AssertThat(s1, !Equals(s2));
+			AssertThat(s1->graphOf(), Equals(&G));
+			AssertThat(s2->graphOf(), Equals(&G));
+		}
+	});
+}
+
+go_bandit([]() {
+	describe("Triconnectivity", []() {
+		describe("for triconnected graphs", []() {
+			forEachGraphDescribe(
+					{GraphProperty::triconnected, GraphProperty::simple},
+					[](const Graph& G) {
+						it("computes components", [&G]() {
+							Triconnectivity T(G);
+							int comps = checkEdgeCounts(G, T);
+							AssertThat(comps, Equals(1));
+							AssertThat(T.m_component[0].m_type,
+									Equals(Triconnectivity::CompType::triconnected));
+							AssertThat(T.m_component[0].m_edges.size(), Equals(G.numberOfEdges()));
+							AssertThat(T.m_pG->numberOfEdges(), Equals(G.numberOfEdges()));
+						});
+
+						it("computes split pairs", [&G]() {
+							bool isTric = false;
+							node s1 = nullptr;
+							node s2 = nullptr;
+							Triconnectivity(G, isTric, s1, s2);
+							AssertThat(isTric, IsTrue());
+							AssertThat(s1, IsNull());
+							AssertThat(s2, IsNull());
+						});
+					},
+					GraphSizes(), 3);
+		});
+
+		describe(
+				"for triconnected graphs with parallel edges",
+				[]() {
+					forEachGraphDescribe(
+							{GraphProperty::triconnected, GraphProperty::loopFree},
+							[](const Graph& G) {
+								std::vector<edge> edges {G.edges.begin(), G.edges.end()};
+								int parallels = 0;
+								for (int i = 0; i < G.edges.size(); ++i) {
+									if (randomDouble(0, 1) < 0.1) {
+										parallels++;
+										edge e = edges[i];
+										for (int j = 0; j < randomNumber(1, 10); j++) {
+											edges.push_back(e);
+										}
+									}
+								}
+								if (parallels < 1) {
+									parallels++;
+									edge e = edges[randomNumber(0, G.numberOfEdges() - 1)];
+									for (int j = 0; j < randomNumber(1, 10); j++) {
+										edges.push_back(e);
+									}
+								}
+								auto rng = std::default_random_engine {randomSeed()};
+								std::shuffle(edges.begin(), edges.end(), rng);
+
+								Graph G2;
+								NodeArray<node> origN(G, nullptr);
+								EdgeArray<edge> origE(G, nullptr);
+								G2.insert<internal::GraphObjectContainer<NodeElement>::iterator, //
+										std::vector<edge>::iterator, //
+										false, false, true>( //
+										G.nodes.begin(), G.nodes.end(), //
+										edges.begin(), edges.end(), //
+										origN, origE);
+								makeIndicesNonContinuous(G2, 0.2);
+								for (edge e : G2.edges) {
+									if (randomDouble(0, 1) < 0.3) {
+										G2.reverseEdge(e);
+									}
+								}
+
+								EdgeArray<SListPure<edge>> para_edges(G2);
+								getParallelFreeUndirected(G2, para_edges);
+
+								it("computes components", [&G2, &G, &para_edges, parallels]() {
+									Triconnectivity T(G2);
+									const GraphCopySimple& GC =
+											*dynamic_cast<const GraphCopySimple*>(T.m_pG);
+									int comps = checkEdgeCounts(G, T);
+									AssertThat(comps, Equals(1 + parallels));
+									int found_ps = 0, found_rs = 0;
+									for (int i = 0; i < T.m_numComp; ++i) {
+										auto& comp = T.m_component[i];
+										if (comp.m_type == Triconnectivity::CompType::triconnected) {
+											found_rs++;
+											AssertThat(comp.m_edges.size(),
+													Equals(G.numberOfEdges()));
+										} else {
+											AssertThat(comp.m_type,
+													Equals(Triconnectivity::CompType::bond));
+											found_ps++;
+											edge orig = nullptr;
+											edge virt = nullptr;
+											for (edge e : comp.m_edges) {
+												if (GC.isDummy(e)) {
+													AssertThat(virt, IsNull());
+													virt = e;
+												} else if (para_edges[GC.original(e)].size() > 0) {
+													AssertThat(orig, IsNull());
+													AssertThat(comp.m_edges.size(),
+															Equals(para_edges[GC.original(e)].size()
+																	+ 2));
+													orig = e;
+												}
+											}
+											AssertThat(orig, !IsNull());
+											AssertThat(virt, !IsNull());
+										}
+									}
+									AssertThat(found_ps, Equals(parallels));
+									AssertThat(found_rs, Equals(1));
+								});
+
+								it("computes split pairs", [&G2]() {
+									bool isTric = true;
+									node s1 = nullptr;
+									node s2 = nullptr;
+									Triconnectivity(G2, isTric, s1, s2);
+									AssertThat(isTric, IsFalse());
+									AssertThat(s1, !IsNull());
+									AssertThat(s2, !IsNull());
+									AssertThat(s1, !Equals(s2));
+									AssertThat(s1->graphOf(), Equals(&G2));
+									AssertThat(s2->graphOf(), Equals(&G2));
+								});
+							},
+							GraphSizes(), 3);
+
+					it("correctly handles the instance from GH issue #207", []() {
+						RandomSkeleton Po;
+						customGraph(Po, 2, {{0, 1}, {0, 1}, {0, 1}});
+
+						auto& Sl = Po.makeVirtual(Po.edges.head());
+						auto& Sr = Po.makeVirtual(Po.edges.tail());
+						customGraph(Sl, 4, {{0, 1}, {1, 2}, {2, 3}, {3, 0}});
+						Sl.m_parent_edge = Sl.edges.head();
+						customGraph(Sr, 4, {{0, 1}, {1, 2}, {2, 3}, {0, 3}});
+						Sr.m_parent_edge = Sr.edges.head();
+
+						auto& Pr = Sr.makeVirtual(*std::next(Sr.edges.begin(), 2));
+						customGraph(Pr, 2, {{0, 1}, {0, 1}, {1, 0}});
+						Pr.m_parent_edge = Pr.edges.head();
+
+						auto& Pl = Sl.makeVirtual(*std::next(Sr.edges.begin(), 2));
+						customGraph(Pl, 2, {{0, 1}, {0, 1}, {0, 1}});
+						Pl.m_parent_edge = Pl.edges.head();
+
+						Graph G;
+						Po.createGraph(G);
+
+						Triconnectivity T(G);
+						int comps = checkEdgeCounts(G, T);
+						AssertThat(comps, Equals(4));
+					});
+				},
+				true); // FIXME reenable
+
+		describe("for biconnected graphs", []() {
+			forEachGraphDescribe(
+					{GraphProperty::biconnected, GraphProperty::loopFree},
+					[](const Graph& G, const std::string& graphName,
+							const std::set<GraphProperty>& props) {
+						// // it seems that all our biconnected graphs are already parallel free
+						// GraphCopySimple GC(G);
+						// makeParallelFree(GC);
+						// if (GC.numberOfEdges() != G.numberOfEdges()) {
+						// 	describe("without parallels", [&G, &GC, &graphName]() {
+						// 		AssertThat(isSimpleUndirected(GC), IsTrue());
+						// 		bool checkIsTric = isTriconnectedPrimitive(G);
+						// 		checkBicon(GC, graphName, checkIsTric);
+						// 	});
+						// }
+						AssertThat(isSimpleUndirected(G), IsTrue());
+						bool checkIsTric = isTriconnectedPrimitive(G);
+						checkBicon(G, graphName, checkIsTric);
+					},
+					GraphSizes(), 3);
+		});
+
+		describe("for two joined rigids", []() {
+			forEachGraphDescribe(
+					{GraphProperty::triconnected, GraphProperty::simple},
+					[](const Graph& G1) {
+						RandomSkeleton rigid1;
+						rigid1.insert(G1);
+						RandomSkeleton& rigid2 = rigid1.makeVirtual(rigid1.edges.head());
+						randomPlanarTriconnectedGraph(rigid2, 20, 60);
+						rigid2.m_parent_edge = rigid2.edges.head();
+
+						Graph G;
+						rigid1.createGraph(G);
+
+						it("computes components", [&G, &rigid1, &rigid2]() {
+							Triconnectivity T(G);
+							int comps = checkEdgeCounts(G, T);
+							AssertThat(comps, Equals(2));
+
+							Triconnectivity::CompStruct *comp1 = nullptr, *comp2 = nullptr;
+							for (int i = 0; i < T.m_numComp; ++i) {
+								if (T.m_component[i].m_edges.empty()) {
+									continue;
+								}
+								if (!comp1) {
+									comp1 = &T.m_component[i];
+								} else {
+									AssertThat(comp2, IsNull());
+									comp2 = &T.m_component[i];
+								}
+							}
+							AssertThat(comp2, !IsNull());
+
+							AssertThat(comp1->m_type,
+									Equals(Triconnectivity::CompType::triconnected));
+							AssertThat(comp2->m_type,
+									Equals(Triconnectivity::CompType::triconnected));
+							if (comp1->m_edges.size() == rigid1.numberOfEdges()) {
+								AssertThat(comp2->m_edges.size(), Equals(rigid2.numberOfEdges()));
+							} else {
+								AssertThat(comp1->m_edges.size(), Equals(rigid2.numberOfEdges()));
+								AssertThat(comp2->m_edges.size(), Equals(rigid1.numberOfEdges()));
+							}
+						});
+
+						it("computes split pairs", [&G]() {
+							bool isTric = false;
+							node s1 = nullptr;
+							node s2 = nullptr;
+							Triconnectivity(G, isTric, s1, s2);
+							AssertThat(isTric, IsFalse());
+							AssertThat(s1, IsNull()); // TODO
+							AssertThat(s2, IsNull());
+						});
+					},
+					GraphSizes(), 3);
+		});
+
+		// TODO check that random SPQR tree structure matches
+		// TODO check that separation pair occurs in random SPQR tree
+		{
+			RandomSkeleton skel(static_cast<Triconnectivity::CompType>(randomNumber(0, 2)), 20,
+					nullptr, 0.3, 0.8);
+			Graph G;
+			skel.createGraph(G, nullptr);
+			std::cout << G.numberOfNodes() << " " << G.numberOfEdges() << std::endl;
+		}
+	});
+});

--- a/test/src/decomposition/triconnectivity.cpp
+++ b/test/src/decomposition/triconnectivity.cpp
@@ -226,7 +226,7 @@ void checkBicon(const Graph& G, const string& graphName, bool checkIsTric) {
 				bool isTric = true;
 				node s1 = nullptr;
 				node s2 = nullptr;
-				Triconnectivity(G, isTric, s1, s2);
+				Triconnectivity _(G, isTric, s1, s2);
 				AssertThat(isTric, Equals(checkIsTric));
 				if (checkIsTric) {
 					AssertThat(s1, IsNull());
@@ -268,7 +268,7 @@ go_bandit([]() {
 									bool isTric = false;
 									node s1 = nullptr;
 									node s2 = nullptr;
-									Triconnectivity(G, isTric, s1, s2);
+									Triconnectivity _(G, isTric, s1, s2);
 									AssertThat(isTric, IsTrue());
 									AssertThat(s1, IsNull());
 									AssertThat(s2, IsNull());
@@ -379,7 +379,7 @@ go_bandit([]() {
 											bool isTric = true;
 											node s1 = nullptr;
 											node s2 = nullptr;
-											Triconnectivity(G2, isTric, s1, s2);
+											Triconnectivity _(G2, isTric, s1, s2);
 											AssertThat(isTric, IsFalse());
 											AssertThat(s1, !IsNull());
 											AssertThat(s2, !IsNull());
@@ -501,7 +501,7 @@ go_bandit([]() {
 									bool isTric = false;
 									node s2 = nullptr;
 									node t2 = nullptr;
-									Triconnectivity(G, isTric, s2, t2);
+									Triconnectivity _(G, isTric, s2, t2);
 									AssertThat(isTric, IsFalse());
 									if (s1 == s2) {
 										AssertThat(t2, Equals(t1));

--- a/util/compile_for_tests.sh
+++ b/util/compile_for_tests.sh
@@ -61,13 +61,14 @@ export CCACHE_BASEDIR="$tmp"
 export CCACHE_NOHASHDIR=1
 
 # CMake config according to the arguments
-cmakecommand="-DCGAL_DO_NOT_WARN_ABOUT_CMAKE_BUILD_TYPE=TRUE "
-cmakecommand+="-DOGDF_SEPARATE_TESTS=OFF -DOGDF_WARNING_ERRORS=ON "
+cmakeargs=()
+cmakeargs+=("-DCGAL_DO_NOT_WARN_ABOUT_CMAKE_BUILD_TYPE=TRUE")
+cmakeargs+=("-DOGDF_SEPARATE_TESTS=OFF" "-DOGDF_WARNING_ERRORS=ON")
 case "$libtype" in
 static)
 	;;
 dynamic)
-	cmakecommand+="-DBUILD_SHARED_LIBS=1 "
+	cmakeargs+=("-DBUILD_SHARED_LIBS=1")
 	;;
 *)
 	usage
@@ -75,14 +76,14 @@ esac
 
 case "$buildtype" in
 release)
-	cmakecommand+="-DCMAKE_BUILD_TYPE=Release "
+	cmakeargs+=("-DCMAKE_BUILD_TYPE=Release")
 	;;
 debug)
-	cmakecommand+="-DCMAKE_CXX_FLAGS_DEBUG='-g -O1' "
-	cmakecommand+="-DCMAKE_BUILD_TYPE=Debug "
-	cmakecommand+="-DOGDF_DEBUG_MODE=HEAVY "
-	cmakecommand+="-DOGDF_LEAK_CHECK=ON "
-	cmakecommand+="-DOGDF_MEMORY_MANAGER=MALLOC_TS "
+	cmakeargs+=("-DCMAKE_CXX_FLAGS_DEBUG='-g -O1'")
+	cmakeargs+=("-DCMAKE_BUILD_TYPE=Debug")
+	cmakeargs+=("-DOGDF_DEBUG_MODE=HEAVY")
+	cmakeargs+=("-DOGDF_LEAK_CHECK=ON")
+	cmakeargs+=("-DOGDF_MEMORY_MANAGER=MALLOC_TS")
 	;;
 *)
 	usage
@@ -90,10 +91,10 @@ esac
 
 case "$compilertype" in
 gcc)
-	cmakecommand+="-DCMAKE_CXX_COMPILER='g++' "
+	cmakeargs+=("-DCMAKE_CXX_COMPILER='g++'")
 	;;
 clang)
-	cmakecommand+="-DCMAKE_CXX_COMPILER='clang++' "
+	cmakeargs+=("-DCMAKE_CXX_COMPILER='clang++'")
 	;;
 default_c|*)
 esac
@@ -105,10 +106,8 @@ if [ "$ilpsolvertype" = "gurobi" ]; then
     # For Mac and gurobi version >= 8, the library is not .so anymore but .dylib
     library=`$OGDF_FIND $GUROBI_HOME/lib/libgurobi*.dylib | head -n 1`
   fi
-  cmakecommand+="-DCOIN_SOLVER=GRB -DCOIN_EXTERNAL_SOLVER_INCLUDE_DIRECTORIES=$GUROBI_HOME/include -DCOIN_EXTERNAL_SOLVER_LIBRARIES=$library "
+  cmakeargs+=("-DCOIN_SOLVER=GRB" "-DCOIN_EXTERNAL_SOLVER_INCLUDE_DIRECTORIES='$GUROBI_HOME/include'" "-DCOIN_EXTERNAL_SOLVER_LIBRARIES='$library'")
 fi
-
-cmakecommand+="${@:7}"
 
 run_cmake() {
 	echo cmake $@
@@ -130,7 +129,7 @@ compile () {
 }
 
 echo "::group::($(date -Iseconds)) Initial run of cmake"
-run_cmake "$cmakecommand"
+run_cmake "${cmakeargs[@]}" "${@:7}"
 echo "::endgroup::"
 
 # build


### PR DESCRIPTION
This fixes several CI issues:
- The prune caches jobs only pruned cached of the master branch because the "workflow-finished" trigger is always running against master and it's hard to know the branch of the triggering workflow. Now we simply always deduplicate the caches of all branches.
-  The CI stopped using ccache on Linux/MacOs because the `cmakecommand` was no longer split correctly (or at all), thus cramming all args into a unused `DCGAL_DO_NOT_WARN_ABOUT_CMAKE_BUILD_TYPE` flag.
- The planaritzation test produced stack overflows on the Mac OS debug build. The culprit was the `Triconnectivity` class, where I unrolled a recursion into a loop. For doing so, I also added some initial tests that should be extended when tackling #207.
- ~Also included is a small fix for [GraphCopy::setOriginalEmbedding](https://github.com/ogdf/ogdf/pull/240/commits/957819db3c22b7bda060f89df34f532f097c9fcd) which should now increase the number of cases where it works.~ This will come in a later PR.
- PR Workflow runs run against a [synthetic merge commit](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request) combining the new stuff from the PR with the target branch. Our SonarScanner runs now respect that and also use that instead of only scanning the PR branch.