### PR TITLE
Fix buiding with windows gcc (mingw) as dll

### DIFF
--- a/include/ogdf/basic/memory/PoolMemoryAllocator.h
+++ b/include/ogdf/basic/memory/PoolMemoryAllocator.h
@@ -76,7 +76,7 @@ public:
 	static OGDF_EXPORT void cleanup();
 
 	//! Returns true iff #allocate can be invoked with \c nBytes
-	static OGDF_EXPORT bool checkSize(size_t nBytes) { return nBytes < TABLE_SIZE; }
+	static OGDF_EXPORT bool checkSize(size_t nBytes);
 
 	//! Allocates memory of size \c nBytes.
 	static OGDF_EXPORT void* allocate(size_t nBytes);

--- a/src/ogdf/basic/memory/PoolMemoryAllocator.cpp
+++ b/src/ogdf/basic/memory/PoolMemoryAllocator.cpp
@@ -71,6 +71,8 @@ void PoolMemoryAllocator::cleanup() {
 	}
 }
 
+bool PoolMemoryAllocator::checkSize(size_t nBytes) { return nBytes < TABLE_SIZE; }
+
 void* PoolMemoryAllocator::allocate(size_t nBytes) {
 	MemElemPtr& pFreeBytes = s_tp[nBytes];
 	void* result;


### PR DESCRIPTION
Hi,

When I build my app which uses `ogdf` using Windows GCC (MINGW), I have this error:
```
ogdf/include/ogdf/basic/memory/PoolMemoryAllocator.h:79:33: error: function 'static bool ogdf::PoolMemoryAllocator::checkSize(size_t)' definition is marked dllimport
   79 |         static OGDF_EXPORT bool checkSize(size_t nBytes) { return nBytes < TABLE_SIZE; }
      |                                 ^~~~~~~~~
```
This PR fixed the issue by moving the function _definition_ from .h file to .cpp file.

This is a gcc only issue (on Windows, build as DLL)