### PR TITLE
Ensure edge bends are preserved when using layouts with packing operation

### DIFF
--- a/include/ogdf/packing/ComponentSplitterLayout.h
+++ b/include/ogdf/packing/ComponentSplitterLayout.h
@@ -53,7 +53,8 @@ private:
 	//! Combines drawings of connected components to
 	//! a single drawing by rotating components and packing
 	//! the result (optimizes area of axis-parallel rectangle).
-	void reassembleDrawings(GraphAttributes& GA, const Array<List<node>>& nodesInCC);
+	void reassembleDrawings(GraphAttributes& GA, const Array<List<node>>& nodesInCC,
+			const Array<List<edge>>& edgesInCC);
 
 public:
 	ComponentSplitterLayout();

--- a/include/ogdf/packing/ComponentSplitterLayout.h
+++ b/include/ogdf/packing/ComponentSplitterLayout.h
@@ -53,8 +53,7 @@ private:
 	//! Combines drawings of connected components to
 	//! a single drawing by rotating components and packing
 	//! the result (optimizes area of axis-parallel rectangle).
-	void reassembleDrawings(GraphAttributes& GA, const Array<List<node>>& nodesInCC,
-			const Array<List<edge>>& edgesInCC);
+	void reassembleDrawings(GraphAttributes& GA, const Graph::CCsInfo& ccs);
 
 public:
 	ComponentSplitterLayout();

--- a/src/ogdf/packing/ComponentSplitterLayout.cpp
+++ b/src/ogdf/packing/ComponentSplitterLayout.cpp
@@ -48,11 +48,13 @@ ComponentSplitterLayout::ComponentSplitterLayout() {
 void ComponentSplitterLayout::call(GraphAttributes& GA) {
 	// Only do preparations and call if layout is valid
 	if (m_secondaryLayout) {
-		//first we split the graph into its components
+		// first we split the graph into its components
 		const Graph& G = GA.constGraph();
 
-		NodeArray<int> componentNumber(G);
-		int numberOfComponents = connectedComponents(G, componentNumber);
+		Graph::CCsInfo ccs = Graph::CCsInfo(G);
+
+		int numberOfComponents = ccs.numberOfCCs();
+
 		if (numberOfComponents == 0) {
 			return;
 		}
@@ -60,8 +62,16 @@ void ComponentSplitterLayout::call(GraphAttributes& GA) {
 		// intialize the array of lists of nodes contained in a CC
 		Array<List<node>> nodesInCC(numberOfComponents);
 
-		for (node v : G.nodes) {
-			nodesInCC[componentNumber[v]].pushBack(v);
+		// intialize the array of lists of edges contained in a CC
+		Array<List<edge>> edgesInCC(numberOfComponents);
+
+		for (int i = 0; i < numberOfComponents; ++i) {
+			for (int j = ccs.startNode(i); j < ccs.stopNode(i); ++j) {
+				nodesInCC[i].pushBack(ccs.v(j));
+			}
+			for (int j = ccs.startEdge(i); j < ccs.stopEdge(i); ++j) {
+				edgesInCC[i].pushBack(ccs.e(j));
+			}
 		}
 
 		// Create copies of the connected components and corresponding
@@ -79,22 +89,28 @@ void ComponentSplitterLayout::call(GraphAttributes& GA) {
 			GC.insert(nodesInCC[i].begin(), nodesInCC[i].end(), filter_any_edge, nodeCopy, auxCopy);
 
 			GraphAttributes cGA(GC, GA.attributes());
-			//copy information into copy GA
+
+			// copy information into copy GA
 			for (node v : GC.nodes) {
 				cGA.width(v) = GA.width(GC.original(v));
 				cGA.height(v) = GA.height(GC.original(v));
 				cGA.x(v) = GA.x(GC.original(v));
 				cGA.y(v) = GA.y(GC.original(v));
 			}
+
 			// copy information on edges
-			if (GA.has(GraphAttributes::edgeDoubleWeight)) {
-				for (edge e : GC.edges) {
+			for (edge e : GC.edges) {
+				if (GA.has(GraphAttributes::edgeDoubleWeight)) {
 					cGA.doubleWeight(e) = GA.doubleWeight(GC.original(e));
 				}
+				if (GA.has(GraphAttributes::edgeGraphics)) {
+					cGA.bends(e) = GA.bends(GC.original(e));
+				}
 			}
+
 			m_secondaryLayout->call(cGA);
 
-			//copy layout information back into GA
+			// copy layout information back into GA
 			for (node v : GC.nodes) {
 				node w = GC.original(v);
 				if (w != nullptr) {
@@ -105,10 +121,18 @@ void ComponentSplitterLayout::call(GraphAttributes& GA) {
 					}
 				}
 			}
+			if (GA.has(GraphAttributes::edgeGraphics)) {
+				for (edge e : GC.edges) {
+					edge f = GC.original(e);
+					if (f != nullptr) {
+						GA.bends(f) = cGA.bends(e);
+					}
+				}
+			}
 		}
 
 		// rotate component drawings and call the packer
-		reassembleDrawings(GA, nodesInCC);
+		reassembleDrawings(GA, nodesInCC, edgesInCC);
 	}
 }
 
@@ -159,7 +183,7 @@ double atan2ex(double y, double x) {
 //TODO: Regard some kind of aspect ration (input)
 //(then also the rotation of a single component makes sense)
 void ComponentSplitterLayout::reassembleDrawings(GraphAttributes& GA,
-		const Array<List<node>>& nodesInCC) {
+		const Array<List<node>>& nodesInCC, const Array<List<edge>>& edgesInCC) {
 	int numberOfComponents = nodesInCC.size();
 
 	Array<IPoint> box;
@@ -172,11 +196,11 @@ void ComponentSplitterLayout::reassembleDrawings(GraphAttributes& GA,
 
 	//iterate through all components and compute convex hull
 	for (int j = 0; j < numberOfComponents; j++) {
-		//todo: should not use std::vector, but in order not
-		//to have to change all interfaces, we do it anyway
+		// todo: should not use std::vector, but in order not
+		// to have to change all interfaces, we do it anyway
 		std::vector<DPoint> points;
 
-		//collect node positions and at the same time center average
+		// collect node positions and at the same time center average
 		// at origin
 		double avg_x = 0.0;
 		double avg_y = 0.0;
@@ -186,20 +210,43 @@ void ComponentSplitterLayout::reassembleDrawings(GraphAttributes& GA,
 			avg_y += dp.m_y;
 			points.push_back(dp);
 		}
-		avg_x /= nodesInCC[j].size();
-		avg_y /= nodesInCC[j].size();
+		size_t nbBends = 0;
+		if (GA.has(GraphAttributes::edgeGraphics)) {
+			for (edge e : edgesInCC[j]) {
+				const DPolyline& bends = GA.bends(e);
+				for (const DPoint& dp : bends) {
+					avg_x += dp.m_x;
+					avg_y += dp.m_y;
+					points.push_back(dp);
+				}
+				nbBends += bends.size();
+			}
+		}
+		avg_x /= (nodesInCC[j].size() + nbBends);
+		avg_y /= (nodesInCC[j].size() + nbBends);
 
-		//adapt positions to origin
+		// adapt positions to origin
 		int count = 0;
-		//assume same order of vertices and positions
+		// assume same order of vertices and positions
 		for (node v : nodesInCC[j]) {
-			//TODO: I am not sure if we need to update both
+			// TODO: I am not sure if we need to update both
 			GA.x(v) = GA.x(v) - avg_x;
 			GA.y(v) = GA.y(v) - avg_y;
 			points.at(count).m_x -= avg_x;
 			points.at(count).m_y -= avg_y;
 
 			count++;
+		}
+		if (GA.has(GraphAttributes::edgeGraphics)) {
+			for (edge e : edgesInCC[j]) {
+				for (DPoint& bend : GA.bends(e)) {
+					bend.m_x = bend.m_x - avg_x;
+					bend.m_y = bend.m_y - avg_y;
+					points.at(count).m_x -= avg_x;
+					points.at(count).m_y -= avg_y;
+					count++;
+				}
+			}
 		}
 
 		// calculate convex hull
@@ -299,29 +346,39 @@ void ComponentSplitterLayout::reassembleDrawings(GraphAttributes& GA,
 	// call packer
 	m_packer->call(box, offset, m_targetRatio);
 
+	auto rotatePoint = [&](const DPoint& p, int index) -> DPoint {
+		double x = p.m_x, y = p.m_y;
+		double angle = rotation[index];
+		double ang = atan2(y, x);
+		double len = sqrt(x * x + y * y);
+		ang += angle;
+		x = cos(ang) * len;
+		y = sin(ang) * len;
+
+		x += static_cast<double>(offset[index].m_x);
+		y += static_cast<double>(offset[index].m_y);
+
+		x -= oldOffset[index].m_x;
+		y -= oldOffset[index].m_y;
+		return DPoint(x, y);
+	};
+
 	int index = 0;
 	// Apply offset and rebuild Graph
 	for (int j = 0; j < numberOfComponents; j++) {
-		double angle = rotation[index];
 		// apply rotation and offset to all nodes
-
 		for (node v : nodesInCC[j]) {
-			double x = GA.x(v);
-			double y = GA.y(v);
-			double ang = atan2(y, x);
-			double len = sqrt(x * x + y * y);
-			ang += angle;
-			x = cos(ang) * len;
-			y = sin(ang) * len;
+			DPoint rp = rotatePoint(DPoint(GA.x(v), GA.y(v)), index);
+			GA.x(v) = rp.m_x;
+			GA.y(v) = rp.m_y;
+		}
 
-			x += static_cast<double>(offset[index].m_x);
-			y += static_cast<double>(offset[index].m_y);
-
-			x -= oldOffset[index].m_x;
-			y -= oldOffset[index].m_y;
-
-			GA.x(v) = x;
-			GA.y(v) = y;
+		if (GA.has(GraphAttributes::edgeGraphics)) {
+			for (edge e : edgesInCC[j]) {
+				for (DPoint& bend : GA.bends(e)) {
+					bend = rotatePoint(bend, index);
+				}
+			}
 		}
 
 		index++;

--- a/test/src/layout/misc.cpp
+++ b/test/src/layout/misc.cpp
@@ -101,7 +101,6 @@ go_bandit([] {
 			randomPlanarConnectedGraph(graph, 30, 84);
 			randomPlanarConnectedGraph(graph2, 30, 84);
 
-
 			// draw first graph using mixed model that generates bends to edges
 			MixedModelLayout mixedModelLayout;
 			mixedModelLayout.call(graphAttr);
@@ -112,6 +111,36 @@ go_bandit([] {
 			ComponentSplitterLayout compSplitterLayout;
 			compSplitterLayout.setLayoutModule(new MixedModelLayout);
 			compSplitterLayout.call(graphAttr2);
+			// edge bends should have been preserved atfer the drawing of connected components
+			AssertThat(edgesHaveBends(graph2, graphAttr2), Equals(true));
+		});
+	});
+	describe("SimpleCCPacker", [] {
+		it("should preserve edge bends of connected component drawings", [&]() {
+			Graph graph, graph2;
+			GraphAttributes graphAttr(graph), graphAttr2(graph2);
+
+			// generate two planar graphs
+			randomPlanarConnectedGraph(graph, 30, 84);
+			randomPlanarConnectedGraph(graph2, 30, 84);
+
+			// add a new connected component in second graph
+			node n1 = graph2.newNode();
+			node n2 = graph2.newNode();
+			node n3 = graph2.newNode();
+			graph2.newEdge(n1, n2);
+			graph2.newEdge(n2, n3);
+			graph2.newEdge(n3, n1);
+
+			// draw first graph using mixed model that generates bends to edges
+			MixedModelLayout mixedModelLayout;
+			mixedModelLayout.call(graphAttr);
+			// check bends have been set to some edges
+			AssertThat(edgesHaveBends(graph, graphAttr), Equals(true));
+
+			// draw second graph using mixed model but wrapped by SimpleCCPacker
+			SimpleCCPacker simpleCCPacker(new MixedModelLayout);
+			simpleCCPacker.call(graphAttr2);
 			// edge bends should have been preserved atfer the drawing of connected components
 			AssertThat(edgesHaveBends(graph2, graphAttr2), Equals(true));
 		});

--- a/test/src/layout/misc.cpp
+++ b/test/src/layout/misc.cpp
@@ -30,6 +30,7 @@
  */
 
 #include <ogdf/basic/PreprocessorLayout.h>
+#include <ogdf/basic/graph_generators/randomized.h>
 #include <ogdf/energybased/FMMMLayout.h>
 #include <ogdf/misclayout/BalloonLayout.h>
 #include <ogdf/misclayout/BertaultLayout.h>
@@ -45,6 +46,15 @@
 #include <ogdf/upward/VisibilityLayout.h>
 
 #include "layout_helpers.h"
+
+static bool edgesHaveBends(const Graph& g, const GraphAttributes& ga) {
+	for (edge e : g.edges) {
+		if (ga.bends(e).size() > 0) {
+			return true;
+		}
+	}
+	return false;
+}
 
 go_bandit([] {
 	describe("Miscellaneous layouts", [] {
@@ -81,5 +91,29 @@ go_bandit([] {
 		describeLayout<VisibilityLayout>("VisibilityLayout", 0,
 				{GraphProperty::connected, GraphProperty::simple, GraphProperty::sparse}, false,
 				smallSizes);
+	});
+	describe("ComponentSplitterLayout", [] {
+		it("should preserve edge bends of connected component drawings", [&]() {
+			Graph graph, graph2;
+			GraphAttributes graphAttr(graph), graphAttr2(graph2);
+
+			// generate two planar graphs
+			randomPlanarConnectedGraph(graph, 30, 84);
+			randomPlanarConnectedGraph(graph2, 30, 84);
+
+
+			// draw first graph using mixed model that generates bends to edges
+			MixedModelLayout mixedModelLayout;
+			mixedModelLayout.call(graphAttr);
+			// check bends have been set to some edges
+			AssertThat(edgesHaveBends(graph, graphAttr), Equals(true));
+
+			// draw second graph using mixed model but wrapped by ComponentSplitterLayout
+			ComponentSplitterLayout compSplitterLayout;
+			compSplitterLayout.setLayoutModule(new MixedModelLayout);
+			compSplitterLayout.call(graphAttr2);
+			// edge bends should have been preserved atfer the drawing of connected components
+			AssertThat(edgesHaveBends(graph2, graphAttr2), Equals(true));
+		});
 	});
 });


### PR DESCRIPTION
The `ComponentSplitterLayout` and `SimpleCCPacker` layout modules in OGDF draw each connected component of a graph with a provided layout algorithm then pack the resulting drawings.

However, the drawings of components with edge bends were not taken into account in the previous implementation.
Indeed when using a layout algorithm that produces edge bends with those  layouts, those were not available in the `GraphAttributes` passed as parameter to `ComponentSplitterLayout::call` or `SimpleCCPacker::call` method.

This PR ensures edge bends are preserved after each connected component drawing but also taken into consideration when performing the packing operation.

For the record, I maintain a fork of [Tulip](https://tulip.labri.fr) for fun and non-profit, relicensed under GPL, that I named [Talipot](https://github.com/anlambert/talipot). I used to be a contributor of Tulip (I notably worked on integrating OGDF layout algorithms in it) but decided to create a fork due to strong divergences with the folks that keep "maintaining" it.
I did not file any real release so far as I can only work on that project during my spare time but I still offer binaries for all supported systems (linux, macos and windows) of the [latest development snapshot](https://github.com/anlambert/talipot/releases/tag/dev-latest).

I was working on [integrating some planar layout algorithms](https://github.com/anlambert/talipot/tree/ogdf-planar-layout-algos) that were not wrapped yet in Talipot and noticed that `ComponentSplitterLayout` was not preserving edge bends. Indeed I use that layout algorithm to draw each connected component of a graph with a given layout algorithm from OGDF in order to avoid issues when attempting to draw a non connected graph.


During my tests, I wanted to draw these 3 planar connected components of a graph using the `MixedModelLayout` from OGDF.
![image](https://github.com/ogdf/ogdf/assets/5493543/5a5f201c-979b-46fc-99fb-549455dc7b11)

This is what I obtained **without the changes** in that PR when using `ComponentSplitterLayout` for the drawings and packing.
![image](https://github.com/ogdf/ogdf/assets/5493543/9e34368e-2c13-4455-91bc-2d00c881cd43)

This is what I obtained **without the changes** in that PR when using `SimpleCCPacker` for the drawings and packing.
![image](https://github.com/ogdf/ogdf/assets/5493543/bcf0a394-8582-4779-ac84-cc0505d4124f)

`MixedModelLayout` produces drawings of edges with bends but we can see those were discarded.

This is what I obtained **with the changes** in that PR when using `ComponentSplitterLayout` for the drawings and packing.
![image](https://github.com/ogdf/ogdf/assets/5493543/580b1e8f-8f87-488c-83a4-10748eae6b21)

This is what I obtained **with the changes** in that PR when using `SimpleCCPacker` for the drawings and packing.
![image](https://github.com/ogdf/ogdf/assets/5493543/3a180cad-e8a6-4a4a-adbc-5925d9509428)
