### PR TITLE
Fix PoolMemoryAllocator Issues

### DIFF
--- a/doc/porting/unreleased.md
+++ b/doc/porting/unreleased.md
@@ -74,3 +74,8 @@ void inducedSubGraph(const Graph &G, LISTITERATOR start, GraphCopySimple &subGra
 
 `GraphCopy::insert` (and `GraphCopySimple::insert`) will automatically update its mappings when inserting parts of the original Graph.
 This can be disabled by using `setLinkCopiesOnInsert`.
+
+## PoolMemoryAllocator
+
+`PoolMemoryAllocator::defrag()` was renamed to `defragGlobal()` and (more importantly) now has a companion method `defragThread()`
+that defragments the thread-local memory pool.

--- a/include/ogdf/basic/memory/PoolMemoryAllocator.h
+++ b/include/ogdf/basic/memory/PoolMemoryAllocator.h
@@ -37,6 +37,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <vector>
 #ifndef OGDF_MEMORY_POOL_NTS
 #	include <mutex>
 #endif
@@ -124,6 +125,12 @@ public:
 	 * the pool like lists and graphs.
 	 */
 	static OGDF_EXPORT void defragThread();
+
+	//! Reports the number of pooled memory chunks in the global free lists for each possible size up to TABLE_SIZE.
+	static OGDF_EXPORT void getGlobalFreeListSizes(std::vector<size_t>& sizes);
+
+	//! Reports the number of pooled memory chunks in the thread's free lists for each possible size up to TABLE_SIZE.
+	static OGDF_EXPORT void getThreadFreeListSizes(std::vector<size_t>& sizes);
 
 private:
 	static inline void enterCS() {

--- a/include/ogdf/basic/memory/PoolMemoryAllocator.h
+++ b/include/ogdf/basic/memory/PoolMemoryAllocator.h
@@ -48,9 +48,9 @@ namespace ogdf {
 /**
  * Possibly allocates more memory than required.
  * Newly allocated chunks contain #BLOCK_SIZE many bytes.
- * Can allocate at most #TABLE_SIZE bytes per invocation of #allocate.
+ * Can allocate elements of size at most #TABLE_SIZE.
  *
- * For each requested memory segment of \c n bytes,
+ * For each requested memory segment of #BLOCK_SIZE bytes,
  * \c OGDF_POINTER_SIZE bytes are allocated in addition to store a pointer to another segment of memory.
  *
  * This allows to store memory that is requested to be deallocated in a single linked list,
@@ -160,12 +160,6 @@ private:
 	static MemElemPtr allocateBlock();
 	static void makeSlices(MemElemPtr p, int nWords, int nSlices);
 
-	static size_t unguardedMemGlobalFreelist();
-
-	//! Contains allocated but free memory that may be used by all threads.
-	//! Filled upon exiting a thread that allocated memory that was later freed.
-	static PoolElement s_pool[TABLE_SIZE];
-
 	//! Holds all allocated memory independently of whether it is cleared in chunks of size #BLOCK_SIZE.
 	static BlockChain* s_blocks;
 
@@ -179,6 +173,10 @@ private:
 #ifdef OGDF_MEMORY_POOL_NTS
 	static MemElemPtr s_tp[TABLE_SIZE];
 #else
+	//! Contains allocated but free memory that may be used by all threads.
+	//! Filled upon exiting a thread that allocated memory that was later freed.
+	static PoolElement s_pool[TABLE_SIZE];
+
 	static std::mutex s_mutex;
 	//! Contains the allocated but free memory for a single thread.
 	static thread_local MemElemPtr s_tp[TABLE_SIZE];

--- a/include/ogdf/basic/memory/PoolMemoryAllocator.h
+++ b/include/ogdf/basic/memory/PoolMemoryAllocator.h
@@ -110,11 +110,20 @@ public:
 	/**
 	 * Defragments the global free lists.
 	 *
-	 * This methods sorts the global free lists, so that successive elements come after each
-	 * other. This can improve perfomance for data structure that allocate many elements from
+	 * This method sorts the global free lists, so that successive parts of memory come after each
+	 * other. This can improve performance for data structures that allocate many elements from
 	 * the pool like lists and graphs.
 	 */
-	static OGDF_EXPORT void defrag();
+	static OGDF_EXPORT void defragGlobal();
+
+	/**
+	 * Defragments the thread's free lists.
+	 *
+	 * This method sorts the thread's free lists, so that successive parts of memory come after each
+	 * other. This can improve performance for data structures that allocate many elements from
+	 * the pool like lists and graphs.
+	 */
+	static OGDF_EXPORT void defragThread();
 
 private:
 	static inline void enterCS() {

--- a/src/ogdf/basic/memory/PoolMemoryAllocator.cpp
+++ b/src/ogdf/basic/memory/PoolMemoryAllocator.cpp
@@ -38,6 +38,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <mutex>
+#include <vector>
 
 namespace ogdf {
 

--- a/src/ogdf/basic/memory/PoolMemoryAllocator.cpp
+++ b/src/ogdf/basic/memory/PoolMemoryAllocator.cpp
@@ -307,4 +307,30 @@ void PoolMemoryAllocator::defragThread() {
 	}
 }
 
+void PoolMemoryAllocator::getGlobalFreeListSizes(std::vector<size_t>& sizes) {
+#ifdef OGDF_MEMORY_POOL_NTS
+	sizes.clear();
+#else
+	enterCS();
+	sizes.reserve(TABLE_SIZE);
+	sizes.assign(1, 0);
+	for (size_t sz = 1; sz < TABLE_SIZE; ++sz) {
+		sizes.push_back(s_pool[sz].m_size);
+	}
+	leaveCS();
+#endif
+}
+
+void PoolMemoryAllocator::getThreadFreeListSizes(std::vector<size_t>& sizes) {
+	sizes.reserve(TABLE_SIZE);
+	sizes.assign(1, 0);
+	for (size_t sz = 1; sz < TABLE_SIZE; ++sz) {
+		size_t size = 0;
+		for (auto p = s_tp[sz]; p != nullptr; p = p->m_next) {
+			size += sz;
+		}
+		sizes.push_back(size);
+	}
+}
+
 }

--- a/src/ogdf/basic/memory/PoolMemoryAllocator.cpp
+++ b/src/ogdf/basic/memory/PoolMemoryAllocator.cpp
@@ -247,7 +247,7 @@ size_t PoolMemoryAllocator::memoryInGlobalFreeList() {
 size_t PoolMemoryAllocator::memoryInThreadFreeList() {
 	size_t bytesFree = 0;
 	for (size_t sz = 1; sz < TABLE_SIZE; ++sz) {
-		MemElemPtr& p = s_tp[sz];
+		MemElemPtr p = s_tp[sz];
 		for (; p != nullptr; p = p->m_next) {
 			bytesFree += sz;
 		}

--- a/src/ogdf/basic/memory/PoolMemoryAllocator.cpp
+++ b/src/ogdf/basic/memory/PoolMemoryAllocator.cpp
@@ -323,7 +323,7 @@ void PoolMemoryAllocator::getThreadFreeListSizes(std::vector<size_t>& sizes) {
 	for (size_t sz = 1; sz < TABLE_SIZE; ++sz) {
 		size_t size = 0;
 		for (auto p = s_tp[sz]; p != nullptr; p = p->m_next) {
-			size += sz;
+			size++;
 		}
 		sizes.push_back(size);
 	}

--- a/test/src/basic/memory-allocator.cpp
+++ b/test/src/basic/memory-allocator.cpp
@@ -30,11 +30,17 @@
  */
 
 #include <ogdf/basic/System.h>
+#include <ogdf/basic/Thread.h>
+#include <ogdf/basic/basic.h>
 #include <ogdf/basic/memory.h>
+#include <ogdf/basic/memory/PoolMemoryAllocator.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <functional>
+#include <random>
 #include <string>
+#include <vector>
 
 #include <testing.h>
 
@@ -73,4 +79,165 @@ void describeMemoryManager(const std::string& name) {
 go_bandit([] {
 	describeMemoryManager<OGDFObject>("OGDF");
 	describeMemoryManager<MallocObject>("Malloc");
+
+#define OBJ_SIZE 128
+
+	describe(
+			"PoolMemoryManager",
+			[] {
+				std::vector<OGDFObject<OBJ_SIZE>*> objects;
+				const size_t MAX = 1024;
+				const size_t ALL_OBJS_SIZE = MAX * sizeof(OGDFObject<OBJ_SIZE>);
+				objects.reserve(MAX);
+
+				it("allocates memory", [&] {
+					auto get_used = [] {
+						return OGDF_ALLOCATOR::memoryAllocatedInBlocks()
+								- OGDF_ALLOCATOR::memoryInGlobalFreeList()
+								- OGDF_ALLOCATOR::memoryInThreadFreeList();
+					};
+					size_t used_before = get_used();
+					for (int i = 0; i < MAX; ++i) {
+						objects.push_back(new OGDFObject<OBJ_SIZE>());
+					}
+					AssertThat(get_used() - used_before, IsGreaterThanOrEqualTo(ALL_OBJS_SIZE));
+				});
+
+				it("grows its free list when objects are deleted", [&] {
+					std::vector<size_t> sizes_old;
+					PoolMemoryAllocator::getThreadFreeListSizes(sizes_old);
+
+					size_t mAllocatedInBlocks = PoolMemoryAllocator::memoryAllocatedInBlocks();
+					size_t mInGlobalFreeList = PoolMemoryAllocator::memoryInGlobalFreeList();
+					size_t mInThreadFreeList = PoolMemoryAllocator::memoryInThreadFreeList();
+					std::shuffle(objects.begin(), objects.end(), std::mt19937(randomSeed()));
+					for (auto object : objects) {
+						delete object;
+					}
+					AssertThat(PoolMemoryAllocator::memoryAllocatedInBlocks(),
+							Equals(mAllocatedInBlocks));
+					AssertThat(PoolMemoryAllocator::memoryInGlobalFreeList(),
+							Equals(mInGlobalFreeList));
+					AssertThat(PoolMemoryAllocator::memoryInThreadFreeList(),
+							IsGreaterThan(mInThreadFreeList));
+					AssertThat(PoolMemoryAllocator::memoryInThreadFreeList() - mInThreadFreeList,
+							Equals(ALL_OBJS_SIZE));
+
+					std::vector<size_t> sizes_new;
+					PoolMemoryAllocator::getThreadFreeListSizes(sizes_new);
+					AssertThat(sizes_new.at(OBJ_SIZE) - sizes_old.at(OBJ_SIZE), Equals(MAX));
+					sizes_new[OBJ_SIZE] = sizes_old[OBJ_SIZE];
+					AssertThat(sizes_new, Equals(sizes_old));
+
+					objects.clear();
+				});
+
+				it("correctly defragments its thread free list", [&] {
+					PoolMemoryAllocator::defragThread();
+					for (int i = 0; i < MAX; ++i) { // first set of objects from main thread for later
+						objects.push_back(new OGDFObject<OBJ_SIZE>());
+					}
+					AssertThat(std::is_sorted(objects.begin(), objects.end()), IsTrue());
+				});
+
+				std::vector<size_t> thread_sizes_old;
+				PoolMemoryAllocator::getThreadFreeListSizes(thread_sizes_old);
+				std::vector<size_t> global_sizes_old;
+				PoolMemoryAllocator::getGlobalFreeListSizes(global_sizes_old);
+				std::vector<size_t> side_thread_sizes_new;
+
+				ogdf::Thread([&] {
+					it("handles allocations and deletions mixed between threads", [&] {
+						for (int i = 0; i < MAX; ++i) { // second set of objects from side thread
+							objects.push_back(new OGDFObject<OBJ_SIZE>());
+						}
+						std::shuffle(objects.begin(), objects.end(), std::mt19937(randomSeed()));
+						AssertThat(objects.size(), Equals(MAX * 2));
+						for (int i = 0; i < MAX; ++i) { // half of objects deleted in side thread
+							delete objects.back();
+							objects.pop_back();
+						}
+						AssertThat(objects.size(), Equals(MAX));
+						PoolMemoryAllocator::getThreadFreeListSizes(side_thread_sizes_new);
+					});
+				}).join();
+				it("handles deletions of objects from other threads", [&] {
+					for (auto object : objects) { // last half of objects deleted in main thread
+						delete object;
+					}
+					objects.clear();
+				});
+
+				it("hands thread memory over to global pool on thread termination", [&] {
+					std::vector<size_t> thread_sizes_new;
+					PoolMemoryAllocator::getThreadFreeListSizes(thread_sizes_new);
+					std::vector<size_t> global_sizes_new;
+					PoolMemoryAllocator::getGlobalFreeListSizes(global_sizes_new);
+
+#ifdef OGDF_MEMORY_POOL_NTS
+					AssertThat(thread_sizes_new.at(OBJ_SIZE), IsGreaterThanOrEqualTo(MAX * 2));
+					AssertThat(global_sizes_new.empty(), IsTrue());
+#else
+			AssertThat(thread_sizes_new.at(OBJ_SIZE),
+					Equals(thread_sizes_old.at(OBJ_SIZE) + MAX));
+			AssertThat(global_sizes_new.at(OBJ_SIZE),
+					Equals(global_sizes_old.at(OBJ_SIZE) + side_thread_sizes_new.at(OBJ_SIZE)));
+#endif
+				});
+
+
+				it(
+						"correctly defragments its global free list",
+						[&] {
+							// update counters
+							PoolMemoryAllocator::getGlobalFreeListSizes(global_sizes_old);
+							size_t mAllocatedInBlocks =
+									PoolMemoryAllocator::memoryAllocatedInBlocks();
+
+							PoolMemoryAllocator::defragGlobal(); // thread list will not be defrag'ed...
+
+							// so use up those guys first
+							std::vector<size_t> thread_sizes_new;
+							PoolMemoryAllocator::getThreadFreeListSizes(thread_sizes_new);
+							std::vector<OGDFObject<OBJ_SIZE>*> objects2;
+							for (int i = 0; i < thread_sizes_new.at(OBJ_SIZE); ++i) {
+								objects2.push_back(new OGDFObject<OBJ_SIZE>());
+							}
+							PoolMemoryAllocator::getThreadFreeListSizes(thread_sizes_new);
+							AssertThat(thread_sizes_new.at(OBJ_SIZE), Equals(0));
+
+							// now we should be using from the global list
+							for (int i = 0; i < MAX; ++i) {
+								objects.push_back(new OGDFObject<OBJ_SIZE>());
+							}
+							AssertThat(std::is_sorted(objects.begin(), objects.end()), IsTrue());
+
+							std::vector<size_t> global_sizes_new;
+							PoolMemoryAllocator::getGlobalFreeListSizes(global_sizes_new);
+							AssertThat(global_sizes_new.at(OBJ_SIZE) - global_sizes_old.at(OBJ_SIZE),
+									IsGreaterThanOrEqualTo(MAX));
+
+							AssertThat(PoolMemoryAllocator::memoryAllocatedInBlocks(),
+									Equals(mAllocatedInBlocks));
+
+							for (auto object : objects) {
+								delete object;
+							}
+							for (auto object : objects2) {
+								delete object;
+							}
+						},
+#ifdef OGDF_MEMORY_POOL_NTS
+						true
+#else
+						false
+#endif
+				);
+			},
+#ifdef OGDF_MEMORY_MALLOC_TS
+			true
+#else
+			false
+#endif
+	);
 });


### PR DESCRIPTION
When profiling the runtime of an algorithm, I often run it multiple times like so:
```cpp
for (int i = 0; i < 10; ++i) {
  auto start = chrono::high_resolution_clock::now();
  bool plan = isPlanar(G); // or, e.g., isTriconnected(G)
  auto end = chrono::high_resolution_clock::now();
  chrono::nanoseconds elapsed = end - start;
  cout << i << ", " << plan << ", " << elapsed.count() << endl;
}
```
With the current OGDF compiled with memory manager `POOL_NTS`, I often saw the first of the 10 runs to be by far the fastest (especially when running the program multiple times consecutively, and independently of the algorithm used). This was very counter intuitive, as I expected the memory allocations of the first run to be an overhead, while later runs should be faster through reusing this memory from the pool. Actually checking the memory usage made the problem even worse: 
```cpp
cout << "u" << System::memoryUsedByProcess()
     << ", a" << System::memoryAllocatedByMemoryManager()
     << ", g" << System::memoryInGlobalFreeListOfMemoryManager()
     << ", t" << System::memoryInThreadFreeListOfMemoryManager()
     << ", m" << System::memoryAllocatedByMalloc()
     << ", f" << System::memoryInFreelistOfMalloc();
```
What you now would see here is linearly increasing u, a and m values over each run (which is very bad); while t and f alternate between the exact same two values before and after each run (as expected when you e.g. keep a copy of `G` around until the end of run, which then frees up memory).

What took me *quite* some time to debug is that the linearly increasing memory usage actually comes from the `memoryInThreadFreeList()` call, which not only measures the free list, but also entirely discards it - here the measurement clearly not only changes, but breaks the experiment. This is fixed by removing a single `&` in b90ae65dd114568445976b0e9d440427e3fa1402. \*ugh*

Having fixed this, the memory measurements now remained constant after the first run, but that one still remained the fastest. Assuming this may be due to pool memory fragmentation, I added a call to `PoolMemoryAllocator::defrag()` after each iteration. This didn't help either, because that method only cleaned up the global free list (which is only used by `POOL_TS`, but not `POOL_NTS`). Thus, I renamed this method to `defragGlobal` and added a companion `PoolMemoryAllocator::defragThread()` to also sort the thread-local free list. Calling this after every iteration now finally made my measurements make sense.

So lesson of the (last two) day(s): do not measure multiple algorithm runs with the OGDF in `POOL_NTS` mode without these fixes, and call `PoolMemoryAllocator::defragThread()` (plus `defragGlobal` when using `POOL_TS`) after each run.