### PR TITLE
ccache remote storage

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -4,6 +4,19 @@ on:
   pull_request:
   push:
 
+# the defaults here are for a read-only http account, allowing anyone to read the ccache results from CI
+# which is very useful when using the same docker images as used for the build locally
+env:
+  CCACHE_REMOTE_STORAGE_USER: ${{ secrets.CCACHE_REMOTE_STORAGE_USER || 'u427124-sub1' }}
+  CCACHE_REMOTE_STORAGE_PASS: ${{ secrets.CCACHE_REMOTE_STORAGE_PASS || 'Anw4Lc4ZUcUYVsZf' }}
+  CCACHE_REMOTE_STORAGE_HOST: ${{ secrets.CCACHE_REMOTE_STORAGE_HOST || 'u427124-sub1.your-storagebox.de' }}
+  CCACHE_SECONDARY_STORAGE: "http://\
+    ${{ secrets.CCACHE_REMOTE_STORAGE_USER || 'u427124-sub1' }}:\
+    ${{ secrets.CCACHE_REMOTE_STORAGE_PASS || 'Anw4Lc4ZUcUYVsZf' }}\
+    @127.0.0.1:44443/\
+    ${{ secrets.CCACHE_REMOTE_STORAGE_DIR }}"
+# CCACHE_SECONDARY_STORAGE is a backwards-compatible alias for CCACHE_REMOTE_STORAGE
+
 # # Debug setup:
 # env:
 #   OGDF_UTILS_PREQUEL: "set -x"
@@ -74,10 +87,22 @@ jobs:
       CCACHE_COMPILERCHECK: "%compiler% -v"
     steps:
       - uses: actions/checkout@v4
+
       - name: Set-up ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.job }}
+      - name: Set-up HTTPS proxy for ccache
+        run: pipx install mitmproxy
+      - uses: JarvusInnovations/background-action@v1
+        name: Start HTTPS proxy for ccache
+        with:
+          run: mitmdump --mode reverse:https://${CCACHE_REMOTE_STORAGE_HOST}@44443
+          wait-on: tcp:localhost:44443
+          tail: false
+          log-output-if: failure
+          wait-for: 10s
+
       - name: Test self-sufficiency
         run: |
           # the script calls gcc directly, so ensure that it finds the ccache version instead
@@ -110,16 +135,31 @@ jobs:
       - name: "Add workspace as a safe directory in containers"
         run: git config --system --add safe.directory $GITHUB_WORKSPACE
       - uses: actions/checkout@v4
+
       - name: Set-up ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.job }}
+      - name: Set-up HTTPS proxy for ccache
+        run: |
+          apt-get update
+          apt-get install -y python3-pip
+          pip3 install mitmproxy || pip3 install mitmproxy --break-system-packages
+      - uses: JarvusInnovations/background-action@v1
+        name: Start HTTPS proxy for ccache
+        with:
+          run: mitmdump --mode reverse:https://${CCACHE_REMOTE_STORAGE_HOST}@44443
+          wait-on: tcp:localhost:44443
+          tail: false
+          log-output-if: failure
+          wait-for: 10s
       - name: Restore clang-tidy cache
         uses: actions/cache/restore@v4
         with:
           path: ${{ github.workspace }}/.ctcache
           key: clang-tidy-cache-${{ github.run_id }}.${{ github.run_attempt }}
           restore-keys: clang-tidy-cache
+
       - name: Run analysis
         env:
           CTCACHE_LOCAL: 1
@@ -187,10 +227,25 @@ jobs:
       - name: "Add workspace as a safe directory in containers"
         run: git config --system --add safe.directory $GITHUB_WORKSPACE
       - uses: actions/checkout@v4
+
       - name: Set-up ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.job }}
+      - name: Set-up HTTPS proxy for ccache
+        run: |
+          apt-get update
+          apt-get install -y python3-pip
+          pip3 install mitmproxy || pip3 install mitmproxy --break-system-packages
+      - uses: JarvusInnovations/background-action@v1
+        name: Start HTTPS proxy for ccache
+        with:
+          run: mitmdump --mode reverse:https://${CCACHE_REMOTE_STORAGE_HOST}@44443
+          wait-on: tcp:localhost:44443
+          tail: false
+          log-output-if: failure
+          wait-for: 10s
+
       - name: Run analysis
         run: |
           util/test_coverage.sh -DOGDF_ARCH=haswell -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
@@ -236,6 +291,19 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.job }}-${{ matrix.compiler }}-${{ matrix.mode }}
+      - name: Set-up HTTPS proxy for ccache
+        run: |
+          apt-get update
+          apt-get install -y python3-pip
+          pip3 install mitmproxy || pip3 install mitmproxy --break-system-packages
+      - uses: JarvusInnovations/background-action@v1
+        name: Start HTTPS proxy for ccache
+        with:
+          run: mitmdump --mode reverse:https://${CCACHE_REMOTE_STORAGE_HOST}@44443
+          wait-on: tcp:localhost:44443
+          tail: false
+          log-output-if: failure
+          wait-for: 10s
       - name: Check ccache version
         run: ccache --version
       - name: Check CPU model
@@ -289,6 +357,16 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: build-${{ matrix.os }}-${{ matrix.mode }}
+      - name: Set-up HTTPS proxy for ccache
+        run: pipx install mitmproxy
+      - uses: JarvusInnovations/background-action@v1
+        name: Start HTTPS proxy for ccache
+        with:
+          run: mitmdump --mode reverse:https://${CCACHE_REMOTE_STORAGE_HOST}@44443
+          wait-on: tcp:localhost:44443
+          tail: false
+          log-output-if: failure
+          wait-for: 10s
       - name: Check CPU model
         run: |
           uname -av
@@ -336,6 +414,16 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.job }}-${{ matrix.mode }}
+      - name: Set-up HTTPS proxy for ccache
+        run: pipx install mitmproxy
+      - uses: JarvusInnovations/background-action@v1
+        name: Start HTTPS proxy for ccache
+        with:
+          run: mitmdump --mode reverse:https://${CCACHE_REMOTE_STORAGE_HOST}@44443
+          wait-on: tcp:localhost:44443
+          tail: false
+          log-output-if: failure
+          wait-for: 10s
       - name: Test ${{ matrix.mode }} build and run
         run: powershell util\test_build_and_run.ps1 ${{ matrix.mode == 'debug' && '-debug' }}
         env:

--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -143,11 +143,10 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.job }}
-      - name: Set-up HTTPS proxy for ccache
+      - name: Set-up HTTPS proxy for ccache in docker container
         run: |
-          apt-get update
-          apt-get install -y python3-pip
-          pip3 install mitmproxy || pip3 install mitmproxy --break-system-packages
+          pipx install mitmproxy
+          echo "PATH=$PATH:$HOME/.local/bin" >> "$GITHUB_ENV"
       - uses: JarvusInnovations/background-action@v1
         name: Start HTTPS proxy for ccache
         with:
@@ -235,11 +234,10 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.job }}
-      - name: Set-up HTTPS proxy for ccache
+      - name: Set-up HTTPS proxy for ccache in docker container
         run: |
-          apt-get update
-          apt-get install -y python3-pip
-          pip3 install mitmproxy || pip3 install mitmproxy --break-system-packages
+          pipx install mitmproxy
+          echo "PATH=$PATH:$HOME/.local/bin" >> "$GITHUB_ENV"
       - uses: JarvusInnovations/background-action@v1
         name: Start HTTPS proxy for ccache
         with:
@@ -280,8 +278,8 @@ jobs:
       CCACHE_COMPILERCHECK: "%compiler% -v"
     steps:
       - name: Process compiler name
-        # artifact names may not contain colons and GHA has no string splitting function, so we do it in bash
         run: |
+          # artifact names may not contain colons and GHA has no string splitting function, so we do it in bash
           S="${{ matrix.compiler }}"
           A=(${S//:/ })
           echo "GH_COMPILER_NAME=${A[0]}" >> "$GITHUB_ENV"
@@ -294,11 +292,10 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.job }}-${{ matrix.compiler }}-${{ matrix.mode }}
-      - name: Set-up HTTPS proxy for ccache
+      - name: Set-up HTTPS proxy for ccache in docker container
         run: |
-          apt-get update
-          apt-get install -y python3-pip
-          pip3 install mitmproxy || pip3 install mitmproxy --break-system-packages
+          pipx install mitmproxy
+          echo "PATH=$PATH:$HOME/.local/bin" >> "$GITHUB_ENV"
       - uses: JarvusInnovations/background-action@v1
         name: Start HTTPS proxy for ccache
         with:

--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -7,6 +7,8 @@ on:
 # the defaults here are for a read-only http account, allowing anyone to read the ccache results from CI
 # which is very useful when using the same docker images as used for the build locally
 env:
+  # CCACHE_BASEDIR is set by build scripts
+  CCACHE_NOHASHDIR: 1 # also cache debug builds even if symbol location info may be wrong
   CCACHE_REMOTE_STORAGE_USER: ${{ secrets.CCACHE_REMOTE_STORAGE_USER || 'u427124-sub1' }}
   CCACHE_REMOTE_STORAGE_PASS: ${{ secrets.CCACHE_REMOTE_STORAGE_PASS || 'Anw4Lc4ZUcUYVsZf' }}
   CCACHE_REMOTE_STORAGE_HOST: ${{ secrets.CCACHE_REMOTE_STORAGE_HOST || 'u427124-sub1.your-storagebox.de' }}
@@ -15,7 +17,8 @@ env:
     ${{ secrets.CCACHE_REMOTE_STORAGE_PASS || 'Anw4Lc4ZUcUYVsZf' }}\
     @127.0.0.1:44443/\
     ${{ secrets.CCACHE_REMOTE_STORAGE_DIR }}"
-# CCACHE_SECONDARY_STORAGE is a backwards-compatible alias for CCACHE_REMOTE_STORAGE
+  # CCACHE_SECONDARY_STORAGE is a backwards-compatible alias for CCACHE_REMOTE_STORAGE
+
 
 # # Debug setup:
 # env:

--- a/util/compile_for_tests.sh
+++ b/util/compile_for_tests.sh
@@ -57,8 +57,7 @@ tmp=`realpath $6`
 sourcedir=`realpath $5`
 
 mkdir -p $tmp
-export CCACHE_BASEDIR="$tmp"
-export CCACHE_NOHASHDIR=1
+export CCACHE_BASEDIR="$sourcedir"
 
 # CMake config according to the arguments
 cmakeargs=()

--- a/util/docker/Dockerfile
+++ b/util/docker/Dockerfile
@@ -3,8 +3,10 @@ ARG version=13
 FROM $compiler:$version
 
 RUN apt -y update \
- && apt -y install graphviz unzip wget git time ccache cmake doxygen \
- && apt -y upgrade ca-certificates
+ && apt -y install graphviz unzip wget git time ccache cmake doxygen python3-pip python3-venv \
+ && apt -y upgrade ca-certificates \
+ && pip3 install pipx --break-system-packages \
+ && pipx ensurepath
 
 # CGAL
 ARG CGAL_INSTALL=false

--- a/util/docker/Dockerfile
+++ b/util/docker/Dockerfile
@@ -2,16 +2,21 @@ ARG compiler=gcc
 ARG version=13
 FROM $compiler:$version
 
-RUN apt -y update \
- && apt -y install graphviz unzip wget git time ccache cmake doxygen python3-pip python3-venv \
- && apt -y upgrade ca-certificates \
- && pip3 install pipx --break-system-packages \
+ARG ld_lib_path=
+ENV LD_LIBRARY_PATH=${ld_lib_path}
+
+RUN apt-get -y update \
+ && apt-get -y install graphviz unzip wget git time ccache cmake doxygen python3-pip python3-venv \
+ && apt-get -y upgrade ca-certificates \
+ && mkdir -p ~/.config/pip/ \
+ && printf "[global]\nbreak-system-packages = true" >> ~/.config/pip/pip.conf \
+ && pip3 install pipx \
  && pipx ensurepath
 
 # CGAL
 ARG CGAL_INSTALL=false
 RUN [ "$CGAL_INSTALL" = "false" ] || { \
-  apt -y install libgmp-dev libmpfr-dev libboost-thread-dev && \
+  apt-get -y install libgmp-dev libmpfr-dev libboost-thread-dev && \
   wget -q -O CGAL.zip https://github.com/CGAL/cgal/releases/download/v5.5.2/CGAL-5.5.2-library.zip && \
   unzip -q CGAL.zip && \
   rm CGAL.zip && \

--- a/util/docker/build-all.sh
+++ b/util/docker/build-all.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+set -x
+
+# on gcc:9-bookworm, apt needs to be pointed to the newer system libstdc++ via LD_LIBRARY_PATH
+./build.sh "$@" gcc:9    bookworm "/usr/lib/x86_64-linux-gnu/"
+./build.sh "$@" gcc:13   bookworm # here our gcc 13 actually brings newer libstdc++ than system gcc 12
+./build.sh "$@" clang:15 bookworm
+./build.sh "$@" clang:18 bookworm

--- a/util/docker/clang/Dockerfile
+++ b/util/docker/clang/Dockerfile
@@ -30,13 +30,7 @@ RUN apt-get update \
  && ln -sf /usr/bin/llvm-profdata-${llvmver} /usr/bin/llvm-profdata \
  && ln -sf /usr/bin/llvm-cov-$llvmver /usr/bin/llvm-cov
 
-# Bypass pip externally managed warning to install sonar output converter,
-# see https://stackoverflow.com/questions/75608323/
-RUN mkdir -p ~/.config/pip/ \
- && printf "[global]\nbreak-system-packages = true" > ~/.config/pip/pip.conf
-RUN pip install git+https://github.com/N-Coder/clang-tidy-converter.git
-
-# Install clang-tidy-cache
-RUN wget https://raw.githubusercontent.com/matus-chochlik/ctcache/main/clang-tidy-cache \
- && mv clang-tidy-cache /usr/bin/clang-tidy-cache \
- && chmod +x /usr/bin/clang-tidy-cache
+# Install clang-tidy cache and converter
+RUN pip install --break-system-packages \
+    git+https://github.com/matus-chochlik/ctcache.git \
+    git+https://github.com/N-Coder/clang-tidy-converter.git

--- a/util/test_coverage.sh
+++ b/util/test_coverage.sh
@@ -36,6 +36,8 @@ opts+="-DCMAKE_CXX_FLAGS='-fprofile-instr-generate -fcoverage-mapping -Wall -Wex
 ## cmd-line args
 opts+="$@"
 
+export CCACHE_BASEDIR="$(pwd)"
+
 # Compile!
 echo "::group::($(date -Iseconds)) Compile"
 cd build-coverage

--- a/util/test_self-sufficiency.sh
+++ b/util/test_self-sufficiency.sh
@@ -22,6 +22,8 @@ then
 	headers=$(cd include ; find ogdf -name '*.h')
 fi
 
+export CCACHE_BASEDIR="$(pwd)"
+
 make_tmpdir $0
 (cd $tmp && cmake -LA -DCMAKE_BUILD_TYPE=Debug -DOGDF_WARNING_ERRORS=ON .. > cmakelog.txt) || exit 1
 

--- a/util/test_static_analysis.sh
+++ b/util/test_static_analysis.sh
@@ -38,6 +38,8 @@ opts+="-DCGAL_DO_NOT_WARN_ABOUT_CMAKE_BUILD_TYPE=TRUE "
 ## cmd-line args
 opts+="$@"
 
+export CCACHE_BASEDIR="$(pwd)"
+
 # Compile!
 echo "::group::($(date -Iseconds)) Compile"
 cd build-static-analysis


### PR DESCRIPTION
It seems that ccache drastically speeds up CI runs, roughly from 45min down to 5min if nothing changed. Unfortunately, GitHub won't let us store more than 10GB of caches, which is by far not enough. Additionally, this caching doesn't help much when compiling locally. Fortunately, ccache can also use an additional [remote cache](https://ccache.dev/manual/latest.html#_remote_storage_backends) via HTTP GET (and optionally, PUT).

For testing this, I created a [hetzner storage box](https://docs.hetzner.com/de/storage/storage-box/) with the required WebDAV functionality, 1TB storage and unlimited traffic for currently less 4€/month. As hetzner requires HTTPS, which ccache does not support, I added `mitmproxy` as background service that simply (un)wraps the HTTP(S) traffic for `ccache`. I added a public, read-only WebDAV account as default (passwordless access is not possible), so anyone can benefit from the caches when running our build docker images locally. For the CI, the read-write credentials are stored in a secret.