### PR TITLE
Registry Callbacks

### DIFF
--- a/doc/examples/cluster/cluster-plan.cpp
+++ b/doc/examples/cluster/cluster-plan.cpp
@@ -32,7 +32,7 @@ int main(void) {
 	}
 
 	// add the computed augmentation edges
-	EdgeSet<> added(G);
+	EdgeSet added(G);
 	insertAugmentationEdges(CG, G, augmentation, &added);
 
 	// the augmentation edges make the instance c-connected c-plane, fixing the embedding for ClusterPlanarizationLayout

--- a/doc/porting/unreleased.md
+++ b/doc/porting/unreleased.md
@@ -39,10 +39,14 @@ When their height is equal to their width, `Shape::Triangle` and `Shape::InvTria
 If the stored elements have a non-trivial move-constructor, it should be marked `noexcept`.
 Otherwise, all elements will be [copied when the array grows](https://stackoverflow.com/a/28627764).
 
-## ClusterSetSimple and ClusterSetPure
-`ClusterSetSimple` was removed in favor of `ClusterArray<bool>`.
-`ClusterSetPure` was removed in favor of `ClusterSet`, which does keep track of its size at a negligible overhead
+## NodeSet, FaceSet, and ClusterSet(Simple|Pure)
+The template classes `NodeSet<bool SupportFastSizeQuery = true>` and `FaceSet<bool>` were converted to non-templated classes
+using their default `SupportFastSizeQuery = true` versions, which now always keeps track of its size at a negligible overhead
 (these sets do not support merging by splicing as simple double-linked lists do anyways).
+Similarly, `ClusterSetPure` was removed in favor of `ClusterSet`.
+`ClusterSetSimple` was removed in favor of `ClusterArray<bool>`.
+All these `RegisteredSet`s now automatically remove members (nodes, faces, clusters,...) from their lists when they are deleted
+from the corresponding registries (Graphs, CombEmbeddings, ClusterGraphs,...).
 
 ## Graph
 The move constructor and assignment operators of `Graph` are now deleted, which especially means that `NodeArray<Graph>`, `EdgeArray<Graph>`, `FaceArray<Graph>`, etc. is no longer possible.
@@ -55,7 +59,7 @@ For this reason, `SimDraw::getBasicGraph` now returns a `std::unique_ptr<GraphCo
 `GraphCopy::createEmpty()` was deprecated in favor of `setOriginalGraph()`.
 The same holds for `createEmpty()` of `GraphCopySimple` and `EdgeWeightedGraph`.
 
-## GraphObserver
+## (Hyper/Cluster)GraphObserver
 `GraphObserver`s are now notified when their `Graph` is destructed through `GraphObserver::registrationChanged()`.
 
 `ClusterGraphObserver`s are now notified of their `ClusterGraph` being cleared through `ClusterGraphObserver::clustersCleared()`.
@@ -65,6 +69,10 @@ The same holds for `createEmpty()` of `GraphCopySimple` and `EdgeWeightedGraph`.
 `Observer`s and their `Observable`s now have deleted copy and move constructors and assignment operators.
 Subclasses can instead explicitly declare their copy and move behaviour using the default constructors of `Observer` / `Observable`,
 `Observer::getObservers()`, `Observer::clearObservers()` and `Observable::reregister()`.
+
+Additionally, the `Observer(Observable*)` constructor (e.g. `GraphObserver(Graph*)`) is now deprecated as it would
+trigger a `registrationChanged` callback before the construction of your subclass is done.
+Instead, use the default `Observer()` constructor and explicitly call `reregister(...)` in the constructor of your subclass.
 
 ## Graph::insert
 Multiple methods for inserting (parts of) a graph were merged into a single `Graph::insert` implementation.

--- a/doc/porting/unreleased.md
+++ b/doc/porting/unreleased.md
@@ -40,7 +40,9 @@ If the stored elements have a non-trivial move-constructor, it should be marked 
 Otherwise, all elements will be [copied when the array grows](https://stackoverflow.com/a/28627764).
 
 ## ClusterSetSimple and ClusterSetPure
-`ClusterSetSimple` was removed in favor of `ClusterArray<bool>` and `ClusterSetPure` in favor of `ClusterSet<false>` (which does not keep track of its size).
+`ClusterSetSimple` was removed in favor of `ClusterArray<bool>`.
+`ClusterSetPure` was removed in favor of `ClusterSet`, which does keep track of its size at a negligible overhead
+(these sets do not support merging by splicing as simple double-linked lists do anyways).
 
 ## Graph
 The move constructor and assignment operators of `Graph` are now deleted, which especially means that `NodeArray<Graph>`, `EdgeArray<Graph>`, `FaceArray<Graph>`, etc. is no longer possible.

--- a/include/ogdf/basic/CombinatorialEmbedding.h
+++ b/include/ogdf/basic/CombinatorialEmbedding.h
@@ -561,9 +561,16 @@ public:
 	/**
 	 * \brief Removes edge \p e and joins the two faces adjacent to \p e.
 	 * @param e is an edge in the associated graph.
-	 * \return the resulting (joined) face.
+	 * \return the resulting (joined) face, which will be based on the larger one of the two faces separated by \p e
 	 */
 	face joinFaces(edge e);
+
+	/**
+	 * \brief Removes edge \p e corresponding to \p adj and joins the two faces adjacent to \p e.
+	 * @param adj is an adjEntry in the associated graph.
+	 * \return the resulting (joined) face, which will be the one to the right of \p adj
+	 */
+	face joinFaces(adjEntry adj);
 
 	//! Reverses edges \p e and updates embedding.
 	void reverseEdge(edge e);

--- a/include/ogdf/basic/DualGraph.h
+++ b/include/ogdf/basic/DualGraph.h
@@ -58,7 +58,7 @@ using DynamicDualGraph = DualGraphBase<false>;
  * @ingroup graphs
  */
 template<bool isConst>
-class OGDF_EXPORT DualGraphBase : public CombinatorialEmbedding {
+class DualGraphBase : public CombinatorialEmbedding {
 public:
 	using Embedding = typename std::conditional<isConst, const ConstCombinatorialEmbedding,
 			CombinatorialEmbedding>::type;

--- a/include/ogdf/basic/FaceSet.h
+++ b/include/ogdf/basic/FaceSet.h
@@ -45,25 +45,20 @@ namespace ogdf {
  * Provides efficient operations for testing membership,
  * iteration, insertion and deletion of elements, as well as clearing the set.
  *
- * \tparam SupportFastSizeQuery Whether this set supports querying its #size in
- * constant instead of linear time (in the size).
- *
  * \sa NodeSet
  */
-template<bool SupportFastSizeQuery = true>
-class FaceSet : public RegisteredSet<ConstCombinatorialEmbedding, SupportFastSizeQuery> {
-	using RS = RegisteredSet<ConstCombinatorialEmbedding, SupportFastSizeQuery>;
-
+class OGDF_EXPORT FaceSet : public RegisteredSet<ConstCombinatorialEmbedding> {
 public:
-	OGDF_REGSET_CONSTR(FaceSet, RS)
+	using RegisteredSet::RegisteredSet;
+	OGDF_DEFAULT_COPY(FaceSet);
 
 	//! Returns a reference to the list of faces contained in this set.
-	const typename RS::list_type& faces() const { return RS::elements(); }
+	const list_type& faces() const { return elements(); }
 
 	//! Returns the associated combinatorial embedding
 	const ConstCombinatorialEmbedding& embeddingOf() const {
-		OGDF_ASSERT(RS::registeredAt());
-		return *RS::registeredAt();
+		OGDF_ASSERT(RegisteredSet::registeredAt());
+		return *registeredAt();
 	}
 };
 

--- a/include/ogdf/basic/FaceSet.h
+++ b/include/ogdf/basic/FaceSet.h
@@ -45,7 +45,7 @@ namespace ogdf {
  * Provides efficient operations for testing membership,
  * iteration, insertion and deletion of elements, as well as clearing the set.
  *
- * \tparam SupportFastSizeQuery Whether this set supports querying it's #size in
+ * \tparam SupportFastSizeQuery Whether this set supports querying its #size in
  * constant instead of linear time (in the size).
  *
  * \sa NodeSet
@@ -55,7 +55,7 @@ class FaceSet : public RegisteredSet<ConstCombinatorialEmbedding, SupportFastSiz
 	using RS = RegisteredSet<ConstCombinatorialEmbedding, SupportFastSizeQuery>;
 
 public:
-	using RS::RS;
+	OGDF_REGSET_CONSTR(FaceSet, RS)
 
 	//! Returns a reference to the list of faces contained in this set.
 	const typename RS::list_type& faces() const { return RS::elements(); }

--- a/include/ogdf/basic/FaceSet.h
+++ b/include/ogdf/basic/FaceSet.h
@@ -34,6 +34,7 @@
 #include <ogdf/basic/CombinatorialEmbedding.h>
 #include <ogdf/basic/RegisteredSet.h>
 #include <ogdf/basic/basic.h>
+#include <ogdf/basic/internal/copy_move.h>
 
 namespace ogdf {
 

--- a/include/ogdf/basic/GraphCopy.h
+++ b/include/ogdf/basic/GraphCopy.h
@@ -45,7 +45,6 @@
 namespace ogdf {
 
 class CombinatorialEmbedding;
-template<bool>
 class FaceSet;
 
 class OGDF_EXPORT GraphCopyBase : public Graph {
@@ -715,7 +714,7 @@ public:
 	 * @param newFaces is assigned the set of new faces resulting from joining faces
 	 *        when removing edges.
 	 */
-	void removeEdgePathEmbedded(CombinatorialEmbedding& E, edge eOrig, FaceSet<false>& newFaces);
+	void removeEdgePathEmbedded(CombinatorialEmbedding& E, edge eOrig, FaceSet& newFaces);
 
 	void removeEdgePathEmbedded(CombinatorialEmbedding& E, DynamicDualGraph& dual, edge eOrig);
 

--- a/include/ogdf/basic/GraphSets.h
+++ b/include/ogdf/basic/GraphSets.h
@@ -50,7 +50,7 @@ namespace ogdf {
  * Provides efficient operations for testing membership,
  * iteration, insertion, and deletion of elements, as well as clearing the set.
  *
- * \tparam SupportFastSizeQuery Whether this set supports querying it's #size in
+ * \tparam SupportFastSizeQuery Whether this set supports querying its #size in
  * constant instead of linear time (in the size).
  */
 template<bool SupportFastSizeQuery = true>
@@ -58,13 +58,10 @@ class NodeSet : public RegisteredSet<internal::GraphNodeRegistry, SupportFastSiz
 	using RS = RegisteredSet<internal::GraphNodeRegistry, SupportFastSizeQuery>;
 
 public:
-	using RS::RS;
-
 	//! Creates a new node set associated with \p graph.
-	explicit NodeSet(const Graph& graph) : RS((const internal::GraphNodeRegistry&)graph) {};
+	explicit NodeSet(const Graph& graph) : RS((const internal::GraphNodeRegistry&)graph) { }
 
-	//! Creates an empty node set associated with no graph.
-	explicit NodeSet() = default;
+	OGDF_REGSET_CONSTR(NodeSet, RS)
 
 	//! Returns a reference to the list of nodes contained in this set.
 	const typename RS::list_type& nodes() { return RS::elements(); }
@@ -85,7 +82,11 @@ public:
  * Provides efficient operations for testing membership,
  * iteration, insertion, and deletion of elements, as well as clearing the set.
  *
- * \tparam SupportFastSizeQuery Whether this set supports querying it's #size in
+ * Note that an EdgeSet is not notified if an edge is hidden using HiddenEdgeSet. Thus, hidden
+ * edges will stay part of EdgeSets even if they are (temporarily) no longer accessible as entry in
+ * the edge list of their corresponding Graph.
+ *
+ * \tparam SupportFastSizeQuery Whether this set supports querying its #size in
  * constant instead of linear time (in the size).
  */
 template<bool SupportFastSizeQuery = true>
@@ -93,13 +94,10 @@ class EdgeSet : public RegisteredSet<internal::GraphEdgeRegistry, SupportFastSiz
 	using RS = RegisteredSet<internal::GraphEdgeRegistry, SupportFastSizeQuery>;
 
 public:
-	using RS::RS;
-
 	//! Creates a new edge set associated with \p graph.
-	explicit EdgeSet(const Graph& graph) : RS((const internal::GraphEdgeRegistry&)graph) {};
+	explicit EdgeSet(const Graph& graph) : RS((const internal::GraphEdgeRegistry&)graph) { }
 
-	//! Creates an empty edge set associated with no graph.
-	explicit EdgeSet() = default;
+	OGDF_REGSET_CONSTR(EdgeSet, RS)
 
 	//! Returns a reference to the list of edges contained in this set.
 	const typename RS::list_type& edges() { return RS::elements(); }
@@ -120,7 +118,7 @@ public:
  * Provides efficient operations for testing membership,
  * iteration, insertion, and deletion of elements, as well as clearing the set.
  *
- * \tparam SupportFastSizeQuery Whether this set supports querying it's #size in
+ * \tparam SupportFastSizeQuery Whether this set supports querying its #size in
  * constant instead of linear time (in the size).
  */
 template<bool SupportFastSizeQuery = true>
@@ -128,13 +126,10 @@ class AdjEntrySet : public RegisteredSet<internal::GraphAdjRegistry, SupportFast
 	using RS = RegisteredSet<internal::GraphAdjRegistry, SupportFastSizeQuery>;
 
 public:
-	using RS::RS;
-
 	//! Creates a new adjEntry set associated with \p graph.
-	explicit AdjEntrySet(const Graph& graph) : RS((const internal::GraphAdjRegistry&)graph) {};
+	explicit AdjEntrySet(const Graph& graph) : RS((const internal::GraphAdjRegistry&)graph) { }
 
-	//! Creates an empty adjEntry set associated with no graph.
-	explicit AdjEntrySet() = default;
+	OGDF_REGSET_CONSTR(AdjEntrySet, RS)
 
 	//! Returns a reference to the list of adjEntries contained in this set.
 	const typename RS::list_type& adjEntries() { return RS::elements(); }

--- a/include/ogdf/basic/GraphSets.h
+++ b/include/ogdf/basic/GraphSets.h
@@ -49,27 +49,23 @@ namespace ogdf {
  *
  * Provides efficient operations for testing membership,
  * iteration, insertion, and deletion of elements, as well as clearing the set.
- *
- * \tparam SupportFastSizeQuery Whether this set supports querying its #size in
- * constant instead of linear time (in the size).
  */
-template<bool SupportFastSizeQuery = true>
-class NodeSet : public RegisteredSet<internal::GraphNodeRegistry, SupportFastSizeQuery> {
-	using RS = RegisteredSet<internal::GraphNodeRegistry, SupportFastSizeQuery>;
-
+class OGDF_EXPORT NodeSet : public RegisteredSet<internal::GraphNodeRegistry> {
 public:
 	//! Creates a new node set associated with \p graph.
-	explicit NodeSet(const Graph& graph) : RS((const internal::GraphNodeRegistry&)graph) { }
+	explicit NodeSet(const Graph& graph)
+		: RegisteredSet((const internal::GraphNodeRegistry&)graph) { }
 
-	OGDF_REGSET_CONSTR(NodeSet, RS)
+	using RegisteredSet::RegisteredSet;
+	OGDF_DEFAULT_COPY(NodeSet);
 
 	//! Returns a reference to the list of nodes contained in this set.
-	const typename RS::list_type& nodes() { return RS::elements(); }
+	const list_type& nodes() { return elements(); }
 
 	//! Returns the associated graph.
 	const Graph& graphOf() const {
-		OGDF_ASSERT(RS::registeredAt());
-		return *RS::registeredAt();
+		OGDF_ASSERT(registeredAt());
+		return *registeredAt()->graphOf();
 	}
 };
 
@@ -85,27 +81,23 @@ public:
  * Note that an EdgeSet is not notified if an edge is hidden using HiddenEdgeSet. Thus, hidden
  * edges will stay part of EdgeSets even if they are (temporarily) no longer accessible as entry in
  * the edge list of their corresponding Graph.
- *
- * \tparam SupportFastSizeQuery Whether this set supports querying its #size in
- * constant instead of linear time (in the size).
  */
-template<bool SupportFastSizeQuery = true>
-class EdgeSet : public RegisteredSet<internal::GraphEdgeRegistry, SupportFastSizeQuery> {
-	using RS = RegisteredSet<internal::GraphEdgeRegistry, SupportFastSizeQuery>;
-
+class OGDF_EXPORT EdgeSet : public RegisteredSet<internal::GraphEdgeRegistry> {
 public:
 	//! Creates a new edge set associated with \p graph.
-	explicit EdgeSet(const Graph& graph) : RS((const internal::GraphEdgeRegistry&)graph) { }
+	explicit EdgeSet(const Graph& graph)
+		: RegisteredSet((const internal::GraphEdgeRegistry&)graph) { }
 
-	OGDF_REGSET_CONSTR(EdgeSet, RS)
+	using RegisteredSet::RegisteredSet;
+	OGDF_DEFAULT_COPY(EdgeSet);
 
 	//! Returns a reference to the list of edges contained in this set.
-	const typename RS::list_type& edges() { return RS::elements(); }
+	const list_type& edges() { return elements(); }
 
 	//! Returns the associated graph.
 	const Graph& graphOf() const {
-		OGDF_ASSERT(RS::registeredAt());
-		return *RS::registeredAt();
+		OGDF_ASSERT(RegisteredSet::registeredAt());
+		return *registeredAt()->graphOf();
 	}
 };
 
@@ -117,47 +109,33 @@ public:
  *
  * Provides efficient operations for testing membership,
  * iteration, insertion, and deletion of elements, as well as clearing the set.
- *
- * \tparam SupportFastSizeQuery Whether this set supports querying its #size in
- * constant instead of linear time (in the size).
  */
-template<bool SupportFastSizeQuery = true>
-class AdjEntrySet : public RegisteredSet<internal::GraphAdjRegistry, SupportFastSizeQuery> {
-	using RS = RegisteredSet<internal::GraphAdjRegistry, SupportFastSizeQuery>;
-
+class OGDF_EXPORT AdjEntrySet : public RegisteredSet<internal::GraphAdjRegistry> {
 public:
 	//! Creates a new adjEntry set associated with \p graph.
-	explicit AdjEntrySet(const Graph& graph) : RS((const internal::GraphAdjRegistry&)graph) { }
+	explicit AdjEntrySet(const Graph& graph)
+		: RegisteredSet((const internal::GraphAdjRegistry&)graph) { }
 
-	OGDF_REGSET_CONSTR(AdjEntrySet, RS)
+	using RegisteredSet::RegisteredSet;
+	OGDF_DEFAULT_COPY(AdjEntrySet);
 
 	//! Returns a reference to the list of adjEntries contained in this set.
-	const typename RS::list_type& adjEntries() { return RS::elements(); }
+	const list_type& adjEntries() { return elements(); }
 
 	//! Returns the associated graph.
 	const Graph& graphOf() const {
-		OGDF_ASSERT(RS::registeredAt());
-		return *RS::registeredAt();
+		OGDF_ASSERT(RegisteredSet::registeredAt());
+		return *registeredAt()->graphOf();
 	}
 };
 
 template<OGDF_NODE_LIST NL>
-std::pair<int, int> Graph::insert(const NL& nodeList, const EdgeSet<true>& edgeSet,
+std::pair<int, int> Graph::insert(const NL& nodeList, const EdgeSet& edgeSet,
 		NodeArray<node>& nodeMap, EdgeArray<edge>& edgeMap) {
 	using std::size;
 	m_regNodeArrays.reserveSpace(size(nodeList));
 	m_regEdgeArrays.reserveSpace(size(edgeSet));
 	m_regAdjArrays.reserveSpace(size(edgeSet));
-	using std::begin;
-	using std::end;
-	return insert(begin(nodeList), end(nodeList), edgeSet, nodeMap, edgeMap);
-}
-
-template<OGDF_NODE_LIST NL>
-std::pair<int, int> Graph::insert(const NL& nodeList, const EdgeSet<false>& edgeSet,
-		NodeArray<node>& nodeMap, EdgeArray<edge>& edgeMap) {
-	using std::size;
-	m_regNodeArrays.reserveSpace(size(nodeList));
 	using std::begin;
 	using std::end;
 	return insert(begin(nodeList), end(nodeList), edgeSet, nodeMap, edgeMap);

--- a/include/ogdf/basic/GraphSets.h
+++ b/include/ogdf/basic/GraphSets.h
@@ -35,6 +35,7 @@
 #include <ogdf/basic/GraphList.h> // IWYU pragma: keep
 #include <ogdf/basic/RegisteredSet.h>
 #include <ogdf/basic/basic.h>
+#include <ogdf/basic/internal/copy_move.h>
 
 #include <iterator>
 #include <utility>

--- a/include/ogdf/basic/Graph_d.h
+++ b/include/ogdf/basic/Graph_d.h
@@ -64,6 +64,7 @@ class OGDF_EXPORT EdgeElement; // IWYU pragma: keep
 class OGDF_EXPORT FaceElement; // IWYU pragma: keep
 class OGDF_EXPORT Graph; // IWYU pragma: keep
 class OGDF_EXPORT NodeElement; // IWYU pragma: keep
+class OGDF_EXPORT EdgeSet; // needed for Graph::insert
 
 //! The type of nodes.
 //! @ingroup graphs
@@ -750,9 +751,6 @@ OGDF_DECL_REG_ARRAY(EdgeArray)
 //! RegisteredArray for labeling the \ref adjEntry "adjEntries" in a Graph with an arbitrary \p Value.
 OGDF_DECL_REG_ARRAY(AdjEntryArray)
 #undef OGDF_DECL_REG_ARRAY_TYPE
-
-template<bool>
-class EdgeSet;
 
 //! Abstract Base class for graph observers.
 /**
@@ -1758,21 +1756,11 @@ public:
 	 * Inserts a copy of a given subgraph into this graph.
 	 *
 	 * See the other insert() variants for details, this method is a short-cut for a container of nodes
-	 * together with an EdgeSet<true> used for filtering edges.
+	 * together with an EdgeSet used for filtering edges.
 	 */
 	template<OGDF_NODE_LIST NL>
-	std::pair<int, int> insert(const NL& nodeList, const EdgeSet<true>& edgeSet,
-			NodeArray<node>& nodeMap, EdgeArray<edge>& edgeMap);
-
-	/**
-	 * Inserts a copy of a given subgraph into this graph.
-	 *
-	 * See the other insert() variants for details, this method is a short-cut for a container of nodes
-	 * together with an EdgeSet<false> used for filtering edges.
-	 */
-	template<OGDF_NODE_LIST NL>
-	std::pair<int, int> insert(const NL& nodeList, const EdgeSet<false>& edgeSet,
-			NodeArray<node>& nodeMap, EdgeArray<edge>& edgeMap);
+	std::pair<int, int> insert(const NL& nodeList, const EdgeSet& edgeSet, NodeArray<node>& nodeMap,
+			EdgeArray<edge>& edgeMap);
 
 	/**
 	 * Inserts a copy of a given subgraph into this graph.

--- a/include/ogdf/basic/Graph_d.h
+++ b/include/ogdf/basic/Graph_d.h
@@ -61,10 +61,10 @@ namespace ogdf {
 class OGDF_EXPORT AdjElement; // IWYU pragma: keep
 class OGDF_EXPORT ClusterElement; // IWYU pragma: keep
 class OGDF_EXPORT EdgeElement; // IWYU pragma: keep
+class OGDF_EXPORT EdgeSet; // needed for Graph::insert
 class OGDF_EXPORT FaceElement; // IWYU pragma: keep
 class OGDF_EXPORT Graph; // IWYU pragma: keep
 class OGDF_EXPORT NodeElement; // IWYU pragma: keep
-class OGDF_EXPORT EdgeSet; // needed for Graph::insert
 
 //! The type of nodes.
 //! @ingroup graphs

--- a/include/ogdf/basic/Graph_d.h
+++ b/include/ogdf/basic/Graph_d.h
@@ -777,10 +777,9 @@ public:
 	//! Constructs instance of GraphObserver class
 	GraphObserver() = default;
 
-	/**
-	 *\brief Constructs instance of GraphObserver class
-	 * \param G is the graph to be watched
-	 */
+	OGDF_DEPRECATED("calls registrationChanged with only partially-constructed child classes, "
+					"see copy constructor of Observer for fix")
+
 	explicit GraphObserver(const Graph* G) { reregister(G); }
 
 	//! Called by watched graph just before a node is deleted.

--- a/include/ogdf/basic/Graph_d.h
+++ b/include/ogdf/basic/Graph_d.h
@@ -1175,6 +1175,7 @@ public:
 
 		m_regEdgeArrays.keyAdded(e);
 		m_regAdjArrays.keyAdded(e->adjSource());
+		m_regAdjArrays.keyAdded(e->adjTarget());
 		for (GraphObserver* obs : getObservers()) {
 			obs->edgeAdded(e);
 		}

--- a/include/ogdf/basic/InducedSubgraph.h
+++ b/include/ogdf/basic/InducedSubgraph.h
@@ -145,6 +145,7 @@ std::pair<int, int> Graph::insert(const NI& nodesBegin, const NI& nodesEnd, cons
 			if (notifyObservers) {
 				m_regEdgeArrays.keyAdded(e);
 				m_regAdjArrays.keyAdded(e->adjSource());
+				m_regAdjArrays.keyAdded(e->adjTarget());
 				edgeInserted(cbData, eG, e);
 				for (GraphObserver* obs : getObservers()) {
 					obs->edgeAdded(e);
@@ -195,6 +196,7 @@ std::pair<int, int> Graph::insert(const NI& nodesBegin, const NI& nodesEnd, cons
 			OGDF_ASSERT(e != nullptr);
 			m_regEdgeArrays.keyAdded(e);
 			m_regAdjArrays.keyAdded(e->adjSource());
+			m_regAdjArrays.keyAdded(e->adjTarget());
 			edgeInserted(cbData, eG, e);
 			for (GraphObserver* obs : getObservers()) {
 				obs->edgeAdded(e);
@@ -287,6 +289,7 @@ std::pair<int, int> Graph::insert(const NI& nodesBegin, const NI& nodesEnd, cons
 				}
 				m_regEdgeArrays.keyAdded(e);
 				m_regAdjArrays.keyAdded(e->adjSource());
+				m_regAdjArrays.keyAdded(e->adjTarget());
 				edgeInserted(cbData, eG, e);
 				for (GraphObserver* obs : getObservers()) {
 					obs->edgeAdded(e);

--- a/include/ogdf/basic/Observer.h
+++ b/include/ogdf/basic/Observer.h
@@ -87,6 +87,11 @@ public:
 	OGDF_NO_MOVE(Observer)
 
 	//! Associates observer instance with instance \p obs.
+	/**
+	 * This always unregisters and reregisters the observer, even if \p obs == getObserved().
+	 * Consequently, this observer will always be the last in the list to be notified of events.
+	 * Furthermore, registrationChanged() will always be fired when this method is called.
+	 */
 	void reregister(const TObserved* obs) {
 		const TObserved* old = m_pObserved;
 		if (m_pObserved) {

--- a/include/ogdf/basic/Observer.h
+++ b/include/ogdf/basic/Observer.h
@@ -59,7 +59,8 @@ public:
 	 */
 	Observer() = default;
 
-	OGDF_DEPRECATED("calls registrationChanged with only partially-constructed child classes")
+	OGDF_DEPRECATED("calls registrationChanged with only partially-constructed child classes, "
+					"see copy constructor of Observer for fix")
 
 	explicit Observer(const TObserved* R) { reregister(R); }
 

--- a/include/ogdf/basic/RegisteredArray.h
+++ b/include/ogdf/basic/RegisteredArray.h
@@ -80,7 +80,8 @@ public:
 	//! Constructs instance of RegisteredObserver class
 	RegisteredObserver() = default;
 
-	OGDF_DEPRECATED("calls registrationChanged with only partially-constructed child classes")
+	OGDF_DEPRECATED("calls registrationChanged with only partially-constructed child classes, "
+					"see copy constructor of Observer for fix")
 
 	explicit RegisteredObserver(const Registry* R) { Obs::reregister(R); }
 

--- a/include/ogdf/basic/RegisteredArray.h
+++ b/include/ogdf/basic/RegisteredArray.h
@@ -58,7 +58,7 @@ template<typename Registry>
 class RegisteredArrayBase;
 }
 template<typename Key, typename Registry, typename Iterator = void>
-class RegistryBase;
+class RegistryBase; // IWYU pragma: keep
 
 //! The default minimum table size for registered arrays.
 static constexpr int MIN_TABLE_SIZE = (1 << 4);

--- a/include/ogdf/basic/RegisteredArray.h
+++ b/include/ogdf/basic/RegisteredArray.h
@@ -73,7 +73,7 @@ inline int calculateTableSize(int actualCount) {
 
 //! Abstract Base class for registry observers.
 template<typename Registry>
-class OGDF_EXPORT RegisteredObserver : public Observer<Registry, RegisteredObserver<Registry>> {
+class RegisteredObserver : public Observer<Registry, RegisteredObserver<Registry>> {
 	using Obs = Observer<Registry, RegisteredObserver<Registry>>;
 
 public:

--- a/include/ogdf/basic/RegisteredArray.h
+++ b/include/ogdf/basic/RegisteredArray.h
@@ -32,6 +32,7 @@
 #pragma once
 
 #include <ogdf/basic/Math.h>
+#include <ogdf/basic/Observer.h>
 #include <ogdf/basic/basic.h>
 #include <ogdf/basic/internal/config_autogen.h>
 #include <ogdf/basic/memory.h>
@@ -56,6 +57,8 @@ namespace internal {
 template<typename Registry>
 class RegisteredArrayBase;
 }
+template<typename Key, typename Registry, typename Iterator = void>
+class RegistryBase;
 
 //! The default minimum table size for registered arrays.
 static constexpr int MIN_TABLE_SIZE = (1 << 4);
@@ -67,6 +70,37 @@ static constexpr int MIN_TABLE_SIZE = (1 << 4);
 inline int calculateTableSize(int actualCount) {
 	return Math::nextPower2(MIN_TABLE_SIZE, actualCount);
 }
+
+//! Abstract Base class for registry observers.
+template<typename Registry>
+class OGDF_EXPORT RegisteredObserver : public Observer<Registry, RegisteredObserver<Registry>> {
+	using Obs = Observer<Registry, RegisteredObserver<Registry>>;
+
+public:
+	//! Constructs instance of RegisteredObserver class
+	RegisteredObserver() = default;
+
+	OGDF_DEPRECATED("calls registrationChanged with only partially-constructed child classes")
+
+	explicit RegisteredObserver(const Registry* R) { Obs::reregister(R); }
+
+	//! Called by watched registry just before a key is deleted.
+	virtual void keyRemoved(typename Registry::key_type v) = 0;
+
+	//! Called by watched registry after a key has been added.
+	virtual void keyAdded(typename Registry::key_type v) = 0;
+
+	//! Called when an entry is swapped between \p index1 and \p index2 in all registered arrays.
+	virtual void keysSwapped(int index1, int index2) = 0;
+
+	//! Called when an entry is copied from \p fromIndex to \p toIndex in all registered arrays.
+	virtual void keysCopied(int toIndex, int fromIndex) = 0;
+
+	//! Called by watched registry when its clear function is called, just before things are removed.
+	virtual void keysCleared() = 0;
+
+	const Registry* getRegistry() const { return Obs::getObserved(); }
+};
 
 //! Abstract base class for registries.
 /**
@@ -100,8 +134,8 @@ inline int calculateTableSize(int actualCount) {
  *
  * \sa RegisteredArray
  */
-template<typename Key, typename Registry, typename Iterator = void>
-class RegistryBase {
+template<typename Key, typename Registry, typename Iterator> // default Iterator=void defined above
+class RegistryBase : public Observable<RegisteredObserver<Registry>, Registry> {
 public:
 	using registered_array_type = internal::RegisteredArrayBase<Registry>;
 	using key_type = Key;
@@ -112,6 +146,8 @@ public:
 	using registration_iterator_type = typename registration_list_type::iterator;
 
 private:
+	using Obs = Observable<RegisteredObserver<Registry>, Registry>;
+
 	mutable registration_list_type m_registeredArrays;
 	bool m_autoShrink = false;
 	int m_size = 0;
@@ -125,15 +161,10 @@ protected:
 
 public:
 	//! Destructor. Unregisters all associated arrays.
-	virtual ~RegistryBase() noexcept { unregisterArrays(); }
-
-	RegistryBase(const RegistryBase& copy) = delete;
-
-	RegistryBase(RegistryBase&& move) noexcept = delete;
-
-	RegistryBase& operator=(const RegistryBase& other) = delete;
-
-	RegistryBase& operator=(RegistryBase&& other) noexcept = delete;
+	virtual ~RegistryBase() noexcept {
+		Obs::clearObservers();
+		unregisterArrays();
+	}
 
 	//! Registers a new array with this registry.
 	/**
@@ -172,6 +203,9 @@ public:
 		if (static_cast<Registry*>(this)->keyToIndex(key) >= m_size) {
 			resizeArrays();
 		}
+		for (auto& ob : getObservers()) {
+			ob->keyAdded(key);
+		}
 	}
 
 	//! Records the deletion of a key and resizes all registered arrays if auto shrink is enabled.
@@ -179,10 +213,18 @@ public:
 		if (m_autoShrink) {
 			resizeArrays();
 		}
+		for (auto& ob : getObservers()) {
+			ob->keyRemoved(key);
+		}
 	}
 
 	//! Records that all keys have been cleared. If auto shrink is enabled, all arrays are cleared and resized to 0.
-	void keysCleared() { resizeArrays(0); }
+	void keysCleared() {
+		resizeArrays(0);
+		for (auto& ob : getObservers()) {
+			ob->keysCleared();
+		}
+	}
 
 	//! Resizes all arrays to the size requested by calculateArraySize(). Only shrinks the arrays if auto shrink is
 	//! enabled
@@ -212,12 +254,18 @@ public:
 		for (registered_array_type* ab : m_registeredArrays) {
 			ab->swapEntries(index1, index2);
 		}
+		for (auto& ob : getObservers()) {
+			ob->keysSwapped(index1, index2);
+		}
 	}
 
 	//! Copies the entry from \p fromIndex to \p toIndex in all registered arrays.
 	void copyArrayEntries(int toIndex, int fromIndex) {
 		for (registered_array_type* ab : m_registeredArrays) {
 			ab->copyEntry(toIndex, fromIndex);
+		}
+		for (auto& ob : getObservers()) {
+			ob->keysCopied(fromIndex, toIndex);
 		}
 	}
 
@@ -243,6 +291,8 @@ public:
 
 	//! Returns the current size of all registered arrays.
 	int getArraySize() const { return m_size; }
+
+	using Obs::getObservers;
 };
 
 namespace internal {
@@ -581,7 +631,8 @@ protected:
 	}
 
 	void swapEntries(int index1, int index2) override {
-		std::swap(m_data.at(index1), m_data.at(index2));
+		using std::swap;
+		swap(m_data.at(index1), m_data.at(index2));
 	}
 
 	//! This operation is not supported for registered arrays without default.

--- a/include/ogdf/basic/RegisteredSet.h
+++ b/include/ogdf/basic/RegisteredSet.h
@@ -35,6 +35,21 @@
 
 #include <type_traits>
 
+#define OGDF_REGSET_CONSTR(ClassName, ParentName)                             \
+	/** Creates an empty set associated with no graph. */                     \
+	using ParentName::ParentName;                                             \
+	explicit ClassName() = default;                                           \
+	explicit ClassName(const ClassName<true>& other) : ParentName(other) { }  \
+	explicit ClassName(const ClassName<false>& other) : ParentName(other) { } \
+	ClassName& operator=(const ClassName<false>& other) {                     \
+		ParentName::assignFrom(other);                                        \
+		return *this;                                                         \
+	}                                                                         \
+	ClassName& operator=(const ClassName<true>& other) {                      \
+		ParentName::assignFrom(other);                                        \
+		return *this;                                                         \
+	}
+
 namespace ogdf {
 
 //! Constant-time set operations.

--- a/include/ogdf/basic/RegisteredSet.h
+++ b/include/ogdf/basic/RegisteredSet.h
@@ -35,20 +35,7 @@
 
 #include <type_traits>
 
-#define OGDF_REGSET_CONSTR(ClassName, ParentName)                             \
-	/** Creates an empty set associated with no graph. */                     \
-	using ParentName::ParentName;                                             \
-	explicit ClassName() = default;                                           \
-	explicit ClassName(const ClassName<true>& other) : ParentName(other) { }  \
-	explicit ClassName(const ClassName<false>& other) : ParentName(other) { } \
-	ClassName& operator=(const ClassName<false>& other) {                     \
-		ParentName::assignFrom(other);                                        \
-		return *this;                                                         \
-	}                                                                         \
-	ClassName& operator=(const ClassName<true>& other) {                      \
-		ParentName::assignFrom(other);                                        \
-		return *this;                                                         \
-	}
+#define OGDF_REGSET_CONSTR(ClassName, ParentName) using ParentName::ParentName;
 
 namespace ogdf {
 

--- a/include/ogdf/basic/RegisteredSet.h
+++ b/include/ogdf/basic/RegisteredSet.h
@@ -32,8 +32,8 @@
 
 #include <ogdf/basic/List.h>
 #include <ogdf/basic/RegisteredArray.h>
-
-#include <type_traits>
+#include <ogdf/basic/basic.h>
+#include <ogdf/basic/internal/copy_move.h>
 
 namespace ogdf {
 

--- a/include/ogdf/basic/pctree/PCEnum.h
+++ b/include/ogdf/basic/pctree/PCEnum.h
@@ -50,8 +50,7 @@ class OGDF_EXPORT PCTreeRegistry;
 OGDF_DECL_REG_ARRAY(PCTreeNodeArray)
 #undef OGDF_DECL_REG_ARRAY_TYPE
 
-template<bool SupportFastSizeQuery = true>
-using PCTreeNodeSet = ogdf::RegisteredSet<PCTreeRegistry, SupportFastSizeQuery>;
+using PCTreeNodeSet = ogdf::RegisteredSet<PCTreeRegistry>;
 
 OGDF_EXPORT std::ostream& operator<<(std::ostream&, ogdf::pc_tree::NodeLabel);
 

--- a/include/ogdf/cluster/ClusterGraph.h
+++ b/include/ogdf/cluster/ClusterGraph.h
@@ -344,10 +344,12 @@ public:
  * clustering of the nodes in a graph, providing additional functionality.
  */
 class OGDF_EXPORT ClusterGraph
-	: public GraphObserver, // to get updates when graph nodes/edges added/removed
+	: private GraphObserver, // to get updates when graph nodes/edges added/removed
 	  public Observable<ClusterGraphObserver, ClusterGraph>, // to publish updates when clusters added/removed
 	  public ClusterGraphRegistry // for ClusterArrays
 {
+	using Obs = Observable<ClusterGraphObserver, ClusterGraph>;
+
 	int m_clusterIdCount = 0; //!< The index assigned to the next created cluster.
 
 	mutable cluster m_postOrderStart = nullptr; //!< The first cluster in postorder.
@@ -435,6 +437,8 @@ public:
 	 * @name Access methods
 	 */
 	//! @{
+
+	using GraphObserver::getGraph;
 
 	//! Returns the root cluster.
 	cluster rootCluster() const { return m_rootCluster; }
@@ -866,6 +870,14 @@ protected:
 	}
 
 	void registrationChanged(const Graph* newG) override;
+
+	// need to re-export both to allow parameter-type-based overload in the same namespace
+	friend Observer<ClusterGraph, ClusterGraphObserver>;
+	friend Observer<ClusterGraph, RegisteredObserver<ClusterGraph>>;
+	using ClusterGraphRegistry::registerObserver;
+	using ClusterGraphRegistry::unregisterObserver;
+	using Obs::registerObserver;
+	using Obs::unregisterObserver;
 
 	//! @}
 

--- a/include/ogdf/cluster/ClusterGraph.h
+++ b/include/ogdf/cluster/ClusterGraph.h
@@ -327,6 +327,9 @@ class OGDF_EXPORT ClusterGraphObserver : public Observer<ClusterGraph, ClusterGr
 public:
 	ClusterGraphObserver() = default;
 
+	OGDF_DEPRECATED("calls registrationChanged with only partially-constructed child classes, "
+					"see copy constructor of Observer for fix")
+
 	explicit ClusterGraphObserver(const ClusterGraph* CG) { reregister(CG); }
 
 	virtual void clusterDeleted(cluster v) = 0;

--- a/include/ogdf/cluster/ClusterSet.h
+++ b/include/ogdf/cluster/ClusterSet.h
@@ -43,22 +43,17 @@ namespace ogdf {
  * A cluster set maintains a subset \a S of the clusters contained in an associated
  * clustered graph. This kind of cluster set provides efficient operations for testing
  * membership, insertion and deletion of elements, and clearing the set.
- *
- * @tparam SupportFastSizeQuery Whether this set supports querying its #size in
- * constant instead of linear time (in the size).
  */
-template<bool SupportFastSizeQuery = true>
-class ClusterSet : public RegisteredSet<ClusterGraph, SupportFastSizeQuery> {
-	using RS = RegisteredSet<ClusterGraph, SupportFastSizeQuery>;
-
+class OGDF_EXPORT ClusterSet : public RegisteredSet<ClusterGraph> {
 public:
-	OGDF_REGSET_CONSTR(ClusterSet, RS)
+	using RegisteredSet::RegisteredSet;
+	OGDF_DEFAULT_COPY(ClusterSet);
 
 	//! Returns a reference to the list of clusters contained in \a S.
 	/**
 	 * This list can be used for iterating over all clusters in \a S.
 	 */
-	const typename RS::list_type& clusters() const { return RS::elements(); }
+	const list_type& clusters() const { return elements(); }
 };
 
 }

--- a/include/ogdf/cluster/ClusterSet.h
+++ b/include/ogdf/cluster/ClusterSet.h
@@ -32,6 +32,7 @@
 #pragma once
 
 #include <ogdf/basic/RegisteredSet.h>
+#include <ogdf/basic/basic.h>
 #include <ogdf/cluster/ClusterGraph.h>
 
 namespace ogdf {

--- a/include/ogdf/cluster/ClusterSet.h
+++ b/include/ogdf/cluster/ClusterSet.h
@@ -52,7 +52,7 @@ class ClusterSet : public RegisteredSet<ClusterGraph, SupportFastSizeQuery> {
 	using RS = RegisteredSet<ClusterGraph, SupportFastSizeQuery>;
 
 public:
-	using RS::RS;
+	OGDF_REGSET_CONSTR(ClusterSet, RS)
 
 	//! Returns a reference to the list of clusters contained in \a S.
 	/**

--- a/include/ogdf/cluster/sync_plan/ClusterPlanarity.h
+++ b/include/ogdf/cluster/sync_plan/ClusterPlanarity.h
@@ -95,7 +95,7 @@ OGDF_EXPORT void reduceLevelPlanarityToClusterPlanarity(const Graph& LG,
  * @sa SyncPlan::SyncPlan(Graph*, ClusterGraph*, std::vector<std::pair<adjEntry, adjEntry>>*, ClusterGraphAttributes*)
  */
 OGDF_EXPORT void insertAugmentationEdges(const ClusterGraph& CG, Graph& G,
-		std::vector<std::pair<adjEntry, adjEntry>>& augmentation, EdgeSet<>* added = nullptr,
+		std::vector<std::pair<adjEntry, adjEntry>>& augmentation, EdgeSet* added = nullptr,
 		bool embedded = true, bool assert_minimal = true);
 
 }

--- a/include/ogdf/cluster/sync_plan/PMatching.h
+++ b/include/ogdf/cluster/sync_plan/PMatching.h
@@ -93,7 +93,7 @@ private:
 	std::unique_ptr<PipeQueue> queue;
 
 public:
-	explicit PMatching(const Graph* G) : GraphObserver(G), nodes(*G, nullptr) { }
+	explicit PMatching(const Graph* G) : GraphObserver(), nodes(*G, nullptr) { reregister(G); }
 
 	bool isMatchedPVertex(node n) const;
 

--- a/include/ogdf/cluster/sync_plan/QPartitioning.h
+++ b/include/ogdf/cluster/sync_plan/QPartitioning.h
@@ -54,8 +54,9 @@ private:
 public:
 	static inline int NO_PARTITION = -1;
 
-	explicit QPartitioning(const Graph* G) : GraphObserver(G), partitions(*G, NO_PARTITION) {
+	explicit QPartitioning(const Graph* G) : GraphObserver(), partitions(*G, NO_PARTITION) {
 		partitioned_nodes.init(*this);
+		reregister(G);
 	}
 
 	bool isQVertex(node n) const;

--- a/include/ogdf/cluster/sync_plan/SyncPlan.h
+++ b/include/ogdf/cluster/sync_plan/SyncPlan.h
@@ -220,7 +220,7 @@ private:
 	Graph::HiddenEdgeSet deletedEdges;
 #ifdef OGDF_DEBUG
 	//! Set of all node objects deleted during the reduction. Will remain as isolated nodes within \p G.
-	NodeSet<> deletedNodes;
+	NodeSet deletedNodes;
 #endif
 	//! If non-null, will be updated with debugging information from applied operations.
 	GraphAttributes* GA;

--- a/include/ogdf/cluster/sync_plan/SyncPlanComponents.h
+++ b/include/ogdf/cluster/sync_plan/SyncPlanComponents.h
@@ -158,7 +158,7 @@ private:
 class OGDF_EXPORT BiconnectedIsolation {
 	SyncPlanComponents& m_comps;
 	node m_bicon;
-	NodeSet<true> m_to_restore;
+	NodeSet m_to_restore;
 	NodeArray<SListPure<adjEntry>> m_adjEntries; // room for improvement: replace by contiguous vector + indices
 	Graph::HiddenEdgeSet m_hiddenEdges;
 

--- a/include/ogdf/cluster/sync_plan/SyncPlan_operation/Simplify.h
+++ b/include/ogdf/cluster/sync_plan/SyncPlan_operation/Simplify.h
@@ -31,13 +31,16 @@
 #pragma once
 
 #include <ogdf/basic/Graph.h>
-#include <ogdf/basic/GraphSets.h>
 #include <ogdf/basic/List.h>
 #include <ogdf/basic/SList.h>
 #include <ogdf/cluster/sync_plan/SyncPlan.h>
 
 #include <functional>
 #include <iosfwd>
+
+namespace ogdf {
+class EdgeSet;
+} // namespace ogdf
 
 namespace ogdf::pc_tree {
 class NodePCRotation;

--- a/include/ogdf/cluster/sync_plan/SyncPlan_operation/Simplify.h
+++ b/include/ogdf/cluster/sync_plan/SyncPlan_operation/Simplify.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <ogdf/basic/Graph.h>
+#include <ogdf/basic/GraphSets.h>
 #include <ogdf/basic/List.h>
 #include <ogdf/basic/SList.h>
 #include <ogdf/cluster/sync_plan/SyncPlan.h>
@@ -41,11 +42,6 @@
 namespace ogdf::pc_tree {
 class NodePCRotation;
 } // namespace ogdf::pc_tree
-
-namespace ogdf {
-template<bool>
-class EdgeSet;
-} // namespace ogdf
 
 namespace ogdf::sync_plan {
 
@@ -102,7 +98,7 @@ int findCycles(Graph& G, node u, const std::function<adjEntry(adjEntry)>& mappin
  * @param dfs_stack continuation points for the dfs
  * @return an adjEntry of \p v reachable from \p dfs_stack.back() via previously unvisited edges
  */
-adjEntry continueNodeDFS(Graph& G, adjEntry u_adj, node v, EdgeSet<>& visited,
+adjEntry continueNodeDFS(Graph& G, adjEntry u_adj, node v, EdgeSet& visited,
 		List<adjEntry>& dfs_stack);
 
 /**
@@ -114,8 +110,7 @@ adjEntry continueNodeDFS(Graph& G, adjEntry u_adj, node v, EdgeSet<>& visited,
  * If you want to find a further alternative adjEntries that match this criterion, pop the last entry
  * off the stack and call continueNodeDFS (see also exhaustiveNodeDFS).
  */
-adjEntry startNodeDFS(Graph& G, adjEntry u_adj, node v, EdgeSet<>& visited,
-		List<adjEntry>& dfs_stack);
+adjEntry startNodeDFS(Graph& G, adjEntry u_adj, node v, EdgeSet& visited, List<adjEntry>& dfs_stack);
 
 /**
  * Use a DFS to find all edges incident to \p v reachable from \p u_adj without crossing the node u and add them to \p out.
@@ -123,14 +118,14 @@ adjEntry startNodeDFS(Graph& G, adjEntry u_adj, node v, EdgeSet<>& visited,
  * and the edge incident to v found in the end) are added to the set \p visited.
  * Calls startNodeDFS once and then repeatedly calls continueNodeDFS until no new adjEntry is found.
  */
-int exhaustiveNodeDFS(Graph& G, adjEntry u_adj, node v, EdgeSet<>& visited, List<adjEntry>& out);
+int exhaustiveNodeDFS(Graph& G, adjEntry u_adj, node v, EdgeSet& visited, List<adjEntry>& out);
 
 #ifdef OGDF_DEBUG
 
 /**
  * Check that the method exhaustiveNodeDFS would return the same adjEntries as contained in \p found.
  */
-bool compareWithExhaustiveNodeDFS(Graph& G, adjEntry u_adj, node v, const EdgeSet<>& visited,
+bool compareWithExhaustiveNodeDFS(Graph& G, adjEntry u_adj, node v, const EdgeSet& visited,
 		const List<adjEntry>& found);
 
 /**
@@ -142,7 +137,7 @@ void validatePartnerPCTree(const NodePCRotation* u_pc, const NodePCRotation* v_p
 /**
  * Check that /p bij_list contains all adjEntries of \p v which belong to a parallel bundle leading to \p u.
  */
-bool validateCollectedAdjs(node v, node u, List<SimplifyMapping>& bij_list, EdgeSet<>& visited,
+bool validateCollectedAdjs(node v, node u, List<SimplifyMapping>& bij_list, EdgeSet& visited,
 		SyncPlanComponents& components);
 
 #endif

--- a/include/ogdf/geometric/CrossingMinimalPosition.h
+++ b/include/ogdf/geometric/CrossingMinimalPosition.h
@@ -66,7 +66,7 @@ class GraphAttributes;
  * \pre Requires CGAL! See README.md in this folder.
  */
 template<typename FT>
-class OGDF_EXPORT CrossingMinimalPosition : public VertexPositionModule {
+class CrossingMinimalPosition : public VertexPositionModule {
 public: // ~Initialize vertex position module
 	CrossingMinimalPosition() { }
 

--- a/include/ogdf/graphalg/MaximumDensitySubgraph.h
+++ b/include/ogdf/graphalg/MaximumDensitySubgraph.h
@@ -65,7 +65,7 @@ namespace ogdf {
  * \p resultNodeMap can be used if \p subgraphNodes does not belong to \p G.
  * This helps when passing in a GraphCopy or GraphCopySimple:
  * \code
- * NodeSet<true> subgraphNodes(G);
+ * NodeSet subgraphNodes(G);
  * GraphCopySimple GC(G);
  * maximumDensitySubgraph(GC, subgraphNodes, [&](node n){ return GC.original(n);});
  * \endcode
@@ -81,7 +81,7 @@ namespace ogdf {
  * @returns true, if the algorithm was successful and did not run into a timeout.
  */
 OGDF_EXPORT bool maximumDensitySubgraph(
-		Graph& G, NodeSet<true>& subgraphNodes,
+		Graph& G, NodeSet& subgraphNodes,
 		std::function<node(node)> resultNodeMap = [](node v) { return v; }, int64_t timelimit = -1);
 
 }

--- a/include/ogdf/graphalg/MaximumDensitySubgraph.h
+++ b/include/ogdf/graphalg/MaximumDensitySubgraph.h
@@ -32,13 +32,13 @@
 #pragma once
 
 #include <ogdf/basic/Graph.h>
-#include <ogdf/basic/GraphSets.h>
 #include <ogdf/basic/basic.h>
 
 #include <cstdint>
 #include <functional>
 
 namespace ogdf {
+class NodeSet;
 
 /**
  * \brief Calculates the maximum density subgraph of \p G

--- a/include/ogdf/graphalg/MinSteinerTreeShore.h
+++ b/include/ogdf/graphalg/MinSteinerTreeShore.h
@@ -99,7 +99,7 @@ private:
 	const List<node>* m_originalTerminals;
 
 	Graph m_graph;
-	std::unique_ptr<NodeSet<>> m_terminals;
+	std::unique_ptr<NodeSet> m_terminals;
 	EdgeArray<edge> m_mapping;
 	T m_upperBound;
 	Array2D<edge> m_edges;
@@ -281,7 +281,7 @@ T MinSteinerTreeShore<T>::computeSteinerTree(const EdgeWeightedGraph<T>& G,
 	m_upperBound = MAX_WEIGHT;
 	m_graph.clear();
 	m_mapping.init(m_graph);
-	m_terminals.reset(new NodeSet<>(m_graph));
+	m_terminals.reset(new NodeSet(m_graph));
 	int nodeCount = m_originalGraph->numberOfNodes();
 	m_edges = Array2D<edge>(0, nodeCount, 0, nodeCount, nullptr);
 

--- a/include/ogdf/graphalg/NodeColoringModule.h
+++ b/include/ogdf/graphalg/NodeColoringModule.h
@@ -214,7 +214,7 @@ protected:
 	 */
 	template<class CONTAINER>
 	bool checkIndependentSet(const Graph& graph, const CONTAINER& nodes) const {
-		NodeSet<false> nodeSet(graph);
+		NodeSet nodeSet(graph);
 		for (node v : nodes) {
 			nodeSet.insert(v);
 		}

--- a/include/ogdf/graphalg/SpannerBaswanaSen.h
+++ b/include/ogdf/graphalg/SpannerBaswanaSen.h
@@ -137,7 +137,7 @@ private:
 	 */
 	void phase1() {
 		// init
-		NodeSet<true> clusterCenters(m_G);
+		NodeSet clusterCenters(m_G);
 		for (node v : m_G.nodes) {
 			m_cluster[v] = v; // At the beginning each node is it's own cluster
 			clusterCenters.insert(v);
@@ -158,7 +158,7 @@ private:
 			NodeArray<node> oldCluster = m_cluster; // oldCluster is the cluster of iteration i-1
 
 			// 1: Sample new cluster centers
-			NodeSet<true> sampledClusterCenters(m_G);
+			NodeSet sampledClusterCenters(m_G);
 			for (node oldCenter : clusterCenters.nodes()) {
 				if (randomDouble(0.0, 1.0) <= probability) {
 					sampledClusterCenters.insert(oldCenter);

--- a/include/ogdf/graphalg/SpannerKortsarzPeleg.h
+++ b/include/ogdf/graphalg/SpannerKortsarzPeleg.h
@@ -121,7 +121,7 @@ private:
 		while (true) {
 			node maxNode = nullptr;
 			double maxDensity = 0.0;
-			NodeSet<true> maxDenseSubset(m_GA->constGraph());
+			NodeSet maxDenseSubset(m_GA->constGraph());
 			List<edge> maxE_U; // holds the edges of the maximum dense subgraph
 
 			for (node v : m_G.nodes) {
@@ -140,7 +140,7 @@ private:
 				}
 
 				// Calculate dense subgraph and find all edges E_U of this subgraph
-				NodeSet<true> denseSubset(m_G);
+				NodeSet denseSubset(m_G);
 				int64_t timelimit = -1;
 				if (isTimelimitEnabled()) {
 					timelimit = max(static_cast<int64_t>(0), getTimeLeft());

--- a/include/ogdf/hypergraph/Hypergraph.h
+++ b/include/ogdf/hypergraph/Hypergraph.h
@@ -141,7 +141,7 @@ public:
 
 	OGDF_NEW_DELETE;
 
-	friend std::ostream& operator<<(std::ostream& os, ogdf::adjHypergraphEntry v);
+	friend OGDF_EXPORT std::ostream& operator<<(std::ostream& os, ogdf::adjHypergraphEntry v);
 };
 
 //! Class for the representation of hyperedges.
@@ -219,7 +219,7 @@ public:
 		return e->index() == m_index && e->hypergraph() == m_hypergraph;
 	}
 
-	friend std::ostream& operator<<(std::ostream& os, ogdf::hyperedge v);
+	friend OGDF_EXPORT std::ostream& operator<<(std::ostream& os, ogdf::hyperedge v);
 
 	OGDF_NEW_DELETE;
 };
@@ -325,7 +325,7 @@ public:
 
 	OGDF_NEW_DELETE;
 
-	friend std::ostream& operator<<(std::ostream& os, ogdf::hypernode v);
+	friend OGDF_EXPORT std::ostream& operator<<(std::ostream& os, ogdf::hypernode v);
 };
 
 //! Registry for nodes and edges of a hypergraph.
@@ -581,9 +581,9 @@ public:
 
 	Hypergraph& operator=(const Hypergraph& H);
 
-	friend std::ostream& operator<<(std::ostream& os, ogdf::Hypergraph& H);
+	friend OGDF_EXPORT std::ostream& operator<<(std::ostream& os, ogdf::Hypergraph& H);
 
-	friend std::istream& operator>>(std::istream& is, ogdf::Hypergraph& H);
+	friend OGDF_EXPORT std::istream& operator>>(std::istream& is, ogdf::Hypergraph& H);
 
 	OGDF_MALLOC_NEW_DELETE;
 

--- a/include/ogdf/hypergraph/Hypergraph.h
+++ b/include/ogdf/hypergraph/Hypergraph.h
@@ -219,7 +219,7 @@ public:
 		return e->index() == m_index && e->hypergraph() == m_hypergraph;
 	}
 
-	friend OGDF_EXPORT std::ostream& operator<<(std::ostream& os, ogdf::hyperedge v);
+	friend OGDF_EXPORT std::ostream& operator<<(std::ostream& os, ogdf::hyperedge e);
 
 	OGDF_NEW_DELETE;
 };

--- a/include/ogdf/hypergraph/Hypergraph.h
+++ b/include/ogdf/hypergraph/Hypergraph.h
@@ -140,6 +140,8 @@ public:
 	adjHypergraphEntry cyclicPred() const;
 
 	OGDF_NEW_DELETE;
+
+	friend std::ostream& operator<<(std::ostream& os, ogdf::adjHypergraphEntry v);
 };
 
 //! Class for the representation of hyperedges.
@@ -217,7 +219,7 @@ public:
 		return e->index() == m_index && e->hypergraph() == m_hypergraph;
 	}
 
-	friend std::ostream& operator<<(std::ostream& os, ogdf::hyperedge e);
+	friend std::ostream& operator<<(std::ostream& os, ogdf::hyperedge v);
 
 	OGDF_NEW_DELETE;
 };
@@ -322,6 +324,8 @@ public:
 	}
 
 	OGDF_NEW_DELETE;
+
+	friend std::ostream& operator<<(std::ostream& os, ogdf::hypernode v);
 };
 
 //! Registry for nodes and edges of a hypergraph.

--- a/include/ogdf/hypergraph/HypergraphObserver.h
+++ b/include/ogdf/hypergraph/HypergraphObserver.h
@@ -52,6 +52,9 @@ public:
 	HypergraphObserver() = default;
 
 	//! Constructor assigning \p pH hypergraph to the observer.
+	OGDF_DEPRECATED("calls registrationChanged with only partially-constructed child classes, "
+					"see copy constructor of Observer for fix")
+
 	explicit HypergraphObserver(const Hypergraph* pH) { reregister(pH); }
 
 	//! Associates an observer instance with hypergraph \p pH

--- a/include/ogdf/labeling/ELabelInterface.h
+++ b/include/ogdf/labeling/ELabelInterface.h
@@ -65,7 +65,7 @@ enum class UsedLabels {
 // the basic single label defining class
 // holds info about all labels for one edge
 template<class coordType>
-class OGDF_EXPORT EdgeLabel {
+class EdgeLabel {
 public:
 	static const int numberUsedLabels = static_cast<int>(UsedLabels::lAll);
 

--- a/include/ogdf/lib/abacus/poolslot.h
+++ b/include/ogdf/lib/abacus/poolslot.h
@@ -74,7 +74,7 @@ template<class BaseType, class CoType> class CutBuffer;
  * of the optimization process, except that it can be guaranteed that
  * there is no reference to this slot from any other place of the program.
  */
-template<class BaseType, class CoType> class OGDF_EXPORT PoolSlot : public AbacusRoot {
+template<class BaseType, class CoType> class PoolSlot : public AbacusRoot {
 
 	friend class PoolSlotRef<BaseType,CoType>;
 	friend class Pool<BaseType,CoType>;

--- a/include/ogdf/planarity/MMFixedEmbeddingInserter.h
+++ b/include/ogdf/planarity/MMFixedEmbeddingInserter.h
@@ -219,7 +219,7 @@ private:
 	 * @param nsParent is the parent node split.
 	 * @param PG is the planarized expansion.
 	 */
-	void collectAnchorNodes(node v, NodeSet<>& nodes, const PlanRepExpansion::NodeSplit* nsParent,
+	void collectAnchorNodes(node v, NodeSet& nodes, const PlanRepExpansion::NodeSplit* nsParent,
 			const PlanRepExpansion& PG) const;
 
 	/**
@@ -229,7 +229,7 @@ private:
 	 * @param nodes ia assigned the set of anchor nodes.
 	 * @param PG is the planarized expansion.
 	 */
-	void anchorNodes(node vOrig, NodeSet<>& nodes, const PlanRepExpansion& PG) const;
+	void anchorNodes(node vOrig, NodeSet& nodes, const PlanRepExpansion& PG) const;
 
 	/**
 	 * \brief Finds the set of anchor nodes of \p src and \p tgt.
@@ -240,7 +240,7 @@ private:
 	 * @param targets ia assigned the set of anchor nodes of \p tgt's original node.
 	 * @param PG is the planarized expansion.
 	 */
-	void findSourcesAndTargets(node src, node tgt, NodeSet<>& sources, NodeSet<>& targets,
+	void findSourcesAndTargets(node src, node tgt, NodeSet& sources, NodeSet& targets,
 			const PlanRepExpansion& PG) const;
 
 	/**
@@ -249,7 +249,7 @@ private:
 	 * @param sources is a set of anchor nodes.
 	 * @param targets is a set of anchor nodes.
 	 */
-	node commonDummy(NodeSet<>& sources, NodeSet<>& targets);
+	node commonDummy(NodeSet& sources, NodeSet& targets);
 
 	//! Performs several consistency checks on the seach network.
 	bool checkDualGraph(PlanRepExpansion& PG, const CombinatorialEmbedding& E) const;
@@ -308,9 +308,9 @@ private:
 	node m_vT; //!< Represents the end node for the path search.
 	int m_maxCost; //!< The maximal cost of an edge in the search network + 1.
 
-	FaceSet<false>* m_delFaces;
-	FaceSet<false>* m_newFaces;
-	NodeSet<false>* m_mergedNodes;
+	FaceSet* m_delFaces;
+	FaceSet* m_newFaces;
+	NodeSet* m_mergedNodes;
 };
 
 }

--- a/include/ogdf/planarity/MMFixedEmbeddingInserter.h
+++ b/include/ogdf/planarity/MMFixedEmbeddingInserter.h
@@ -32,15 +32,15 @@
 #pragma once
 
 #include <ogdf/basic/CombinatorialEmbedding.h>
-#include <ogdf/basic/FaceSet.h>
 #include <ogdf/basic/Graph.h>
-#include <ogdf/basic/GraphSets.h>
 #include <ogdf/basic/basic.h>
 #include <ogdf/planarity/MMEdgeInsertionModule.h>
 #include <ogdf/planarity/PlanRepExpansion.h>
 #include <ogdf/planarity/RemoveReinsertType.h>
 
 namespace ogdf {
+class FaceSet;
+class NodeSet;
 template<class E1, class E2>
 class Tuple2;
 template<class E>

--- a/include/ogdf/planarity/MMVariableEmbeddingInserter.h
+++ b/include/ogdf/planarity/MMVariableEmbeddingInserter.h
@@ -142,8 +142,7 @@ private:
 	 * @param nodes is assigned the set of anchor nodes.
 	 * @param nsParent is the parent node split.
 	 */
-	void collectAnchorNodes(node v, NodeSet<>& nodes,
-			const PlanRepExpansion::NodeSplit* nsParent) const;
+	void collectAnchorNodes(node v, NodeSet& nodes, const PlanRepExpansion::NodeSplit* nsParent) const;
 
 	/**
 	 * \brief Finds the set of anchor nodes of \p src and \p tgt.
@@ -153,7 +152,7 @@ private:
 	 * @param sources ia assigned the set of anchor nodes of \p src's original node.
 	 * @param targets ia assigned the set of anchor nodes of \p tgt's original node.
 	 */
-	void findSourcesAndTargets(node src, node tgt, NodeSet<>& sources, NodeSet<>& targets) const;
+	void findSourcesAndTargets(node src, node tgt, NodeSet& sources, NodeSet& targets) const;
 
 	/**
 	 * \brief Returns all anchor nodes of \p vOrig in n\p nodes.
@@ -161,9 +160,9 @@ private:
 	 * @param vOrig is a node in the original graph.
 	 * @param nodes ia assigned the set of anchor nodes.
 	 */
-	void anchorNodes(node vOrig, NodeSet<>& nodes) const;
+	void anchorNodes(node vOrig, NodeSet& nodes) const;
 
-	static node commonDummy(NodeSet<>& sources, NodeSet<>& targets);
+	static node commonDummy(NodeSet& sources, NodeSet& targets);
 
 	/**
 	 * \brief Computes insertion path \p eip.
@@ -237,8 +236,8 @@ private:
 
 	PlanRepExpansion* m_pPG; //!< Pointer to the planarized expansion.
 
-	NodeSet<>* m_pSources; //!< The set of possible start nodes of an insertion path.
-	NodeSet<>* m_pTargets; //!< The set of possible end nodes of an insertion path.
+	NodeSet* m_pSources; //!< The set of possible start nodes of an insertion path.
+	NodeSet* m_pTargets; //!< The set of possible end nodes of an insertion path.
 
 	NodeArray<SList<int>> m_compV; //!< The list of blocks containing a node \a v.
 	Array<SList<node>> m_nodeB; //!< The list of nodes in block \a i.

--- a/include/ogdf/planarity/MMVariableEmbeddingInserter.h
+++ b/include/ogdf/planarity/MMVariableEmbeddingInserter.h
@@ -33,7 +33,6 @@
 
 #include <ogdf/basic/Array.h>
 #include <ogdf/basic/Graph.h>
-#include <ogdf/basic/GraphSets.h>
 #include <ogdf/basic/List.h>
 #include <ogdf/basic/SList.h>
 #include <ogdf/basic/basic.h>
@@ -42,6 +41,7 @@
 #include <ogdf/planarity/RemoveReinsertType.h>
 
 namespace ogdf {
+class NodeSet;
 
 //! Minor-monotone edge insertion with variable embedding.
 /**

--- a/include/ogdf/planarity/PlanRep.h
+++ b/include/ogdf/planarity/PlanRep.h
@@ -54,7 +54,6 @@ class CombinatorialEmbedding;
 class GridLayout;
 class Layout;
 class OrthoRep;
-template<bool>
 class FaceSet;
 template<class E>
 class List;
@@ -626,7 +625,7 @@ public:
 	/**
 	 * \pre \p eOrig s an edge in the original graph.
 	 */
-	void removeEdgePathEmbedded(CombinatorialEmbedding& E, edge eOrig, FaceSet<false>& newFaces) {
+	void removeEdgePathEmbedded(CombinatorialEmbedding& E, edge eOrig, FaceSet& newFaces) {
 		GraphCopy::removeEdgePathEmbedded(E, eOrig, newFaces);
 	}
 

--- a/include/ogdf/planarity/PlanRepExpansion.h
+++ b/include/ogdf/planarity/PlanRepExpansion.h
@@ -33,9 +33,7 @@
 #pragma once
 
 #include <ogdf/basic/Array.h>
-#include <ogdf/basic/FaceSet.h>
 #include <ogdf/basic/Graph.h>
-#include <ogdf/basic/GraphSets.h>
 #include <ogdf/basic/List.h>
 #include <ogdf/basic/SList.h>
 #include <ogdf/basic/basic.h>
@@ -44,6 +42,8 @@
 
 namespace ogdf {
 class CombinatorialEmbedding;
+class FaceSet;
+class NodeSet;
 template<class E1, class E2>
 class Tuple2;
 

--- a/include/ogdf/planarity/PlanRepExpansion.h
+++ b/include/ogdf/planarity/PlanRepExpansion.h
@@ -275,7 +275,7 @@ public:
 	 * \pre Not both \p eOrig and \p ns may be 0.
 	 */
 	void removeEdgePathEmbedded(CombinatorialEmbedding& E, edge eOrig, nodeSplit ns,
-			FaceSet<false>& newFaces, NodeSet<false>& mergedNodes, node& oldSrc, node& oldTgt);
+			FaceSet& newFaces, NodeSet& mergedNodes, node& oldSrc, node& oldTgt);
 
 	/**
 	 * \brief Removes the insertion path of \p eOrig or \p ns.

--- a/include/ogdf/planarity/embedder/EmbedderBCTreeBase.h
+++ b/include/ogdf/planarity/embedder/EmbedderBCTreeBase.h
@@ -46,7 +46,7 @@ namespace embedder {
 
 //! Common base for embedder algorithms based on BC trees.
 template<bool EnableLayers, bool IsEmbedderMinDepth = false>
-class OGDF_EXPORT EmbedderBCTreeBase : public EmbedderModule {
+class EmbedderBCTreeBase : public EmbedderModule {
 	using BicompEmbedder = typename std::conditional<EnableLayers,
 			EmbedderMaxFaceBiconnectedGraphsLayers<int>, EmbedderMaxFaceBiconnectedGraphs<int>>::type;
 

--- a/include/ogdf/planarity/embedding_inserter/FixEdgeInserterCore.h
+++ b/include/ogdf/planarity/embedding_inserter/FixEdgeInserterCore.h
@@ -96,8 +96,8 @@ protected:
 	EdgeArray<adjEntry> m_primalAdj; //!< Adjacency entry in primal graph corresponding to edge in dual.
 	FaceArray<node> m_nodeOf; //!< The node in dual corresponding to face in primal.
 
-	FaceSet<false>* m_delFaces;
-	FaceSet<false>* m_newFaces;
+	FaceSet* m_delFaces;
+	FaceSet* m_newFaces;
 
 	node m_vS; //!< The node in extended dual representing s.
 	node m_vT; //!< The node in extended dual representing t.

--- a/include/ogdf/planarity/embedding_inserter/FixEdgeInserterCore.h
+++ b/include/ogdf/planarity/embedding_inserter/FixEdgeInserterCore.h
@@ -34,7 +34,6 @@
 
 #include <ogdf/basic/Array.h>
 #include <ogdf/basic/CombinatorialEmbedding.h>
-#include <ogdf/basic/FaceSet.h>
 #include <ogdf/basic/Graph.h>
 #include <ogdf/basic/Module.h>
 #include <ogdf/basic/SList.h>
@@ -45,6 +44,7 @@
 #include <cstdint>
 
 namespace ogdf {
+class FaceSet;
 enum class RemoveReinsertType;
 template<class E>
 class QueuePure;

--- a/src/ogdf/basic/CombinatorialEmbedding.cpp
+++ b/src/ogdf/basic/CombinatorialEmbedding.cpp
@@ -102,7 +102,6 @@ void ConstCombinatorialEmbedding::init() {
 	m_faceIdCount = 0;
 	m_rightFace.init();
 	faces.clear();
-
 	keysCleared();
 }
 
@@ -319,8 +318,18 @@ face CombinatorialEmbedding::joinFaces(edge e) {
 
 	// we will reuse the largest face and delete the other one
 	if (f2->m_size > f1->m_size) {
-		std::swap(f1, f2);
+		return joinFaces(e->adjTarget());
+	} else {
+		return joinFaces(e->adjSource());
 	}
+}
+
+face CombinatorialEmbedding::joinFaces(adjEntry adj) {
+	OGDF_ASSERT(adj->graphOf() == m_pGraph);
+
+	// get the two faces adjacent to e
+	face f1 = m_rightFace[adj];
+	face f2 = m_rightFace[adj->twin()];
 
 	// the size of the joined face is the sum of the sizes of the two faces
 	// f1 and f2 minus the two adjacency entries of e
@@ -329,22 +338,22 @@ face CombinatorialEmbedding::joinFaces(edge e) {
 	// If the stored (first) adjacency entry of f1 belongs to e, we must set
 	// it to the next entry in the face, because we will remove it by deleting
 	// edge e
-	if (f1->entries.m_adjFirst->theEdge() == e) {
+	if (f1->entries.m_adjFirst->theEdge() == adj->theEdge()) {
 		f1->entries.m_adjFirst = f1->entries.m_adjFirst->faceCycleSucc();
 	}
 
 	if (f1 == f2) {
 		// If e is a bridge, both of its adjEntries belong to f1 (== f2).
 		// We might have to change the adjEntry again.
-		if (f1->entries.m_adjFirst->theEdge() == e) {
+		if (f1->entries.m_adjFirst->theEdge() == adj->theEdge()) {
 			f1->entries.m_adjFirst = f1->entries.m_adjFirst->faceCycleSucc();
 		}
 	} else {
 		// each adjacency entry in f2 belongs now to f1
-		adjEntry adj1 = f2->firstAdj(), adj = adj1;
+		adjEntry adj1 = f2->firstAdj(), a = adj1;
 		do {
-			m_rightFace[adj] = f1;
-		} while ((adj = adj->faceCycleSucc()) != adj1);
+			m_rightFace[a] = f1;
+		} while ((a = a->faceCycleSucc()) != adj1);
 
 		keyRemoved(f2);
 		faces.del(f2);
@@ -353,7 +362,7 @@ face CombinatorialEmbedding::joinFaces(edge e) {
 	// Delete e, but prevent dynamic binding of virtual method Graph::delEdge().
 	// This is for the case that m_pGraph is actually a pointer to a subclass of
 	// Graph, e.g. a GraphCopy. Call Graph::delEdge(), not GraphCopy::delEdge().
-	m_pGraph->Graph::delEdge(e);
+	m_pGraph->Graph::delEdge(adj->theEdge());
 
 #ifdef OGDF_HEAVY_DEBUG
 	consistencyCheck();
@@ -430,10 +439,9 @@ void CombinatorialEmbedding::clear() {
 	m_pGraph->clear();
 
 	faces.clear();
-
 	m_faceIdCount = 0;
-	keysCleared();
 	m_externalFace = nullptr;
+	keysCleared();
 
 #ifdef OGDF_HEAVY_DEBUG
 	consistencyCheck();

--- a/src/ogdf/basic/CombinatorialEmbedding.cpp
+++ b/src/ogdf/basic/CombinatorialEmbedding.cpp
@@ -37,7 +37,6 @@
 
 #include <functional>
 #include <ostream>
-#include <utility>
 #ifdef OGDF_DEBUG
 #	include <ogdf/basic/simple_graph_alg.h>
 #endif

--- a/src/ogdf/basic/Graph.cpp
+++ b/src/ogdf/basic/Graph.cpp
@@ -221,6 +221,7 @@ edge Graph::split(edge e) {
 
 	m_regEdgeArrays.keyAdded(e2); // note: registry observers won't see copied entry
 	m_regAdjArrays.keyAdded(e2->adjSource());
+	m_regAdjArrays.keyAdded(e2->adjTarget());
 
 	// copy array entries from the original adjEntries to the new ones
 	m_regAdjArrays.copyArrayEntries(eadjTgt->m_id, uadjTgt->m_id);
@@ -259,6 +260,7 @@ void Graph::unsplit(edge eIn, edge eOut) {
 
 	// notify all registered observers while everything is still valid
 	m_regAdjArrays.keyRemoved(eOut->adjSource());
+	m_regAdjArrays.keyRemoved(eOut->adjTarget());
 	m_regEdgeArrays.keyRemoved(eOut);
 	for (GraphObserver* obs : getObservers()) {
 		obs->edgeDeleted(eOut);
@@ -314,6 +316,7 @@ void Graph::delEdge(edge e) {
 	OGDF_ASSERT(e->graphOf() == this);
 
 	m_regAdjArrays.keyRemoved(e->adjSource());
+	m_regAdjArrays.keyRemoved(e->adjTarget());
 	m_regEdgeArrays.keyRemoved(e);
 	for (GraphObserver* obs : getObservers()) {
 		obs->edgeDeleted(e);

--- a/src/ogdf/basic/GraphCopy.cpp
+++ b/src/ogdf/basic/GraphCopy.cpp
@@ -351,7 +351,7 @@ void GraphCopy::setEdge(edge eOrig, edge eCopy) {
 void GraphCopy::insertEdgePathEmbedded(edge eOrig, CombinatorialEmbedding& E,
 		const SList<adjEntry>& crossedEdges) {
 	if (m_eCopy[eOrig].size() != 0) {
-		FaceSet<false> fsp(E);
+		FaceSet fsp(E);
 		removeEdgePathEmbedded(E, eOrig, fsp);
 	}
 	m_eCopy[eOrig].clear();
@@ -529,8 +529,7 @@ edge GraphCopy::insertCrossing(edge& crossingEdge, edge crossedEdge, bool rightT
 	return e;
 }
 
-void GraphCopy::removeEdgePathEmbedded(CombinatorialEmbedding& E, edge eOrig,
-		FaceSet<false>& newFaces) {
+void GraphCopy::removeEdgePathEmbedded(CombinatorialEmbedding& E, edge eOrig, FaceSet& newFaces) {
 	const List<edge>& path = m_eCopy[eOrig];
 #ifdef OGDF_DEBUG
 	ListConstIterator<edge> testIt = path.begin();

--- a/src/ogdf/basic/graph_generators/operations.cpp
+++ b/src/ogdf/basic/graph_generators/operations.cpp
@@ -255,8 +255,8 @@ void rootedProduct(const Graph& G1, const Graph& G2, Graph& product, NodeMap& no
 }
 
 void complement(Graph& G, bool directed, bool allowSelfLoops) {
-	NodeSet<true> n1neighbors(G);
-	EdgeSet<true> newEdges(G);
+	NodeSet n1neighbors(G);
+	EdgeSet newEdges(G);
 
 	for (node n1 : G.nodes) {
 		// Delete edges, remember neighbors.
@@ -287,7 +287,7 @@ void complement(Graph& G, bool directed, bool allowSelfLoops) {
 
 void intersection(Graph& G1, const Graph& G2, const NodeArray<node>& nodeMap, bool directed) {
 	OGDF_ASSERT(nodeMap.valid());
-	NodeSet<true> n2aNeighbors(G2);
+	NodeSet n2aNeighbors(G2);
 
 	safeForEach(G1.nodes, [&](node n1) {
 		if (nodeMap[n1] == nullptr) {

--- a/src/ogdf/basic/pctree/PCTree_construction.cpp
+++ b/src/ogdf/basic/pctree/PCTree_construction.cpp
@@ -326,6 +326,7 @@ void PCTree::destroyNode(PCNode* const& node) {
 	OGDF_ASSERT(node->m_child1 == nullptr);
 	OGDF_ASSERT(node->m_child2 == nullptr);
 	OGDF_ASSERT(node != m_rootNode);
+	m_forest->m_nodeArrayRegistry.keyRemoved(node);
 	unregisterNode(node);
 #ifdef OGDF_PCTREE_REUSE_NODES
 	node->m_parentPNode = m_forest->m_reusableNodes;

--- a/src/ogdf/cluster/ClusterGraph.cpp
+++ b/src/ogdf/cluster/ClusterGraph.cpp
@@ -37,7 +37,6 @@
 #include <ogdf/basic/GraphList.h>
 #include <ogdf/basic/List.h>
 #include <ogdf/basic/Math.h>
-#include <ogdf/basic/Observer.h>
 #include <ogdf/basic/Reverse.h>
 #include <ogdf/basic/SList.h>
 #include <ogdf/basic/basic.h>

--- a/src/ogdf/cluster/ClusterGraph.cpp
+++ b/src/ogdf/cluster/ClusterGraph.cpp
@@ -84,7 +84,7 @@ ClusterGraph::ClusterGraph(const Graph& G) { initGraph(G); }
 
 ClusterGraph::ClusterGraph(const ClusterGraph& C)
 	// need to explicitly call default parent class constructors in our copy constructor
-	: GraphObserver(), Observable(), ClusterGraphRegistry() {
+	: GraphObserver(), Obs(), ClusterGraphRegistry() {
 	shallowCopy(C);
 }
 
@@ -102,7 +102,7 @@ ClusterGraph::ClusterGraph(const ClusterGraph& C, Graph& G,
 ClusterGraph::ClusterGraph(const ClusterGraph& C, Graph& G) { deepCopy(C, G); }
 
 ClusterGraph::~ClusterGraph() {
-	clearObservers();
+	Obs::clearObservers();
 	// this is only necessary because GraphObjectContainer simply deallocs its memory without calling destructors
 	while (!clusters.empty()) {
 		clusters.del(clusters.head());
@@ -494,7 +494,7 @@ cluster ClusterGraph::newCluster(int id) {
 #endif
 	clusters.pushBack(c);
 	keyAdded(c);
-	for (ClusterGraphObserver* obs : getObservers()) {
+	for (ClusterGraphObserver* obs : Obs::getObservers()) {
 		obs->clusterAdded(c);
 	}
 
@@ -513,7 +513,7 @@ cluster ClusterGraph::newCluster() {
 #endif
 	clusters.pushBack(c);
 	keyAdded(c);
-	for (ClusterGraphObserver* obs : getObservers()) {
+	for (ClusterGraphObserver* obs : Obs::getObservers()) {
 		obs->clusterAdded(c);
 	}
 
@@ -636,7 +636,7 @@ void ClusterGraph::delCluster(cluster c) {
 	OGDF_ASSERT(c != m_rootCluster);
 
 	// notify observers
-	for (ClusterGraphObserver* obs : getObservers()) {
+	for (ClusterGraphObserver* obs : Obs::getObservers()) {
 		obs->clusterDeleted(c);
 	}
 	keyRemoved(c);
@@ -689,7 +689,7 @@ void ClusterGraph::pullUpSubTree(cluster c) {
 	}
 }
 
-void ClusterGraph::doClear() {
+void ClusterGraph::doClear() { // TODO merge with clear
 	//split condition
 	m_lcaSearch.reset();
 	m_vAncestor.reset();
@@ -698,12 +698,35 @@ void ClusterGraph::doClear() {
 		clearClusterTree(m_rootCluster);
 		clusters.del(m_rootCluster);
 	}
-	for (ClusterGraphObserver* obs : getObservers()) {
+	for (ClusterGraphObserver* obs : Obs::getObservers()) {
 		obs->clustersCleared();
 	}
-	keysCleared();
 	//no clusters, so we can restart at 0
 	m_clusterIdCount = 0;
+	keysCleared();
+}
+
+//don't delete root cluster
+void ClusterGraph::clear() {
+	m_lcaSearch.reset();
+	m_vAncestor.reset();
+	m_wAncestor.reset();
+	if (numberOfClusters() != 0) {
+		//clear the cluster structure under root cluster
+		clearClusterTree(m_rootCluster);
+		//now delete all rootcluster entries
+		while (!m_rootCluster->nodes.empty()) {
+			node v = m_rootCluster->nodes.popFrontRet();
+			m_nodeMap[v] = nullptr;
+		}
+	}
+	for (ClusterGraphObserver* obs : Obs::getObservers()) {
+		obs->clustersCleared();
+	}
+	//no child clusters, so we can restart at 1
+	m_clusterIdCount = 1;
+	keysCleared();
+	keyAdded(0);
 }
 
 // Removes the Clustering of a Tree and frees the allocated memory
@@ -715,7 +738,7 @@ void ClusterGraph::clearClusterTree(cluster c) {
 	recurseClearClusterTreeOnChildren(c, attached);
 
 	if (parent != nullptr) {
-		for (ClusterGraphObserver* obs : getObservers()) {
+		for (ClusterGraphObserver* obs : Obs::getObservers()) {
 			obs->clusterDeleted(c);
 		}
 		keyRemoved(c);
@@ -736,31 +759,13 @@ void ClusterGraph::clearClusterTree(cluster c) {
 }
 
 void ClusterGraph::clearClusterTree(cluster c, List<node>& attached) {
-	for (ClusterGraphObserver* obs : getObservers()) {
+	for (ClusterGraphObserver* obs : Obs::getObservers()) {
 		obs->clusterDeleted(c);
 	}
 	keyRemoved(c);
 	attached.conc(c->nodes);
 	recurseClearClusterTreeOnChildren(c, attached);
 	clusters.del(c);
-}
-
-//don't delete root cluster
-void ClusterGraph::clear() {
-	m_lcaSearch.reset();
-	m_vAncestor.reset();
-	m_wAncestor.reset();
-	if (numberOfClusters() != 0) {
-		//clear the cluster structure under root cluster
-		clearClusterTree(m_rootCluster);
-		//now delete all rootcluster entries
-		while (!m_rootCluster->nodes.empty()) {
-			node v = m_rootCluster->nodes.popFrontRet();
-			m_nodeMap[v] = nullptr;
-		}
-	}
-	//no child clusters, so we can restart at 1
-	m_clusterIdCount = 1;
 }
 
 int ClusterGraph::treeDepth() const {

--- a/src/ogdf/cluster/ClusterGraph.cpp
+++ b/src/ogdf/cluster/ClusterGraph.cpp
@@ -726,7 +726,7 @@ void ClusterGraph::clear() {
 	//no child clusters, so we can restart at 1
 	m_clusterIdCount = 1;
 	keysCleared();
-	keyAdded(0);
+	keyAdded(m_rootCluster);
 }
 
 // Removes the Clustering of a Tree and frees the allocated memory

--- a/src/ogdf/cluster/sync_plan/SyncPlan_ClusterPlanarity.cpp
+++ b/src/ogdf/cluster/sync_plan/SyncPlan_ClusterPlanarity.cpp
@@ -395,7 +395,7 @@ void ogdf::reduceLevelPlanarityToClusterPlanarity(const Graph& LG,
 }
 
 void ogdf::insertAugmentationEdges(const ClusterGraph& CG, Graph& G,
-		std::vector<std::pair<adjEntry, adjEntry>>& augmentation, EdgeSet<>* added, bool embedded,
+		std::vector<std::pair<adjEntry, adjEntry>>& augmentation, EdgeSet* added, bool embedded,
 		bool assert_minimal) {
 	if (embedded) {
 		OGDF_ASSERT(G.representsCombEmbedding());

--- a/src/ogdf/cluster/sync_plan/SyncPlan_operation/Simplify.cpp
+++ b/src/ogdf/cluster/sync_plan/SyncPlan_operation/Simplify.cpp
@@ -314,7 +314,7 @@ SyncPlan::Result SyncPlan::simplify(node u, const NodePCRotation* pc) {
 		leaf_for_u_inc_edge.init(*G, nullptr);
 		pc->generateLeafForIncidentEdgeMapping(leaf_for_u_inc_edge);
 	}
-	EdgeSet<> visited(*G);
+	EdgeSet visited(*G);
 
 	// SYNCPLAN_PROFILE_START("simplify-bondmap")
 	for (const PipeBijPair& pair : matchings.getIncidentEdgeBijection(u2)) {

--- a/src/ogdf/cluster/sync_plan/SyncPlan_operation/SimplifyUtils.cpp
+++ b/src/ogdf/cluster/sync_plan/SyncPlan_operation/SimplifyUtils.cpp
@@ -124,7 +124,7 @@ int findCycles(Graph& G, node u, const std::function<adjEntry(adjEntry)>& mappin
 	return sum;
 }
 
-adjEntry continueNodeDFS(Graph& G, adjEntry u_adj, node v, EdgeSet<>& visited,
+adjEntry continueNodeDFS(Graph& G, adjEntry u_adj, node v, EdgeSet& visited,
 		List<adjEntry>& dfs_stack) {
 	while (!dfs_stack.empty()) {
 		OGDF_ASSERT(dfs_stack.back()->twinNode() != u_adj->theNode());
@@ -166,8 +166,7 @@ adjEntry continueNodeDFS(Graph& G, adjEntry u_adj, node v, EdgeSet<>& visited,
 	return nullptr;
 }
 
-adjEntry startNodeDFS(Graph& G, adjEntry u_adj, node v, EdgeSet<>& visited,
-		List<adjEntry>& dfs_stack) {
+adjEntry startNodeDFS(Graph& G, adjEntry u_adj, node v, EdgeSet& visited, List<adjEntry>& dfs_stack) {
 	dfs_stack.pushBack(u_adj);
 	visited.insert(u_adj->theEdge());
 	adjEntry found = continueNodeDFS(G, u_adj, v, visited, dfs_stack);
@@ -177,7 +176,7 @@ adjEntry startNodeDFS(Graph& G, adjEntry u_adj, node v, EdgeSet<>& visited,
 	return found;
 }
 
-int exhaustiveNodeDFS(Graph& G, adjEntry u_adj, node v, EdgeSet<>& visited, List<adjEntry>& out) {
+int exhaustiveNodeDFS(Graph& G, adjEntry u_adj, node v, EdgeSet& visited, List<adjEntry>& out) {
 	List<adjEntry> queue;
 	adjEntry found = startNodeDFS(G, u_adj, v, visited, queue);
 	out.pushBack(found->twin());
@@ -197,10 +196,10 @@ int exhaustiveNodeDFS(Graph& G, adjEntry u_adj, node v, EdgeSet<>& visited, List
 
 #ifdef OGDF_DEBUG
 
-bool compareWithExhaustiveNodeDFS(Graph& G, adjEntry u_adj, node v, const EdgeSet<>& visited,
+bool compareWithExhaustiveNodeDFS(Graph& G, adjEntry u_adj, node v, const EdgeSet& visited,
 		const List<adjEntry>& found) {
 	List<adjEntry> reference_list;
-	EdgeSet<> reference_visited(G);
+	EdgeSet reference_visited(G);
 	exhaustiveNodeDFS(G, u_adj, v, reference_visited, reference_list);
 	OGDF_ASSERT(reference_list.size() == found.size());
 	for (adjEntry adj : found) {
@@ -237,7 +236,7 @@ void validatePartnerPCTree(const NodePCRotation* u_pc, const NodePCRotation* v_p
 	}
 }
 
-bool validateCollectedAdjs(node v, node u, List<SimplifyMapping>& bij_list, EdgeSet<>& visited,
+bool validateCollectedAdjs(node v, node u, List<SimplifyMapping>& bij_list, EdgeSet& visited,
 		SyncPlanComponents& components) {
 	int collected_v_adjs = 0;
 	for (auto& entry : bij_list) {

--- a/src/ogdf/cluster/sync_plan/SyncPlan_solve/Embedder.cpp
+++ b/src/ogdf/cluster/sync_plan/SyncPlan_solve/Embedder.cpp
@@ -52,7 +52,8 @@ class UpdateGraphReg : public GraphObserver {
 
 public:
 	UpdateGraphReg(const Graph* g, NodeArray<node>* nodeReg, EdgeArray<edge>* edgeReg)
-		: GraphObserver(g), node_reg(nodeReg), edge_reg(edgeReg) {
+		: GraphObserver(), node_reg(nodeReg), edge_reg(edgeReg) {
+		reregister(g);
 		nodeReg->init(*g, nullptr);
 		edgeReg->init(*g, nullptr);
 		for (node n : g->nodes) {

--- a/src/ogdf/graphalg/MaximumDensitySubgraph.cpp
+++ b/src/ogdf/graphalg/MaximumDensitySubgraph.cpp
@@ -45,7 +45,7 @@
 
 namespace ogdf {
 
-bool maximumDensitySubgraph(Graph& G, NodeSet<true>& subgraphNodes,
+bool maximumDensitySubgraph(Graph& G, NodeSet& subgraphNodes,
 		std::function<node(node)> resultNodeMap, int64_t timelimit) {
 	StopwatchCPU watch;
 	watch.start();

--- a/src/ogdf/graphalg/Triconnectivity.cpp
+++ b/src/ogdf/graphalg/Triconnectivity.cpp
@@ -385,7 +385,7 @@ bool Triconnectivity::checkComp() const {
 		}
 	}
 
-	NodeSet<> S(*m_pG);
+	NodeSet S(*m_pG);
 	NodeArray<node> map(*m_pG);
 
 	for (int i = 0; i < m_numComp; i++) {

--- a/src/ogdf/hypergraph/EdgeStandardRep.cpp
+++ b/src/ogdf/hypergraph/EdgeStandardRep.cpp
@@ -41,7 +41,8 @@ namespace ogdf {
 EdgeStandardRep::EdgeStandardRep() : m_type(EdgeStandardType::star), m_hypergraph(nullptr) { }
 
 EdgeStandardRep::EdgeStandardRep(const Hypergraph& pH, EdgeStandardType pType = EdgeStandardType::star)
-	: HypergraphObserver(&pH) {
+	: HypergraphObserver() {
+	reregister(&pH);
 	m_type = pType;
 	m_hypergraph = &pH;
 

--- a/src/ogdf/hypergraph/Hypergraph.cpp
+++ b/src/ogdf/hypergraph/Hypergraph.cpp
@@ -39,6 +39,7 @@
 
 #include <cstring>
 #include <fstream>
+#include <functional>
 #include <string>
 
 namespace ogdf {

--- a/src/ogdf/layered/ExtendedNestingGraph.cpp
+++ b/src/ogdf/layered/ExtendedNestingGraph.cpp
@@ -817,7 +817,7 @@ void ExtendedNestingGraph::buildLayers() {
 	}
 
 
-	ClusterSet<false> activeClusters(m_CGC); // was ClusterSetPure
+	ClusterSet activeClusters(m_CGC); // was ClusterSetPure
 	activeClusters.insert(m_CGC.rootCluster());
 
 	ClusterArray<LHTreeNode*> clusterToTreeNode(m_CGC, nullptr);
@@ -933,7 +933,7 @@ void ExtendedNestingGraph::buildLayers() {
 	// and foreign edges
 	m_markTree.init(m_CGC, nullptr);
 	ClusterArray<List<tuple<edge, LHTreeNode*, LHTreeNode*>>> edgeArray(m_CGC);
-	ClusterSet<false> C(m_CGC); // was ClusterSetSimple
+	ClusterSet C(m_CGC); // was ClusterSetSimple
 	for (i = 0; i < m_numLayers - 1; ++i) {
 		for (node u : L[i]) {
 			for (adjEntry adj : u->adjEntries) {

--- a/src/ogdf/planarity/MMFixedEmbeddingInserter.cpp
+++ b/src/ogdf/planarity/MMFixedEmbeddingInserter.cpp
@@ -181,14 +181,14 @@ Module::ReturnType MMFixedEmbeddingInserter::doCall(PlanRepExpansion& PG,
 	}
 #endif
 
-	m_delFaces = new FaceSet<false>(E);
+	m_delFaces = new FaceSet(E);
 
 	// m_newFaces and m_mergedNodes are used by removeEdge()
 	m_newFaces = nullptr;
 	m_mergedNodes = nullptr;
 	if (removeReinsert() != RemoveReinsertType::None) {
-		m_newFaces = new FaceSet<false>(E);
-		m_mergedNodes = new NodeSet<false>(PG);
+		m_newFaces = new FaceSet(E);
+		m_mergedNodes = new NodeSet(PG);
 	}
 
 	SListPure<edge> currentOrigEdges;
@@ -198,7 +198,7 @@ Module::ReturnType MMFixedEmbeddingInserter::doCall(PlanRepExpansion& PG,
 		}
 	}
 
-	NodeSet<> sources(PG), targets(PG);
+	NodeSet sources(PG), targets(PG);
 
 	// insertion of edges
 	for (edge eOrig : origEdges) {
@@ -1158,7 +1158,7 @@ void MMFixedEmbeddingInserter::contractSplitIfReq(PlanRepExpansion& PG, Combinat
 	}
 }
 
-void MMFixedEmbeddingInserter::collectAnchorNodes(node v, NodeSet<>& nodes,
+void MMFixedEmbeddingInserter::collectAnchorNodes(node v, NodeSet& nodes,
 		const PlanRepExpansion::NodeSplit* nsParent, const PlanRepExpansion& PG) const {
 	if (PG.original(v) != nullptr) {
 		nodes.insert(v);
@@ -1187,13 +1187,13 @@ void MMFixedEmbeddingInserter::collectAnchorNodes(node v, NodeSet<>& nodes,
 	}
 }
 
-void MMFixedEmbeddingInserter::findSourcesAndTargets(node src, node tgt, NodeSet<>& sources,
-		NodeSet<>& targets, const PlanRepExpansion& PG) const {
+void MMFixedEmbeddingInserter::findSourcesAndTargets(node src, node tgt, NodeSet& sources,
+		NodeSet& targets, const PlanRepExpansion& PG) const {
 	collectAnchorNodes(src, sources, nullptr, PG);
 	collectAnchorNodes(tgt, targets, nullptr, PG);
 }
 
-void MMFixedEmbeddingInserter::anchorNodes(node vOrig, NodeSet<>& nodes,
+void MMFixedEmbeddingInserter::anchorNodes(node vOrig, NodeSet& nodes,
 		const PlanRepExpansion& PG) const {
 	node vFirst = PG.expansion(vOrig).front();
 	if (PG.splittableOrig(vOrig)) {
@@ -1203,7 +1203,7 @@ void MMFixedEmbeddingInserter::anchorNodes(node vOrig, NodeSet<>& nodes,
 	}
 }
 
-node MMFixedEmbeddingInserter::commonDummy(NodeSet<>& sources, NodeSet<>& targets) {
+node MMFixedEmbeddingInserter::commonDummy(NodeSet& sources, NodeSet& targets) {
 	ListConstIterator<node> it;
 	for (it = sources.nodes().begin(); it.valid(); ++it) {
 		if (targets.isMember(*it)) {

--- a/src/ogdf/planarity/MMVariableEmbeddingInserter.cpp
+++ b/src/ogdf/planarity/MMVariableEmbeddingInserter.cpp
@@ -119,8 +119,8 @@ Module::ReturnType MMVariableEmbeddingInserter::doCall(PlanRepExpansion& PG,
 		}
 	}
 
-	m_pSources = new NodeSet<>(PG);
-	m_pTargets = new NodeSet<>(PG);
+	m_pSources = new NodeSet(PG);
+	m_pTargets = new NodeSet(PG);
 
 #ifdef OGDF_MMVEI_OUTPUT
 	outputPG(PG, 0);
@@ -1731,7 +1731,7 @@ void MMVariableEmbeddingInserter::convertDummy(node u, node vOrig, PlanRepExpans
 	}
 }
 
-void MMVariableEmbeddingInserter::collectAnchorNodes(node v, NodeSet<>& nodes,
+void MMVariableEmbeddingInserter::collectAnchorNodes(node v, NodeSet& nodes,
 		const PlanRepExpansion::NodeSplit* nsParent) const {
 	if (m_pPG->original(v) != nullptr) {
 		nodes.insert(v);
@@ -1760,13 +1760,13 @@ void MMVariableEmbeddingInserter::collectAnchorNodes(node v, NodeSet<>& nodes,
 	}
 }
 
-void MMVariableEmbeddingInserter::findSourcesAndTargets(node src, node tgt, NodeSet<>& sources,
-		NodeSet<>& targets) const {
+void MMVariableEmbeddingInserter::findSourcesAndTargets(node src, node tgt, NodeSet& sources,
+		NodeSet& targets) const {
 	collectAnchorNodes(src, sources, nullptr);
 	collectAnchorNodes(tgt, targets, nullptr);
 }
 
-void MMVariableEmbeddingInserter::anchorNodes(node vOrig, NodeSet<>& nodes) const {
+void MMVariableEmbeddingInserter::anchorNodes(node vOrig, NodeSet& nodes) const {
 	node vFirst = m_pPG->expansion(vOrig).front();
 	if (m_pPG->splittableOrig(vOrig)) {
 		collectAnchorNodes(vFirst, nodes, nullptr);
@@ -1775,7 +1775,7 @@ void MMVariableEmbeddingInserter::anchorNodes(node vOrig, NodeSet<>& nodes) cons
 	}
 }
 
-node MMVariableEmbeddingInserter::commonDummy(NodeSet<>& sources, NodeSet<>& targets) {
+node MMVariableEmbeddingInserter::commonDummy(NodeSet& sources, NodeSet& targets) {
 	for (node v : sources.nodes()) {
 		if (targets.isMember(v)) {
 			return v;

--- a/src/ogdf/planarity/PlanRepExpansion.cpp
+++ b/src/ogdf/planarity/PlanRepExpansion.cpp
@@ -331,7 +331,7 @@ void PlanRepExpansion::insertEdgePathEmbedded(edge eOrig, nodeSplit ns, Combinat
 }
 
 void PlanRepExpansion::removeEdgePathEmbedded(CombinatorialEmbedding& E, edge eOrig, nodeSplit ns,
-		FaceSet<false>& newFaces, NodeSet<false>& mergedNodes, node& oldSrc, node& oldTgt) {
+		FaceSet& newFaces, NodeSet& mergedNodes, node& oldSrc, node& oldTgt) {
 	OGDF_ASSERT((eOrig != nullptr && ns == nullptr) || (eOrig == nullptr && ns != nullptr));
 
 	const List<edge>& path = (eOrig) ? m_eCopy[eOrig] : ns->m_path;

--- a/src/ogdf/planarity/embedding_inserter/FixEdgeInserterCore.cpp
+++ b/src/ogdf/planarity/embedding_inserter/FixEdgeInserterCore.cpp
@@ -100,12 +100,12 @@ Module::ReturnType FixEdgeInserterCore::call(const Array<edge>& origEdges, bool 
 	// m_delFaces and m_newFaces are used by removeEdge()
 	// if we can't allocate memory for them, we throw an exception
 	if (rrPost != RemoveReinsertType::None) {
-		m_delFaces = new FaceSet<false>(E);
+		m_delFaces = new FaceSet(E);
 		if (m_delFaces == nullptr) {
 			OGDF_THROW(InsufficientMemoryException);
 		}
 
-		m_newFaces = new FaceSet<false>(E);
+		m_newFaces = new FaceSet(E);
 		if (m_newFaces == nullptr) {
 			delete m_delFaces;
 			OGDF_THROW(InsufficientMemoryException);

--- a/test/src/basic/adjentryarray.cpp
+++ b/test/src/basic/adjentryarray.cpp
@@ -30,7 +30,9 @@
  */
 #include <ogdf/basic/Graph.h>
 #include <ogdf/basic/GraphList.h>
+#include <ogdf/basic/GraphSets.h>
 #include <ogdf/basic/List.h>
+#include <ogdf/basic/RegisteredSet.h>
 #include <ogdf/basic/basic.h>
 #include <ogdf/basic/graph_generators/randomized.h>
 

--- a/test/src/basic/adjentryarray.cpp
+++ b/test/src/basic/adjentryarray.cpp
@@ -61,6 +61,10 @@ go_bandit([]() {
 		return randomNumber(0, 1) ? e->adjSource() : e->adjTarget();
 	};
 
+	auto deleteAdjEntry = [](Graph& graph, adjEntry adj) { graph.delEdge(adj->theEdge()); };
+
+	auto clearAdjEntries = [](Graph& graph) { graph.clear(); };
+
 	auto init = [](Graph& graph) { randomGraph(graph, 42, 168); };
 
 	runBasicArrayTests<Graph, AdjEntryArray, adjEntry>( //
@@ -109,4 +113,8 @@ go_bandit([]() {
 			AssertThat(*P[e->adjTarget()], Equals(5));
 		});
 	});
+
+	runBasicSetTests<Graph, AdjEntrySet, adjEntry>("AdjEntrySet", init, chooseAdjEntry,
+			allAdjEntries, createAdjEntry, deleteAdjEntry, clearAdjEntries,
+			[](adjEntry a, adjEntry b) { return a->theEdge() == b->theEdge(); });
 });

--- a/test/src/basic/array_helper.h
+++ b/test/src/basic/array_helper.h
@@ -892,7 +892,7 @@ void describeSetTemplatedCopyAndEquals(const std::string& description,
  * @param clearAllKeys a function to delete all keys in the base
  * @param equals a function to check whether two objects are equal wrt. being deleted together
  */
-template<class BaseType, template<bool> class SetType, typename KeyType>
+template<class BaseType, class SetType, typename KeyType>
 void runBasicSetTests(
 		const std::string& setType, std::function<void(BaseType&)> initBase,
 		std::function<KeyType(const BaseType&)> chooseKey,
@@ -901,23 +901,11 @@ void runBasicSetTests(
 		std::function<void(BaseType&, KeyType)> deleteKey,
 		std::function<void(BaseType&)> clearAllKeys,
 		std::function<bool(KeyType, KeyType)> equals = [](KeyType a, KeyType b) { return a == b; }) {
-	describeSet<BaseType, SetType<true>, KeyType>(setType + "<true>", initBase, chooseKey,
-			getAllKeys, createKey, deleteKey, clearAllKeys, equals);
-	describeSet<BaseType, SetType<false>, KeyType>(setType + "<false>", initBase, chooseKey,
-			getAllKeys, createKey, deleteKey, clearAllKeys, equals);
+	describeSet<BaseType, SetType, KeyType>(setType, initBase, chooseKey, getAllKeys, createKey,
+			deleteKey, clearAllKeys, equals);
 
-	describeSetTemplatedCopyAndEquals<BaseType, SetType<true>, SetType<true>, KeyType>(
-			setType + "<true> and " + setType + "<true>", initBase, chooseKey, getAllKeys,
-			createKey, deleteKey, clearAllKeys, equals);
-	describeSetTemplatedCopyAndEquals<BaseType, SetType<true>, SetType<false>, KeyType>(
-			setType + "<true> and " + setType + "<false>", initBase, chooseKey, getAllKeys,
-			createKey, deleteKey, clearAllKeys, equals);
-	describeSetTemplatedCopyAndEquals<BaseType, SetType<false>, SetType<true>, KeyType>(
-			setType + "<false> and " + setType + "<true>", initBase, chooseKey, getAllKeys,
-			createKey, deleteKey, clearAllKeys, equals);
-	describeSetTemplatedCopyAndEquals<BaseType, SetType<false>, SetType<false>, KeyType>(
-			setType + "<false> and " + setType + "<false>", initBase, chooseKey, getAllKeys,
-			createKey, deleteKey, clearAllKeys, equals);
+	describeSetTemplatedCopyAndEquals<BaseType, SetType, SetType, KeyType>(setType + " and " + setType,
+			initBase, chooseKey, getAllKeys, createKey, deleteKey, clearAllKeys, equals);
 
 	// FIXME is cleared() called before or after the changes?
 }

--- a/test/src/basic/array_helper.h
+++ b/test/src/basic/array_helper.h
@@ -553,3 +553,371 @@ void runBasicArrayTests(const std::string& arrayType, std::function<void(BaseTyp
 			arrayType + " filled with vectors of unique pointers", //
 			initBase, chooseKey, getAllKeys, createKey);
 }
+
+template<class BaseType, typename SetType, typename KeyType>
+void describeSet(const std::string& setType, std::function<void(BaseType&)> initBase,
+		std::function<KeyType(const BaseType&)> chooseKey,
+		std::function<void(const BaseType&, List<KeyType>&)> getAllKeys,
+		std::function<KeyType(BaseType&)> createKey,
+		std::function<void(BaseType&, KeyType)> deleteKey,
+		std::function<void(BaseType&)> clearAllKeys, std::function<bool(KeyType, KeyType)> equals) {
+	describe(setType, [&]() {
+		it("initializes with an empty Registry", [&]() {
+			BaseType B;
+			SetType S(B);
+			AssertThat(S.size(), Equals(0));
+		});
+
+		{
+			BaseType B;
+			initBase(B);
+			it("initializes with a non-empty Registry", [&]() {
+				SetType S(B);
+				AssertThat(S.size(), Equals(0));
+			});
+
+			KeyType a = chooseKey(B);
+			KeyType b = chooseKey(B);
+			while (equals(a, b)) {
+				b = chooseKey(B);
+			}
+			it("allows adding values", [&]() {
+				SetType S(B);
+				AssertThat(S.isMember(a), IsFalse());
+				AssertThat(S.isMember(b), IsFalse());
+				S.insert(a);
+				AssertThat(S.size(), Equals(1));
+				AssertThat(S.elements().size(), Equals(1));
+				AssertThat(S.elements().front(), Equals(a));
+				AssertThat(S.isMember(a), IsTrue());
+				AssertThat(S.isMember(b), IsFalse());
+			});
+			it("allows adding values twice", [&]() {
+				SetType S(B);
+				S.insert(a);
+				S.insert(a);
+				AssertThat(S.size(), Equals(1));
+				AssertThat(S.isMember(a), IsTrue());
+				AssertThat(S.isMember(b), IsFalse());
+			});
+			it("allows removing and adding values back", [&]() {
+				SetType S(B);
+				S.insert(a);
+				AssertThat(S.size(), Equals(1));
+				AssertThat(S.isMember(a), IsTrue());
+				S.remove(a);
+				AssertThat(S.size(), Equals(0));
+				AssertThat(S.isMember(a), IsFalse());
+
+				S.remove(a);
+				AssertThat(S.size(), Equals(0));
+				AssertThat(S.isMember(a), IsFalse());
+
+				S.insert(a);
+				AssertThat(S.size(), Equals(1));
+				AssertThat(S.isMember(a), IsTrue());
+				AssertThat(S.isMember(b), IsFalse());
+			});
+			it("allows clearing", [&]() {
+				SetType S(B);
+				S.insert(a);
+				S.insert(b);
+				AssertThat(S.size(), Equals(2));
+				AssertThat(S.isMember(a), IsTrue());
+				AssertThat(S.isMember(b), IsTrue());
+
+				S.clear();
+				AssertThat(S.size(), Equals(0));
+				AssertThat(S.elements().empty(), IsTrue());
+				AssertThat(S.isMember(a), IsFalse());
+
+				S.remove(a);
+				AssertThat(S.size(), Equals(0));
+				AssertThat(S.isMember(a), IsFalse());
+
+				S.insert(a);
+				AssertThat(S.size(), Equals(1));
+				AssertThat(S.isMember(a), IsTrue());
+				AssertThat(S.isMember(b), IsFalse());
+			});
+			SetType onlyA(B);
+			onlyA.insert(a);
+			it("allows copying", [&]() {
+				SetType S(onlyA);
+				AssertThat(S.size(), Equals(1));
+				AssertThat(S.elements().front(), Equals(a));
+				AssertThat(S.isMember(a), IsTrue());
+				AssertThat(S.isMember(b), IsFalse());
+
+				S.insert(b);
+				AssertThat(S.size(), Equals(2));
+				AssertThat(S.isMember(a), IsTrue());
+				AssertThat(S.isMember(b), IsTrue());
+
+				S.remove(a);
+				AssertThat(S.size(), Equals(1));
+				AssertThat(S.elements().front(), Equals(b));
+				AssertThat(S.isMember(a), IsFalse());
+				AssertThat(S.isMember(b), IsTrue());
+			});
+			it("checks equality", [&]() {
+				SetType S1(onlyA);
+				SetType S2(B);
+				S2.insert(a);
+
+				AssertThat(S1, Equals(S2));
+				AssertThat(S1, Equals(onlyA));
+				AssertThat(S2, Equals(onlyA));
+				AssertThat(onlyA, Equals(S1));
+				AssertThat(onlyA, Equals(S2));
+
+				S1.insert(a);
+				AssertThat(S1, Equals(S2));
+				AssertThat(S1, Equals(onlyA));
+				AssertThat(S2, Equals(onlyA));
+				AssertThat(onlyA, Equals(S1));
+				AssertThat(onlyA, Equals(S2));
+
+				S1.insert(b);
+				AssertThat(S1, !Equals(S2));
+				AssertThat(S1, !Equals(onlyA));
+				AssertThat(S2, Equals(onlyA));
+				AssertThat(onlyA, !Equals(S1));
+				AssertThat(onlyA, Equals(S2));
+			});
+		}
+
+		it("is notified of key deletion", [&]() {
+			BaseType B;
+			initBase(B);
+
+			KeyType a = chooseKey(B);
+			KeyType b = chooseKey(B);
+			while (equals(a, b)) {
+				b = chooseKey(B);
+			}
+
+			SetType S(B);
+			S.insert(a);
+			S.insert(b);
+			AssertThat(S.size(), Equals(2));
+			deleteKey(B, a);
+			AssertThat(S.size(), Equals(1));
+			AssertThat(S.elements().front(), Equals(b));
+		});
+		it("is notified of key clearing", [&]() {
+			BaseType B;
+			initBase(B);
+			SetType S(B);
+
+			List<KeyType> list;
+			getAllKeys(B, list);
+			for (KeyType k : list) {
+				AssertThat(S.isMember(k), IsFalse());
+				S.insert(k);
+				AssertThat(S.isMember(k), IsTrue());
+			}
+			AssertThat(S.size(), Equals(list.size()));
+			S.clear();
+			AssertThat(S.size(), Equals(0));
+
+			for (KeyType k : list) {
+				AssertThat(S.isMember(k), IsFalse());
+				S.insert(k);
+				AssertThat(S.isMember(k), IsTrue());
+			}
+			AssertThat(S.size(), Equals(list.size()));
+
+			clearAllKeys(B);
+			AssertThat(S.size(), Equals(0));
+			AssertThat(S.elements().empty(), IsTrue());
+		});
+		it("allows changing its base", [&]() {
+			std::unique_ptr<BaseType> A = std::make_unique<BaseType>();
+			std::unique_ptr<BaseType> B = std::make_unique<BaseType>();
+			initBase(*A);
+			initBase(*B);
+			SetType S(*A);
+
+#define OGDF_CAST_REGISTRY_PTR(ptr) (&static_cast<const typename SetType::registry_type&>(*(ptr)))
+
+			KeyType a = chooseKey(*A);
+			S.insert(a);
+			AssertThat(S.size(), Equals(1));
+			AssertThat(OGDF_CAST_REGISTRY_PTR(S.registeredAt()), Equals(OGDF_CAST_REGISTRY_PTR(A)));
+			S.init(*B);
+			AssertThat(OGDF_CAST_REGISTRY_PTR(S.registeredAt()), Equals(OGDF_CAST_REGISTRY_PTR(B)));
+			AssertThat(S.size(), Equals(0));
+			KeyType b = chooseKey(*B);
+			S.insert(b);
+			AssertThat(S.size(), Equals(1));
+
+			deleteKey(*A, a);
+			AssertThat(S.size(), Equals(1));
+			deleteKey(*B, b);
+			AssertThat(S.size(), Equals(0));
+			KeyType b2 = chooseKey(*B);
+			S.insert(b2);
+			AssertThat(S.size(), Equals(1));
+
+			A.reset();
+			AssertThat(S.size(), Equals(1));
+			AssertThat(S.elements().front(), Equals(b2));
+
+			B.reset();
+			AssertThat(S.size(), Equals(0));
+			AssertThat(S.registeredAt(), IsNull());
+		});
+	});
+}
+
+template<class BaseType, typename SetTypeA, typename SetTypeB, typename KeyType>
+void describeSetTemplatedCopyAndEquals(const std::string& description,
+		std::function<void(BaseType&)> initBase, std::function<KeyType(const BaseType&)> chooseKey,
+		std::function<void(const BaseType&, List<KeyType>&)> getAllKeys,
+		std::function<KeyType(BaseType&)> createKey,
+		std::function<void(BaseType&, KeyType)> deleteKey,
+		std::function<void(BaseType&)> clearAllKeys, std::function<bool(KeyType, KeyType)> equals) {
+	describe(description, [&]() {
+		it("allows equality comparisons", [&]() {
+			std::unique_ptr<BaseType> G = std::make_unique<BaseType>();
+			initBase(*G);
+
+			SetTypeA SA(*G);
+			SetTypeB SB;
+			AssertThat(SA, !Equals(SB));
+			SB.init(*G);
+			AssertThat(SA, Equals(SB));
+
+			KeyType n = chooseKey(*G);
+			SA.insert(n);
+			AssertThat(SA, !Equals(SB));
+			SB.insert(n);
+			AssertThat(SA, Equals(SB));
+
+			KeyType a = n;
+			while (equals(a, n)) {
+				a = chooseKey(*G);
+			}
+			KeyType b = n;
+			while (equals(n, b) || equals(a, b)) {
+				b = chooseKey(*G);
+			}
+
+			SA.insert(a);
+			AssertThat(SA, !Equals(SB));
+			SB.insert(b);
+			AssertThat(SA, !Equals(SB));
+			SB.insert(a);
+			AssertThat(SA, !Equals(SB));
+			SA.insert(b);
+			AssertThat(SA, Equals(SB));
+
+			SA.remove(n);
+			AssertThat(SA, !Equals(SB));
+			SB.remove(n);
+			AssertThat(SA, Equals(SB));
+
+			SA.init();
+			AssertThat(SA, !Equals(SB));
+			G.reset();
+			AssertThat(SA, Equals(SB));
+		});
+		it("allows copy construction and assignment", [&]() {
+			std::unique_ptr<BaseType> G = std::make_unique<BaseType>();
+			initBase(*G);
+
+			KeyType a = chooseKey(*G);
+			KeyType b = a;
+			while (equals(a, b)) {
+				b = chooseKey(*G);
+			}
+
+			SetTypeA SA(*G);
+			SA.insert(a);
+			SA.insert(b);
+			SetTypeB SB(SA);
+			AssertThat(SB.isMember(a), IsTrue());
+			AssertThat(SB.isMember(b), IsTrue());
+			AssertThat(SB.size(), Equals(2));
+			AssertThat(SA, Equals(SB));
+			AssertThat(SB, Equals(SA));
+
+			SB.remove(a);
+			AssertThat(SA.isMember(a), IsTrue());
+			AssertThat(SA.isMember(b), IsTrue());
+			AssertThat(SA.size(), Equals(2));
+			AssertThat(SB.isMember(a), IsFalse());
+			AssertThat(SB.isMember(b), IsTrue());
+			AssertThat(SB.size(), Equals(1));
+			AssertThat(SA != SB, IsTrue());
+			AssertThat(SB != SA, IsTrue());
+
+			SB = SA;
+			AssertThat(SA.isMember(a), IsTrue());
+			AssertThat(SA.isMember(b), IsTrue());
+			AssertThat(SA.size(), Equals(2));
+			AssertThat(SB.isMember(a), IsTrue());
+			AssertThat(SB.isMember(b), IsTrue());
+			AssertThat(SB.size(), Equals(2));
+			AssertThat(SA, Equals(SB));
+			AssertThat(SB, Equals(SA));
+
+			SB = SetTypeB(*G);
+			AssertThat(SA.isMember(a), IsTrue());
+			AssertThat(SA.isMember(b), IsTrue());
+			AssertThat(SA.size(), Equals(2));
+			AssertThat(SB.isMember(a), IsFalse());
+			AssertThat(SB.isMember(b), IsFalse());
+			AssertThat(SB.size(), Equals(0));
+			AssertThat(SA != SB, IsTrue());
+			AssertThat(SB != SA, IsTrue());
+		});
+	});
+};
+
+/**
+ * Perform several tests for a type of registered set.
+ *
+ * @tparam BaseType the type of the class (e.g. Graph) that maintains the registered keys
+ * @tparam SetType the type of set to be tested
+ * @tparam KeyType the type of registered key
+ *
+ * @param setType the name of the set type
+ * @param initBase a function to initialize the base
+ * @param chooseKey a function to choose an arbitrary key from the base
+ * @param getAllKeys a function to generate a list of all keys
+ * @param createKey a function to create a new key in the base
+ * @param deleteKey a function to delete an existing key in the base
+ * @param clearAllKeys a function to delete all keys in the base
+ * @param equals a function to check whether two objects are equal wrt. being deleted together
+ */
+template<class BaseType, template<bool> class SetType, typename KeyType>
+void runBasicSetTests(
+		const std::string& setType, std::function<void(BaseType&)> initBase,
+		std::function<KeyType(const BaseType&)> chooseKey,
+		std::function<void(const BaseType&, List<KeyType>&)> getAllKeys,
+		std::function<KeyType(BaseType&)> createKey,
+		std::function<void(BaseType&, KeyType)> deleteKey,
+		std::function<void(BaseType&)> clearAllKeys,
+		std::function<bool(KeyType, KeyType)> equals = [](KeyType a, KeyType b) { return a == b; }) {
+	describeSet<BaseType, SetType<true>, KeyType>(setType + "<true>", initBase, chooseKey,
+			getAllKeys, createKey, deleteKey, clearAllKeys, equals);
+	describeSet<BaseType, SetType<false>, KeyType>(setType + "<false>", initBase, chooseKey,
+			getAllKeys, createKey, deleteKey, clearAllKeys, equals);
+
+	describeSetTemplatedCopyAndEquals<BaseType, SetType<true>, SetType<true>, KeyType>(
+			setType + "<true> and " + setType + "<true>", initBase, chooseKey, getAllKeys,
+			createKey, deleteKey, clearAllKeys, equals);
+	describeSetTemplatedCopyAndEquals<BaseType, SetType<true>, SetType<false>, KeyType>(
+			setType + "<true> and " + setType + "<false>", initBase, chooseKey, getAllKeys,
+			createKey, deleteKey, clearAllKeys, equals);
+	describeSetTemplatedCopyAndEquals<BaseType, SetType<false>, SetType<true>, KeyType>(
+			setType + "<false> and " + setType + "<true>", initBase, chooseKey, getAllKeys,
+			createKey, deleteKey, clearAllKeys, equals);
+	describeSetTemplatedCopyAndEquals<BaseType, SetType<false>, SetType<false>, KeyType>(
+			setType + "<false> and " + setType + "<false>", initBase, chooseKey, getAllKeys,
+			createKey, deleteKey, clearAllKeys, equals);
+
+	// FIXME is cleared() called before or after the changes?
+}

--- a/test/src/basic/array_helper.h
+++ b/test/src/basic/array_helper.h
@@ -768,23 +768,13 @@ void describeSet(const std::string& setType, std::function<void(BaseType&)> init
 			AssertThat(S.size(), Equals(0));
 			AssertThat(S.registeredAt(), IsNull());
 		});
-	});
-}
 
-template<class BaseType, typename SetTypeA, typename SetTypeB, typename KeyType>
-void describeSetTemplatedCopyAndEquals(const std::string& description,
-		std::function<void(BaseType&)> initBase, std::function<KeyType(const BaseType&)> chooseKey,
-		std::function<void(const BaseType&, List<KeyType>&)> getAllKeys,
-		std::function<KeyType(BaseType&)> createKey,
-		std::function<void(BaseType&, KeyType)> deleteKey,
-		std::function<void(BaseType&)> clearAllKeys, std::function<bool(KeyType, KeyType)> equals) {
-	describe(description, [&]() {
 		it("allows equality comparisons", [&]() {
 			std::unique_ptr<BaseType> G = std::make_unique<BaseType>();
 			initBase(*G);
 
-			SetTypeA SA(*G);
-			SetTypeB SB;
+			SetType SA(*G);
+			SetType SB;
 			AssertThat(SA, !Equals(SB));
 			SB.init(*G);
 			AssertThat(SA, Equals(SB));
@@ -833,10 +823,10 @@ void describeSetTemplatedCopyAndEquals(const std::string& description,
 				b = chooseKey(*G);
 			}
 
-			SetTypeA SA(*G);
+			SetType SA(*G);
 			SA.insert(a);
 			SA.insert(b);
-			SetTypeB SB(SA);
+			SetType SB(SA);
 			AssertThat(SB.isMember(a), IsTrue());
 			AssertThat(SB.isMember(b), IsTrue());
 			AssertThat(SB.size(), Equals(2));
@@ -863,7 +853,7 @@ void describeSetTemplatedCopyAndEquals(const std::string& description,
 			AssertThat(SA, Equals(SB));
 			AssertThat(SB, Equals(SA));
 
-			SB = SetTypeB(*G);
+			SB = SetType(*G);
 			AssertThat(SA.isMember(a), IsTrue());
 			AssertThat(SA.isMember(b), IsTrue());
 			AssertThat(SA.size(), Equals(2));
@@ -903,9 +893,5 @@ void runBasicSetTests(
 		std::function<bool(KeyType, KeyType)> equals = [](KeyType a, KeyType b) { return a == b; }) {
 	describeSet<BaseType, SetType, KeyType>(setType, initBase, chooseKey, getAllKeys, createKey,
 			deleteKey, clearAllKeys, equals);
-
-	describeSetTemplatedCopyAndEquals<BaseType, SetType, SetType, KeyType>(setType + " and " + setType,
-			initBase, chooseKey, getAllKeys, createKey, deleteKey, clearAllKeys, equals);
-
 	// FIXME is cleared() called before or after the changes?
 }

--- a/test/src/basic/clusterarray.cpp
+++ b/test/src/basic/clusterarray.cpp
@@ -36,13 +36,11 @@
 #include <ogdf/basic/graph_generators/clustering.h>
 #include <ogdf/basic/graph_generators/randomized.h>
 #include <ogdf/cluster/ClusterGraph.h>
+#include <ogdf/cluster/ClusterSet.h>
 
 #include <functional>
 #include <list>
 #include <string>
-#include <vector>
-
-#include "ogdf/cluster/ClusterSet.h"
 
 #include "array_helper.h"
 #include <testing.h>

--- a/test/src/basic/clusterarray.cpp
+++ b/test/src/basic/clusterarray.cpp
@@ -37,6 +37,7 @@
 #include <ogdf/cluster/ClusterGraph.h>
 
 #include <functional>
+#include <list>
 #include <string>
 
 #include "ogdf/cluster/ClusterSet.h"

--- a/test/src/basic/clusterarray.cpp
+++ b/test/src/basic/clusterarray.cpp
@@ -32,6 +32,7 @@
 #include <ogdf/basic/Graph.h>
 #include <ogdf/basic/GraphList.h>
 #include <ogdf/basic/List.h>
+#include <ogdf/basic/RegisteredSet.h>
 #include <ogdf/basic/graph_generators/clustering.h>
 #include <ogdf/basic/graph_generators/randomized.h>
 #include <ogdf/cluster/ClusterGraph.h>
@@ -39,6 +40,7 @@
 #include <functional>
 #include <list>
 #include <string>
+#include <vector>
 
 #include "ogdf/cluster/ClusterSet.h"
 

--- a/test/src/basic/clustergraphattributes.cpp
+++ b/test/src/basic/clustergraphattributes.cpp
@@ -152,17 +152,17 @@ go_bandit([] {
 		std::unique_ptr<NodeArray<int>> nodeArray(new NodeArray<int>(*G, 42));
 		std::unique_ptr<EdgeArray<int>> edgeArray(new EdgeArray<int>(*G, 42));
 		std::unique_ptr<AdjEntryArray<int>> adjEntryArray(new AdjEntryArray<int>(*G, 42));
-		std::unique_ptr<NodeSet<>> nodeSet(new NodeSet<>(*G));
+		std::unique_ptr<NodeSet> nodeSet(new NodeSet(*G));
 		nodeSet->insert(G->nodes.head());
-		std::unique_ptr<EdgeSet<>> edgeSet(new EdgeSet<>(*G));
+		std::unique_ptr<EdgeSet> edgeSet(new EdgeSet(*G));
 		edgeSet->insert(G->edges.head());
-		std::unique_ptr<AdjEntrySet<>> adjEntrySet(new AdjEntrySet<>(*G));
+		std::unique_ptr<AdjEntrySet> adjEntrySet(new AdjEntrySet(*G));
 		adjEntrySet->insert(G->edges.head()->adjSource());
 
 		std::unique_ptr<CombinatorialEmbedding> CE(new CombinatorialEmbedding(*G));
 		std::unique_ptr<ConstCombinatorialEmbedding> CCE(new ConstCombinatorialEmbedding(*G));
 		std::unique_ptr<FaceArray<int>> faceArray(new FaceArray<int>(*CCE, 42));
-		std::unique_ptr<FaceSet<>> faceSet(new FaceSet<>(*CE));
+		std::unique_ptr<FaceSet> faceSet(new FaceSet(*CE));
 		faceSet->insert(CE->faces.head());
 
 		std::unique_ptr<ClusterGraph> CG(new ClusterGraph(*G));
@@ -171,7 +171,7 @@ go_bandit([] {
 		randomClustering(*CG, 10);
 
 		std::unique_ptr<ClusterArray<int>> clusterArray(new ClusterArray<int>(*CG, 42));
-		std::unique_ptr<ClusterSet<>> clusterSet(new ClusterSet<>(*CG));
+		std::unique_ptr<ClusterSet> clusterSet(new ClusterSet(*CG));
 		clusterSet->insert(CG->clusters.head());
 
 		G.reset(nullptr);

--- a/test/src/basic/edgearray.cpp
+++ b/test/src/basic/edgearray.cpp
@@ -30,6 +30,7 @@
  */
 #include <ogdf/basic/Graph.h>
 #include <ogdf/basic/List.h>
+#include <ogdf/basic/RegisteredSet.h>
 #include <ogdf/basic/graph_generators/randomized.h>
 
 #include <functional>

--- a/test/src/basic/edgearray.cpp
+++ b/test/src/basic/edgearray.cpp
@@ -29,14 +29,13 @@
  * http://www.gnu.org/copyleft/gpl.html
  */
 #include <ogdf/basic/Graph.h>
+#include <ogdf/basic/GraphSets.h>
 #include <ogdf/basic/List.h>
 #include <ogdf/basic/RegisteredSet.h>
 #include <ogdf/basic/graph_generators/randomized.h>
 
 #include <functional>
 #include <string>
-
-#include "ogdf/basic/GraphSets.h"
 
 #include "array_helper.h"
 #include <testing.h>

--- a/test/src/basic/edgearray.cpp
+++ b/test/src/basic/edgearray.cpp
@@ -35,6 +35,8 @@
 #include <functional>
 #include <string>
 
+#include "ogdf/basic/GraphSets.h"
+
 #include "array_helper.h"
 #include <testing.h>
 
@@ -47,7 +49,13 @@ go_bandit([]() {
 		return graph.newEdge(graph.chooseNode(), graph.chooseNode());
 	};
 
+	auto deleteEdge = [](Graph& graph, edge e) { return graph.delEdge(e); };
+
+	auto clearEdges = [](Graph& graph) { return graph.clear(); };
+
 	auto init = [](Graph& graph) { randomGraph(graph, 42, 168); };
 
 	runBasicArrayTests<Graph, EdgeArray, edge>("EdgeArray", init, chooseEdge, allEdges, createEdge);
+	runBasicSetTests<Graph, EdgeSet, edge>("EdgeSet", init, chooseEdge, allEdges, createEdge,
+			deleteEdge, clearEdges);
 });

--- a/test/src/basic/facearray.cpp
+++ b/test/src/basic/facearray.cpp
@@ -29,6 +29,7 @@
  * http://www.gnu.org/copyleft/gpl.html
  */
 #include <ogdf/basic/CombinatorialEmbedding.h>
+#include <ogdf/basic/FaceSet.h>
 #include <ogdf/basic/Graph.h>
 #include <ogdf/basic/GraphList.h>
 #include <ogdf/basic/List.h>
@@ -56,14 +57,23 @@ go_bandit([]() {
 		C.splitFace(a1, a2);
 		return C.lastFace();
 	};
+	auto deleteFace = [](CombinatorialEmbedding& C, face f) {
+		face o = C.joinFaces(f->firstAdj()->twin());
+		OGDF_ASSERT(o != f);
+	};
+	auto clearFaces = [](CombinatorialEmbedding& C) { C.clear(); };
 
-	Graph G;
-
+	std::list<Graph> graphs;
 	auto init = [&](CombinatorialEmbedding& C) {
-		randomPlanarConnectedGraph(G, 42, 168);
-		C.init(G);
+		graphs.emplace_back();
+		randomPlanarConnectedGraph(graphs.back(), 42, 168);
+		C.init(graphs.back());
 	};
 
 	runBasicArrayTests<CombinatorialEmbedding, FaceArray, face>( //
 			"FaceArray", init, chooseFace, allFaces, createFace);
+
+	graphs.clear();
+	runBasicSetTests<CombinatorialEmbedding, FaceSet, face>("FaceSet", init, chooseFace, allFaces,
+			createFace, deleteFace, clearFaces);
 });

--- a/test/src/basic/facearray.cpp
+++ b/test/src/basic/facearray.cpp
@@ -40,7 +40,6 @@
 #include <functional>
 #include <list>
 #include <string>
-#include <vector>
 
 #include "array_helper.h"
 #include <testing.h>

--- a/test/src/basic/facearray.cpp
+++ b/test/src/basic/facearray.cpp
@@ -33,11 +33,14 @@
 #include <ogdf/basic/Graph.h>
 #include <ogdf/basic/GraphList.h>
 #include <ogdf/basic/List.h>
+#include <ogdf/basic/RegisteredSet.h>
+#include <ogdf/basic/basic.h>
 #include <ogdf/basic/graph_generators/randomized.h>
 
 #include <functional>
 #include <list>
 #include <string>
+#include <vector>
 
 #include "array_helper.h"
 #include <testing.h>

--- a/test/src/basic/facearray.cpp
+++ b/test/src/basic/facearray.cpp
@@ -36,6 +36,7 @@
 #include <ogdf/basic/graph_generators/randomized.h>
 
 #include <functional>
+#include <list>
 #include <string>
 
 #include "array_helper.h"

--- a/test/src/basic/graphcopy.cpp
+++ b/test/src/basic/graphcopy.cpp
@@ -658,7 +658,7 @@ go_bandit([]() {
 				});
 
 				it("removes a path", [&]() {
-					FaceSet<false> newFaces(combEmb);
+					FaceSet newFaces(combEmb);
 					graphCopy->removeEdgePathEmbedded(combEmb, tw, newFaces);
 					AssertThat(graphCopy->chain(tw).size(), Equals(0));
 					edge newOldEdge = graphCopy->copy(tw);

--- a/test/src/basic/graphobserver.cpp
+++ b/test/src/basic/graphobserver.cpp
@@ -54,7 +54,9 @@ public:
 	int m_reregistered = 0;
 	const Graph* m_graph;
 
-	explicit CountingGraphObserver(const Graph* G) : GraphObserver(G), m_graph(G) { }
+	explicit CountingGraphObserver(const Graph* G) : GraphObserver(), m_graph(nullptr) {
+		reregister(G);
+	}
 
 	void nodeDeleted(node v) override {
 		consistencyCheck();
@@ -288,13 +290,14 @@ go_bandit([]() {
 			std::unique_ptr<Graph> G1 {new Graph()};
 			LoggingGraphObserver GO(G1.get());
 			AssertThat(GO.getGraph(), Equals(G1.get()));
+			AssertThat(GO.m_reregistered, Equals(1));
 			AssertThat(GO.m_graph, Equals(G1.get()));
 			G1->newNode();
 			AssertThat(GO.m_nodesAdded, Equals(1));
 			G1.reset();
 			AssertThat(GO.getGraph(), Equals(nullptr));
 			AssertThat(GO.m_graph, Equals(nullptr));
-			AssertThat(GO.m_reregistered, Equals(1));
+			AssertThat(GO.m_reregistered, Equals(2));
 			AssertThat(GO.m_cleared, Equals(0));
 			AssertThat(GO.m_nodesAdded, Equals(1));
 			AssertThat(GO.m_edgesAdded, Equals(0));
@@ -306,13 +309,13 @@ go_bandit([]() {
 				GO.reregister(&G2);
 				AssertThat(GO.getGraph(), Equals(&G2));
 				AssertThat(GO.m_graph, Equals(&G2));
-				AssertThat(GO.m_reregistered, Equals(2));
+				AssertThat(GO.m_reregistered, Equals(3));
 				G2.newNode();
 				AssertThat(GO.m_nodesAdded, Equals(2));
 			}
 			AssertThat(GO.getGraph(), Equals(nullptr));
 			AssertThat(GO.m_graph, Equals(nullptr));
-			AssertThat(GO.m_reregistered, Equals(3));
+			AssertThat(GO.m_reregistered, Equals(4));
 			AssertThat(GO.m_cleared, Equals(0));
 			AssertThat(GO.m_nodesAdded, Equals(2));
 			AssertThat(GO.m_edgesAdded, Equals(0));

--- a/test/src/basic/hypergrapharray.cpp
+++ b/test/src/basic/hypergrapharray.cpp
@@ -37,10 +37,8 @@
 #include "array_helper.h"
 #include <testing.h>
 
-template<bool SFSQ>
-using HypernodeSet = RegisteredSet<HypergraphRegistry<HypernodeElement>, SFSQ>;
-template<bool SFSQ>
-using HyperedgeSet = RegisteredSet<HypergraphRegistry<HyperedgeElement>, SFSQ>;
+using HypernodeSet = RegisteredSet<HypergraphRegistry<HypernodeElement>>;
+using HyperedgeSet = RegisteredSet<HypergraphRegistry<HyperedgeElement>>;
 
 go_bandit([]() {
 	auto chooseHypernode = [](const Hypergraph& H) { return H.randomHypernode(); };

--- a/test/src/basic/hypergrapharray.cpp
+++ b/test/src/basic/hypergrapharray.cpp
@@ -37,6 +37,11 @@
 #include "array_helper.h"
 #include <testing.h>
 
+template<bool SFSQ>
+using HypernodeSet = RegisteredSet<HypergraphRegistry<HypernodeElement>, SFSQ>;
+template<bool SFSQ>
+using HyperedgeSet = RegisteredSet<HypergraphRegistry<HyperedgeElement>, SFSQ>;
+
 go_bandit([]() {
 	auto chooseHypernode = [](const Hypergraph& H) { return H.randomHypernode(); };
 
@@ -44,13 +49,16 @@ go_bandit([]() {
 
 	auto createHypernode = [](Hypergraph& H) { return H.newHypernode(); };
 
+	auto deleteHypernode = [](Hypergraph& H, hypernode n) { H.delHypernode(n); };
+	auto deleteHyperedge = [](Hypergraph& H, hyperedge e) { H.delHyperedge(e); };
+
 	auto chooseHyperedge = [](const Hypergraph& H) { return H.randomHyperedge(); };
 
 	auto allHyperedges = [](const Hypergraph& H, List<hyperedge>& list) { H.allHyperedges(list); };
 
 	auto createHyperedge = [](Hypergraph& H) {
 		List<hypernode> newNodes;
-		newNodes.pushBack(H.newHypernode());
+		newNodes.pushBack(H.randomHypernode());
 		newNodes.pushBack(H.newHypernode());
 		newNodes.pushBack(H.newHypernode());
 
@@ -59,14 +67,21 @@ go_bandit([]() {
 
 	auto init = [&](Hypergraph& H) {
 		H.clear();
+		H.newHypernode();
 		for (int i = 0; i < 42; ++i) {
 			createHyperedge(H);
 		}
 	};
+	auto clear = [&](Hypergraph& H) { H.clear(); };
 
 	runBasicArrayTests<Hypergraph, HypernodeArray, hypernode>( //
 			"HypernodeArray", init, chooseHypernode, allHypernodes, createHypernode);
 
 	runBasicArrayTests<Hypergraph, HyperedgeArray, hyperedge>( //
 			"HyperedgeArray", init, chooseHyperedge, allHyperedges, createHyperedge);
+
+	runBasicSetTests<Hypergraph, HypernodeSet, hypernode>("HypergraphRegistry<HypernodeElement>",
+			init, chooseHypernode, allHypernodes, createHypernode, deleteHypernode, clear);
+	runBasicSetTests<Hypergraph, HyperedgeSet, hyperedge>("HypergraphRegistry<HyperedgeElement>",
+			init, chooseHyperedge, allHyperedges, createHyperedge, deleteHyperedge, clear);
 });

--- a/test/src/basic/hypergrapharray.cpp
+++ b/test/src/basic/hypergrapharray.cpp
@@ -29,6 +29,7 @@
  * http://www.gnu.org/copyleft/gpl.html
  */
 #include <ogdf/basic/List.h>
+#include <ogdf/basic/RegisteredSet.h>
 #include <ogdf/hypergraph/Hypergraph.h>
 
 #include <functional>

--- a/test/src/basic/insert.cpp
+++ b/test/src/basic/insert.cpp
@@ -404,15 +404,13 @@ go_bandit([]() {
 
 	describe("inserting some nodes and some edges (triangulation)", [&]() {
 		GraphCopySimple origCon(orig);
-		NodeSet<true> origN(origCon);
-		EdgeSet<true> origE(origCon);
-		EdgeSet<false> origEnS(origCon);
+		NodeSet origN(origCon);
+		EdgeSet origE(origCon);
 		for (node n : origCon.nodes) {
 			origN.insert(n);
 		}
 		for (edge e : origCon.edges) {
 			origE.insert(e);
-			origEnS.insert(e);
 		}
 		{
 			Graph H;
@@ -440,8 +438,7 @@ go_bandit([]() {
 					testFiltered<false, false, false>(origCon, origN, origE));
 		});
 
-		describe("with an EdgeSet<true> as filter", testFiltered(origCon, origN, origE));
-		describe("with an EdgeSet<false> as filter", testFiltered(origCon, origN, origEnS));
+		describe("with an EdgeSet as filter", testFiltered(origCon, origN, origE));
 
 		describe("with other insert variants", [&]() {
 			before_each(reset(origCon));
@@ -451,30 +448,17 @@ go_bandit([]() {
 				checkSameGraph(origN, origE, origN, origE);
 			});
 
-			it("works via insert(nodeList, EdgeSet<true>)", [&] {
+			it("works via insert(nodeList, EdgeSet)", [&] {
 				res = ILG->insert(origN.elements(), origE, nodeMap, edgeMap);
 				AssertThat(ILG->m_edgeFilter, IsTrue());
 			});
-			it("works via insert(nodeList, EdgeSet<false>)", [&] {
-				res = ILG->insert(origN.elements(), origEnS, nodeMap, edgeMap);
-				AssertThat(ILG->m_edgeFilter, IsTrue());
-			});
-			it("works via insert(nodeList, EdgeSet<true>.elements List)", [&] {
+			it("works via insert(nodeList, EdgeSet.elements List)", [&] {
 				res = ILG->insert(origN.elements(), origE.elements(), nodeMap, edgeMap);
 				AssertThat(ILG->m_edgeFilter, IsFalse());
 			});
-			it("works via insert(nodeList, EdgeSet<false>.elements List)", [&] {
-				res = ILG->insert(origN.elements(), origEnS.elements(), nodeMap, edgeMap);
-				AssertThat(ILG->m_edgeFilter, IsFalse());
-			});
-			it("works via insert(nodeBegin, nodesEnd, EdgeSet<true>.begin + end)", [&] {
+			it("works via insert(nodeBegin, nodesEnd, EdgeSet.begin + end)", [&] {
 				res = ILG->insert(origN.begin(), origN.end(), origE.begin(), origE.end(), nodeMap,
 						edgeMap);
-				AssertThat(ILG->m_edgeFilter, IsFalse());
-			});
-			it("works via insert(nodeBegin, nodesEnd, EdgeSet<false>.begin + end)", [&] {
-				res = ILG->insert(origN.begin(), origN.end(), origEnS.begin(), origEnS.end(),
-						nodeMap, edgeMap);
 				AssertThat(ILG->m_edgeFilter, IsFalse());
 			});
 		});

--- a/test/src/basic/nodearray.cpp
+++ b/test/src/basic/nodearray.cpp
@@ -29,6 +29,8 @@
  * http://www.gnu.org/copyleft/gpl.html
  */
 #include <ogdf/basic/Graph.h>
+#include <ogdf/basic/GraphSets.h>
+#include <ogdf/basic/RegisteredSet.h>
 #include <ogdf/basic/graph_generators.h>
 
 #include "array_helper.h" // IWYU pragma: associated

--- a/test/src/basic/nodearray.cpp
+++ b/test/src/basic/nodearray.cpp
@@ -41,6 +41,10 @@ go_bandit([]() {
 
 	auto createNode = [](Graph& graph) { return graph.newNode(); };
 
+	auto deleteNode = [](Graph& graph, node n) { return graph.delNode(n); };
+
+	auto clearNodes = [](Graph& graph) { graph.clear(); };
+
 	auto init = [](Graph& graph) { randomGraph(graph, 42, 168); };
 
 	runBasicArrayTests<Graph, NodeArray, node>("NodeArray", init, chooseNode, allNodes, createNode);
@@ -62,4 +66,7 @@ go_bandit([]() {
 			AssertThat(arr[chooseNode(G)], Equals(p.get()));
 		});
 	});
+
+	runBasicSetTests<Graph, NodeSet, node>("NodeSet", init, chooseNode, allNodes, createNode,
+			deleteNode, clearNodes);
 });

--- a/test/src/cluster/sync_plan.cpp
+++ b/test/src/cluster/sync_plan.cpp
@@ -166,7 +166,7 @@ go_bandit([]() {
 						AssertThat(CG.representsCombEmbedding(), IsTrue());
 						validateGraphCopy(Gcopy);
 
-						EdgeSet<> added(Gcopy);
+						EdgeSet added(Gcopy);
 						insertAugmentationEdges(CG, Gcopy, augmentation, &added, true, true);
 
 						Graph::HiddenEdgeSet hes(Gcopy);

--- a/test/src/graphalg/maximum-density-subgraph.cpp
+++ b/test/src/graphalg/maximum-density-subgraph.cpp
@@ -45,15 +45,14 @@
 
 #include <testing.h>
 
-void test(const std::string& description,
-		std::function<void(Graph& G, NodeSet<true>& expected)> setup) {
+void test(const std::string& description, std::function<void(Graph& G, NodeSet& expected)> setup) {
 	Graph G;
-	NodeSet<true> expected(G);
+	NodeSet expected(G);
 	setup(G, expected);
 
 	it(description, [&] {
 		GraphCopySimple GC(G);
-		NodeSet<true> subgraphNodes(G);
+		NodeSet subgraphNodes(G);
 		bool success =
 				maximumDensitySubgraph(GC, subgraphNodes, [&](node n) { return GC.original(n); });
 		AssertThat(success, IsTrue());
@@ -66,7 +65,7 @@ void test(const std::string& description,
 }
 
 void testContainsAll(const std::string& description, std::function<void(Graph& G)> setup) {
-	test(description, [&](Graph& G, NodeSet<true>& expected) {
+	test(description, [&](Graph& G, NodeSet& expected) {
 		setup(G);
 		for (node n : G.nodes) {
 			expected.insert(n);
@@ -81,7 +80,7 @@ go_bandit([] {
 					{GraphProperty::simple},
 					[&](const Graph& G) {
 						GraphCopySimple GC(G);
-						NodeSet<true> subgraphNodes(G);
+						NodeSet subgraphNodes(G);
 						bool success = maximumDensitySubgraph(GC, subgraphNodes,
 								[&](node n) { return GC.original(n); });
 						AssertThat(success, IsTrue());
@@ -94,10 +93,10 @@ go_bandit([] {
 		});
 
 		describe("Small/special cases", [] {
-			test("works for a single node", [](Graph& G, NodeSet<true>& expected) { G.newNode(); });
+			test("works for a single node", [](Graph& G, NodeSet& expected) { G.newNode(); });
 			test("works for nodes without edges",
-					[](Graph& G, NodeSet<true>& expected) { emptyGraph(G, 3); });
-			test("works for a single edge", [](Graph& G, NodeSet<true>& expected) {
+					[](Graph& G, NodeSet& expected) { emptyGraph(G, 3); });
+			test("works for a single edge", [](Graph& G, NodeSet& expected) {
 				customGraph(G, 2, {{0, 1}});
 				expected.insert(G.firstNode());
 				expected.insert(G.lastNode());
@@ -107,7 +106,7 @@ go_bandit([] {
 			testContainsAll("contains all nodes of a wheel graph",
 					[](Graph& G) { wheelGraph(G, 10); });
 			testContainsAll("contains all nodes of a cube graph", [](Graph& G) { cubeGraph(G, 6); });
-			test("finds the K5", [](Graph& G, NodeSet<true>& expected) {
+			test("finds the K5", [](Graph& G, NodeSet& expected) {
 				completeGraph(G, 5);
 				List<node> K5nodes;
 				G.allNodes(K5nodes);
@@ -120,7 +119,7 @@ go_bandit([] {
 			it("timeouts", [] {
 				Graph G;
 				completeGraph(G, 5);
-				NodeSet<true> subgraphNodes(G);
+				NodeSet subgraphNodes(G);
 				bool success = maximumDensitySubgraph(
 						G, subgraphNodes, [&](node n) { return n; }, 0);
 				AssertThat(success, IsFalse());


### PR DESCRIPTION
This PR makes the `Registry`  class an `Observable`, allowing generic callbacks when keys are added or removed or a registry is deallocated, analogously to the current specific callbacks that are supported by `Graph`. This now also allows `RegisteredSet` to automatically remove deleted elements from its member list once again, which (specifically for `NodeSet`) already worked before #101 (and thus in the time from then till now could be considered a regression -- edit: seems like this was actually broken [since always](https://github.com/ogdf/ogdf/blame/elderberry-202309/include/ogdf/basic/NodeSet.h)). This now adds detailed tests for all currently available Sets to ensure this can no longer break.

Along the way, I added a deterministic `CombEmb::joinFaces` and found that the `Hypergraph` node and edge deletions did not work and fixed them. I now also removed `ClusterSet<false>` which did not maintain a size (but was quite some pain to keep for the one place that used it) - and that did not even help much as we cannot support an efficient splice as unsized linked lists can. Finally, I removed all `OGDF_EXPORT`s from template classes as that ([probably?](https://gcc.gnu.org/wiki/Visibility)) never helps but lead to some weird linkage bugs with their subclasses.