### PR TITLE
fix sonar not picking up PR info

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -100,7 +100,22 @@ jobs:
         with:
           cache-binaries: false
 
-      - name: SonarCloud Scan
+      - name: SonarCloud PR Scan
+        if: github.event.workflow_run.event == 'pull_request'
+        run: >
+          sonar-scanner
+          -Dsonar.links.ci=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
+          -Dsonar.pullrequest.key=${{ steps.pr-info.outputs.pr-number }}
+          -Dsonar.pullrequest.branch=${{ github.event.workflow_run.head_branch }}
+          -Dsonar.pullrequest.base=${{ steps.pr-info.outputs.base-ref }}
+          -Dproject.settings=sonar-project.properties
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: SonarCloud non-PR Scan
+        if: github.event.workflow_run.event != 'pull_request'
         run: >
           sonar-scanner
           -Dsonar.links.ci=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
Currently all sonar runs (even those of PRs) are interpreted as if they were for master. This re-adds the missing information, but still leaves the slight inprecision of reporting the PR head sha, not the sha of GitHubs synthetic merge commit.