### PR TITLE
Include `<chrono>` for high_resolution_clock

### DIFF
--- a/include/ogdf/cluster/MaximumCPlanarSubgraph.h
+++ b/include/ogdf/cluster/MaximumCPlanarSubgraph.h
@@ -43,6 +43,7 @@
 
 #include <ogdf/external/abacus.h>
 
+#include <chrono>
 #include <cstdint>
 #include <sstream>
 #include <string>

--- a/include/ogdf/cluster/sync_plan/SyncPlan.h
+++ b/include/ogdf/cluster/sync_plan/SyncPlan.h
@@ -42,6 +42,7 @@
 #include <ogdf/cluster/sync_plan/SyncPlanConsistency.h>
 #include <ogdf/cluster/sync_plan/utils/Bijection.h>
 
+#include <chrono>
 #include <cstdint>
 #include <functional>
 #include <ostream>

--- a/include/ogdf/graphalg/MatchingBlossomV.h
+++ b/include/ogdf/graphalg/MatchingBlossomV.h
@@ -48,6 +48,7 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cstddef>
 #include <initializer_list>
 #include <iostream>

--- a/src/ogdf/basic/graph_generators/clustering.cpp
+++ b/src/ogdf/basic/graph_generators/clustering.cpp
@@ -46,6 +46,7 @@
 #include <ogdf/cluster/sync_plan/SyncPlan.h>
 #include <ogdf/cluster/sync_plan/utils/Bijection.h>
 
+#include <chrono>
 #include <cstdint>
 #include <functional>
 #include <ostream>

--- a/src/ogdf/cluster/HananiTutteCPlanarity.cpp
+++ b/src/ogdf/cluster/HananiTutteCPlanarity.cpp
@@ -48,6 +48,7 @@
 
 #include <ogdf/external/abacus.h>
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <map>

--- a/test/src/graphalg/a-star-search.cpp
+++ b/test/src/graphalg/a-star-search.cpp
@@ -37,6 +37,7 @@
 #include <ogdf/graphalg/AStarSearch.h>
 #include <ogdf/graphalg/Dijkstra.h>
 
+#include <chrono>
 #include <functional>
 #include <iomanip>
 #include <iostream>

--- a/util/fix_includes.sh
+++ b/util/fix_includes.sh
@@ -146,6 +146,7 @@ run_all_replacements () {
   replace_all   "#include <emmintrin.h>"    ""
   replace_all   "#include <pmmintrin.h>"    ""
   replace_all   "#include <xmmintrin.h>"    ""
+  replace_all   "#include <bits/chrono.h>"  "#include <chrono>"
   replace_all   "#include <bits/.*>"        ""
   replace_all   "#include <built-in>"       ""
 


### PR DESCRIPTION
I am a member of Microsoft vcpkg, due to there are new changes merged by microsoft/STL#5105, which revealed a conformance issue in `ogdf`. It must add include `<chrono>` to fix this error.

Compiler error with this STL change:
```
D:\b\ogdf\src\3b65b433a9-facc12a078.clean\src\ogdf\cluster\HananiTutteCPlanarity.cpp(47): error C2039: 'high_resolution_clock': is not a member of 'std::chrono'
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.41.34120\include\__msvc_chrono.hpp(286): note: see declaration of 'std::chrono'
D:\b\ogdf\src\3b65b433a9-facc12a078.clean\src\ogdf\cluster\HananiTutteCPlanarity.cpp(47): error C2873: 'high_resolution_clock': symbol cannot be used in a using-declaration
```