### PR TITLE
Make default .so visibility hidden

### DIFF
--- a/cmake/ogdf.cmake
+++ b/cmake/ogdf.cmake
@@ -129,9 +129,12 @@ set(tinydir_headers "test/include/tinydir.h")
 set(lib_sources "${lib_sources};${lib_headers};${bandit_headers};${tinydir_headers}")
 set_source_files_properties(${lib_sources} PROPERTIES COMPILE_FLAGS " ${warnings_not_as_errors_flag} ")
 
-# set OGDF_INSTALL for shared libraries
+# set OGDF_INSTALL and default visibility to hidden for shared libraries
 if(BUILD_SHARED_LIBS)
   target_compile_definitions(OGDF PRIVATE OGDF_INSTALL)
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(OGDF PRIVATE "-fvisibility=hidden" "-fvisibility-inlines-hidden")
+  endif()
 endif()
 
 # autogen header variables for debug mode

--- a/doc/porting/unreleased.md
+++ b/doc/porting/unreleased.md
@@ -26,6 +26,12 @@ ogdf/hypergraph/HypergraphArray.h
 ```
 The header `ogdf/basic/NodeSet.h` was replaced by `ogdf/basic/GraphSets.h`, now also providing Edge and AdjEntry sets.
 
+## Symbol Visibilities
+To align the behaviour of the Windows and UNIX versions, unix shared library builds now only make classes and functions
+marked `OGDF_EXPORT` publicly visible (as is needed for Windows DLLs anyways). If a non-templated class or top-level
+function you previously used (probably on Linux or MacOS) now became hidden,
+please check the documentation of `OGDF_EXPORT` and then open a PR to make it visible.
+
 ## GraphIO
 
 ### SvgPrinter

--- a/include/ogdf/basic/Graph_d.h
+++ b/include/ogdf/basic/Graph_d.h
@@ -58,13 +58,13 @@
 #endif
 
 namespace ogdf {
-class OGDF_EXPORT AdjElement; // IWYU pragma: keep
-class OGDF_EXPORT ClusterElement; // IWYU pragma: keep
-class OGDF_EXPORT EdgeElement; // IWYU pragma: keep
-class OGDF_EXPORT EdgeSet; // needed for Graph::insert
-class OGDF_EXPORT FaceElement; // IWYU pragma: keep
-class OGDF_EXPORT Graph; // IWYU pragma: keep
-class OGDF_EXPORT NodeElement; // IWYU pragma: keep
+class AdjElement; // IWYU pragma: keep
+class ClusterElement; // IWYU pragma: keep
+class EdgeElement; // IWYU pragma: keep
+class EdgeSet; // needed for Graph::insert
+class FaceElement; // IWYU pragma: keep
+class Graph; // IWYU pragma: keep
+class NodeElement; // IWYU pragma: keep
 
 //! The type of nodes.
 //! @ingroup graphs

--- a/include/ogdf/basic/internal/config.h
+++ b/include/ogdf/basic/internal/config.h
@@ -102,19 +102,71 @@ using std::to_string;
  * - don't use it for any class members (especially member functions)
  * - don't use it for class pre-declarations (used instead of imports or needed for "cyclic" definitions)
  * - use it for all non-template functions (not members, i.e. outside of classes) defined in a header
- * - don't use it for template classes or template functions, except for those that you explicitly instantiate
- *   (see CrossingMinimalPosition<CGAL::Gmpq> in the corresponding cpp file for a somewhat contrived corner-case)
+ * - don't use it for template classes or template functions, except when you explicitly instantiate them
+ *   (see OGDF_EXPORT_TEMPL_INST and OGDF_EXPORT_TEMPL_DECL for explicit template instantiations)
  * - use it for non-member functions declared as friend if you don't declare them somewhere else, e.g.
  *   `class OGDF_EXPORT MyClass { [...] friend OGDF_EXPORT std::ostream& operator<<(std::ostream& os, const MyClass& H); }`
  *
  * For Windows DLL builds, this expands to \c dllexport during library build, and to \c dllimport when
  * a header is used by another library.
- * For shared object builds, this expands to \c __attribute__((visibility("default"))).
+ * For shared object builds, this expands to `__attribute__((visibility("default")))`.
  * For static builds, this expands to nothing.
  *
  * @sa OGDF_LOCAL
  */
 #define OGDF_EXPORT
+
+/**
+ * If you declare a template in a header file, but only provide a definition for its implementation
+ * in a cpp file, you need to also explicitly instantiate this template in the cpp file for all
+ * its anticipated uses. Templates generally do not need to be marked OGDF_EXPORT to be visible
+ * to users of the OGDF, but their explicit instantiations need to be marked such.
+ * As this works slightly different on Windows and UNIX, this macro replaces OGDF_EXPORT (only) for
+ * template instantiations.
+ *
+ * In the header file (usually where you declare the template), you will also need to declare its
+ * explicit instantiations, but also mark them `extern` to not cause their direct instantiation.
+ * For these declarations, use OGDF_EXPORT_TEMPL_DECL.
+ * In the cpp file where you actually instantiate the template, use OGDF_EXPORT_TEMPL_INST.
+ * See `CrossingMinimalPosition<CGAL::Gmpq>` in the corresponding header and cpp file or the code
+ * below for an example.
+ *
+ * Example header file:
+ * ```c++
+ * template<typename T>
+ * class MyTemplate {
+ *     void call(T data);
+ * };
+ *
+ * extern template class OGDF_EXPORT_TEMPL_DECL MyTemplate<double>;
+ * ```
+ * Example cpp implementation file:
+ * ```c++
+ * template<typename T>
+ * void MyTemplate<T>::call(T data) {
+ *     // complicated implementation
+ * }
+ *
+ * template class OGDF_EXPORT_TEMPL_INST MyTemplate<double>;
+ * ```
+ *
+ * On most systems, OGDF_EXPORT_TEMPL_DECL expands to OGDF_EXPORT and OGDF_EXPORT_TEMPL_INST expands
+ * to nothing, as e.g. for gcc the *first* declaration needs to have the export attribute.
+ * Only when building a DLL on Windows, the two definitions are switched as MSVC needs to have the
+ * export attribute on the actual instantiation.
+ *
+ * @sa OGDF_EXPORT
+ * @sa OGDF_EXPORT_TEMPL_INST
+ */
+#define OGDF_EXPORT_TEMPL_DECL OGDF_EXPORT
+
+/**
+ * See OGDF_EXPORT_TEMPL_DECL for documentation.
+ *
+ * @sa OGDF_EXPORT
+ * @sa OGDF_EXPORT_TEMPL_DECL
+ */
+#define OGDF_EXPORT_TEMPL_INST
 
 /**
  * Specifies that a function or class is not exported by the OGDF dynamic library (shared object / DLL).
@@ -130,6 +182,10 @@ using std::to_string;
 #		undef OGDF_EXPORT
 #		ifdef OGDF_INSTALL
 #			define OGDF_EXPORT __declspec(dllexport)
+#			undef OGDF_EXPORT_TEMPL_DECL
+#			undef OGDF_EXPORT_TEMPL_INST
+#			define OGDF_EXPORT_TEMPL_DECL
+#			define OGDF_EXPORT_TEMPL_INST OGDF_EXPORT
 #		else
 #			define OGDF_EXPORT __declspec(dllimport)
 #		endif

--- a/include/ogdf/basic/pctree/PCEnum.h
+++ b/include/ogdf/basic/pctree/PCEnum.h
@@ -38,13 +38,13 @@
 #include <ostream>
 
 namespace ogdf::pc_tree {
-enum class OGDF_EXPORT NodeLabel { Unknown, Partial, Full, Empty = Unknown };
+enum class NodeLabel { Unknown, Partial, Full, Empty = Unknown };
 
-enum class OGDF_EXPORT PCNodeType { PNode, CNode, Leaf };
+enum class PCNodeType { PNode, CNode, Leaf };
 
-class OGDF_EXPORT PCNode;
-class OGDF_EXPORT PCTree;
-class OGDF_EXPORT PCTreeRegistry;
+class PCNode;
+class PCTree;
+class PCTreeRegistry;
 
 #define OGDF_DECL_REG_ARRAY_TYPE(v, c) ogdf::RegisteredArray<PCTreeRegistry, v, c>
 OGDF_DECL_REG_ARRAY(PCTreeNodeArray)

--- a/include/ogdf/basic/pctree/PCNode.h
+++ b/include/ogdf/basic/pctree/PCNode.h
@@ -46,8 +46,8 @@
 
 namespace ogdf::pc_tree {
 class PCTree;
-struct OGDF_EXPORT PCNodeChildrenIterable;
-struct OGDF_EXPORT PCNodeNeighborsIterable;
+struct PCNodeChildrenIterable;
+struct PCNodeNeighborsIterable;
 
 /**
  * A node in a PC-tree that is either a P-node, C-node or leaf.

--- a/include/ogdf/cluster/ClusterGraph.h
+++ b/include/ogdf/cluster/ClusterGraph.h
@@ -49,9 +49,9 @@
 
 namespace ogdf {
 
-class OGDF_EXPORT ClusterElement; // IWYU pragma: keep
-class OGDF_EXPORT ClusterGraph; // IWYU pragma: keep
-class OGDF_EXPORT ClusterGraphObserver; // IWYU pragma: keep
+class ClusterElement; // IWYU pragma: keep
+class ClusterGraph; // IWYU pragma: keep
+class ClusterGraphObserver; // IWYU pragma: keep
 
 using cluster = ClusterElement*; //!< The type of clusters.
 

--- a/include/ogdf/decomposition/PertinentGraph.h
+++ b/include/ogdf/decomposition/PertinentGraph.h
@@ -56,7 +56,7 @@ namespace ogdf {
  * of the skeletons of \a T.
  */
 class OGDF_EXPORT PertinentGraph {
-	friend class OGDF_EXPORT SPQRTree;
+	friend class SPQRTree;
 
 public:
 	// constructor

--- a/include/ogdf/decomposition/Skeleton.h
+++ b/include/ogdf/decomposition/Skeleton.h
@@ -37,7 +37,7 @@
 
 namespace ogdf {
 
-class OGDF_EXPORT SPQRTree;
+class SPQRTree;
 
 //! %Skeleton graphs of nodes in an SPQR-tree.
 /**

--- a/include/ogdf/decomposition/StaticSkeleton.h
+++ b/include/ogdf/decomposition/StaticSkeleton.h
@@ -38,7 +38,7 @@
 
 namespace ogdf {
 
-class OGDF_EXPORT StaticSPQRTree;
+class StaticSPQRTree;
 class SPQRTree;
 
 //! %Skeleton graphs of nodes in a static SPQR-tree.
@@ -60,7 +60,7 @@ class SPQRTree;
  * corresponds to \a eT as well. We call \a e' the twin edge of \a e.
  */
 class OGDF_EXPORT StaticSkeleton : public Skeleton {
-	friend class OGDF_EXPORT StaticSPQRTree;
+	friend class StaticSPQRTree;
 
 public:
 	// constructor

--- a/include/ogdf/external/Minisat.h
+++ b/include/ogdf/external/Minisat.h
@@ -50,6 +50,8 @@
 
 // IWYU pragma: end_keep
 
+#pragma GCC visibility push(default)
+
 namespace Minisat {
 
 using std::endl;
@@ -330,3 +332,5 @@ public:
 };
 
 }
+
+#pragma GCC visibility pop

--- a/include/ogdf/geometric/CrossingMinimalPosition.h
+++ b/include/ogdf/geometric/CrossingMinimalPosition.h
@@ -119,9 +119,13 @@ protected:
 	std::mt19937_64 rnd;
 };
 
+// the actual instantiation happens in CrossingMinimalPosition.cpp (thus the 'extern'),
+// here we just need to mark the instantiated class as EXPORTed
+extern template class OGDF_EXPORT_TEMPL_DECL CrossingMinimalPosition<double>;
 using CrossingMinimalPositionFast = CrossingMinimalPosition<double>;
 
 #ifdef OGDF_INCLUDE_CGAL
+extern template class OGDF_EXPORT_TEMPL_DECL CrossingMinimalPosition<CGAL::Gmpq>;
 using CrossingMinimalPositionPrecise = CrossingMinimalPosition<CGAL::Gmpq>;
 #endif
 

--- a/include/ogdf/hypergraph/Hypergraph.h
+++ b/include/ogdf/hypergraph/Hypergraph.h
@@ -64,10 +64,10 @@ class List;
 
 namespace ogdf {
 
-class OGDF_EXPORT AdjHypergraphElement; // IWYU pragma: keep
-class OGDF_EXPORT HyperedgeElement; // IWYU pragma: keep
-class OGDF_EXPORT Hypergraph; // IWYU pragma: keep
-class OGDF_EXPORT HypernodeElement; // IWYU pragma: keep
+class AdjHypergraphElement; // IWYU pragma: keep
+class HyperedgeElement; // IWYU pragma: keep
+class Hypergraph; // IWYU pragma: keep
+class HypernodeElement; // IWYU pragma: keep
 
 //! The type of hypernodes.
 using hypernode = HypernodeElement*;
@@ -408,7 +408,7 @@ OGDF_DECL_REG_ARRAY(HypernodeArray)
 OGDF_DECL_REG_ARRAY(HyperedgeArray)
 #undef OGDF_DECL_REG_ARRAY_TYPE
 
-class OGDF_EXPORT HypergraphObserver;
+class HypergraphObserver;
 
 class OGDF_EXPORT Hypergraph : public Observable<HypergraphObserver, Hypergraph> {
 	//! The registered hypernode arrays

--- a/include/ogdf/layered/ExtendedNestingGraph.h
+++ b/include/ogdf/layered/ExtendedNestingGraph.h
@@ -272,7 +272,7 @@ private:
 	LHTreeNode* m_root;
 };
 
-class OGDF_EXPORT ExtendedNestingGraph;
+class ExtendedNestingGraph;
 
 class OGDF_EXPORT ClusterGraphCopy : public ClusterGraph {
 public:

--- a/include/ogdf/lib/abacus/abacusroot.h
+++ b/include/ogdf/lib/abacus/abacusroot.h
@@ -45,6 +45,7 @@
 #define ABACUS_VERSION 301
 #define ABACUS_VERSION_STRING "3.0.1/OGDF"
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 using ogdf::AlgorithmFailureException;
@@ -103,3 +104,4 @@ public:
 };
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/active.h
+++ b/include/ogdf/lib/abacus/active.h
@@ -31,6 +31,7 @@
 #include <ogdf/lib/abacus/abacusroot.h>
 
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 class Master;
@@ -219,3 +220,4 @@ private:
 }
 
 #include <ogdf/lib/abacus/active.inc>
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/active.inc
+++ b/include/ogdf/lib/abacus/active.inc
@@ -35,6 +35,7 @@
 #include <ogdf/lib/abacus/convar.h>
 #include <ogdf/lib/abacus/poolslot.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 template <class BaseType, class CoType>
@@ -136,3 +137,4 @@ void Active<BaseType, CoType>::realloc(int newSize)
 }
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/bheap.h
+++ b/include/ogdf/lib/abacus/bheap.h
@@ -32,6 +32,7 @@
 #include <ogdf/lib/abacus/abacusroot.h>
 
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 template<class Type, class Key>
@@ -194,3 +195,4 @@ private:
 }
 
 #include <ogdf/lib/abacus/bheap.inc>
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/bheap.inc
+++ b/include/ogdf/lib/abacus/bheap.inc
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -246,3 +247,4 @@ void AbaBHeap<Type, Key>::heapify(int i)
 }
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/boundbranchrule.h
+++ b/include/ogdf/lib/abacus/boundbranchrule.h
@@ -34,6 +34,7 @@
 #include <ogdf/lib/abacus/branchrule.h>
 #include <ogdf/lib/abacus/sub.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 //! Implements a branching rule for modifying the lower and the upper bound of a variable.
@@ -136,3 +137,4 @@ inline std::ostream &operator<<(std::ostream &out, const BoundBranchRule &rhs)
 }
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/bprioqueue.h
+++ b/include/ogdf/lib/abacus/bprioqueue.h
@@ -32,6 +32,7 @@
 
 #include <ogdf/lib/abacus/bheap.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 //! Bounded priority queues.
@@ -125,3 +126,4 @@ private:
 }
 
 #include <ogdf/lib/abacus/bprioqueue.inc>
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/bprioqueue.inc
+++ b/include/ogdf/lib/abacus/bprioqueue.inc
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -109,3 +110,4 @@ void AbaPrioQueue<Type, Key>::realloc(int newSize)
 }
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/branchrule.h
+++ b/include/ogdf/lib/abacus/branchrule.h
@@ -32,6 +32,7 @@
 
 #include <ogdf/lib/abacus/abacusroot.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 class Master;
@@ -134,3 +135,4 @@ protected:
 };
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/column.h
+++ b/include/ogdf/lib/abacus/column.h
@@ -31,6 +31,7 @@
 
 #include <ogdf/lib/abacus/sparvec.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 //! Representation of variables in column format.
@@ -149,3 +150,4 @@ private:
 };
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/colvar.h
+++ b/include/ogdf/lib/abacus/colvar.h
@@ -37,6 +37,7 @@
 #include <ogdf/lib/abacus/column.h>
 #include <ogdf/lib/abacus/bheap.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 class SparVec;
@@ -180,3 +181,4 @@ inline std::ostream &operator<<(std::ostream &out, const ColVar &rhs)
 }
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/conbranchrule.h
+++ b/include/ogdf/lib/abacus/conbranchrule.h
@@ -38,6 +38,7 @@
 #include <ogdf/lib/abacus/constraint.h>
 #include <ogdf/lib/abacus/variable.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 //! Implements the branching by adding a constraint to the set of active constraints.
@@ -116,3 +117,4 @@ private:
 };
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/conclass.h
+++ b/include/ogdf/lib/abacus/conclass.h
@@ -31,6 +31,7 @@
 
 #include <ogdf/lib/abacus/master.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -96,3 +97,4 @@ private:
 };
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/constraint.h
+++ b/include/ogdf/lib/abacus/constraint.h
@@ -36,6 +36,7 @@
 #include <ogdf/lib/abacus/conclass.h>
 
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 class Row;
@@ -279,10 +280,12 @@ private:
 };
 
 }
+#pragma GCC visibility pop
 
 #include <ogdf/lib/abacus/sub.h>
 #include <ogdf/lib/abacus/master.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 inline Constraint::Constraint (
@@ -313,3 +316,4 @@ inline bool Constraint::valid(Sub *sub) const {
 }
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/convar.h
+++ b/include/ogdf/lib/abacus/convar.h
@@ -32,6 +32,7 @@
 
 #include <ogdf/lib/abacus/abacusroot.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 class Master;
@@ -433,3 +434,4 @@ inline void ConVar::unlock()
 
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/csense.h
+++ b/include/ogdf/lib/abacus/csense.h
@@ -32,6 +32,7 @@
 
 #include <ogdf/lib/abacus/abacusroot.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 class AbacusGlobal;
@@ -114,3 +115,4 @@ private:
 };
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/cutbuffer.h
+++ b/include/ogdf/lib/abacus/cutbuffer.h
@@ -31,6 +31,7 @@
 
 #include <ogdf/lib/abacus/master.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 template<class BaseType, class CoType> class PoolSlot;
@@ -186,3 +187,4 @@ private:
 }
 
 #include <ogdf/lib/abacus/cutbuffer.inc>
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/cutbuffer.inc
+++ b/include/ogdf/lib/abacus/cutbuffer.inc
@@ -37,6 +37,7 @@
 
 #include <ogdf/basic/comparer.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -212,3 +213,4 @@ void CutBuffer<BaseType, CoType>::extract(
 }
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/fixcand.h
+++ b/include/ogdf/lib/abacus/fixcand.h
@@ -32,6 +32,7 @@
 #include <ogdf/lib/abacus/abacusroot.h>
 
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 class Master;
@@ -128,3 +129,4 @@ private:
 };
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/fsvarstat.h
+++ b/include/ogdf/lib/abacus/fsvarstat.h
@@ -31,6 +31,7 @@
 
 #include <ogdf/lib/abacus/abacusroot.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 class AbacusGlobal;
@@ -202,3 +203,4 @@ private:
 };
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/global.h
+++ b/include/ogdf/lib/abacus/global.h
@@ -32,6 +32,7 @@
 #include <ogdf/lib/abacus/abacusroot.h>
 #include <ogdf/lib/abacus/hash.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -423,3 +424,4 @@ private:
 };
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/hash.h
+++ b/include/ogdf/lib/abacus/hash.h
@@ -31,6 +31,7 @@
 
 #include <ogdf/lib/abacus/abacusroot.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 class AbacusGlobal;
@@ -338,3 +339,4 @@ public:
 }
 
 #include <ogdf/lib/abacus/hash.inc>
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/hash.inc
+++ b/include/ogdf/lib/abacus/hash.inc
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -413,3 +414,4 @@ void AbaHash<KeyType, ItemType>::resize(int newSize)
 }
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/history.h
+++ b/include/ogdf/lib/abacus/history.h
@@ -31,6 +31,7 @@
 
 #include <ogdf/lib/abacus/master.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -106,3 +107,4 @@ private:
 };
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/infeascon.h
+++ b/include/ogdf/lib/abacus/infeascon.h
@@ -31,6 +31,7 @@
 
 #include <ogdf/lib/abacus/abacusroot.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 class Constraint;
@@ -96,3 +97,4 @@ private:
 };
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/lp.h
+++ b/include/ogdf/lib/abacus/lp.h
@@ -35,6 +35,7 @@
 #include <ogdf/basic/Stopwatch.h>
 
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 class Master;
@@ -1029,3 +1030,4 @@ inline SlackStat::STATUS LP::slackStat(int i)
 #endif
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/lpmaster.h
+++ b/include/ogdf/lib/abacus/lpmaster.h
@@ -34,6 +34,7 @@
 
 #include <ogdf/lib/abacus/abacusroot.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 class Master;
@@ -60,3 +61,4 @@ protected:
 };
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/lpmasterosi.h
+++ b/include/ogdf/lib/abacus/lpmasterosi.h
@@ -31,6 +31,7 @@
 
 #include <ogdf/lib/abacus/lpmaster.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -67,3 +68,4 @@ public:
 };
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/lpsolution.h
+++ b/include/ogdf/lib/abacus/lpsolution.h
@@ -31,6 +31,7 @@
 
 #include <ogdf/lib/abacus/abacusroot.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -141,3 +142,4 @@ private:
 }
 
 #include <ogdf/lib/abacus/lpsolution.inc>
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/lpsolution.inc
+++ b/include/ogdf/lib/abacus/lpsolution.inc
@@ -33,6 +33,7 @@
 #include <ogdf/lib/abacus/active.h>
 #include <ogdf/lib/abacus/sub.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -149,3 +150,4 @@ int LpSolution<BaseType, CoType>::idLp() const
 }
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/lpsub.h
+++ b/include/ogdf/lib/abacus/lpsub.h
@@ -32,6 +32,7 @@
 #include <ogdf/lib/abacus/lp.h>
 
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 class InfeasCon;
@@ -360,9 +361,11 @@ private:
 };
 
 }
+#pragma GCC visibility pop
 
 #include <ogdf/lib/abacus/sub.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 inline LpSub::LpSub (Master *master, const Sub *sub)
@@ -375,3 +378,4 @@ inline LpSub::LpSub (Master *master, const Sub *sub)
 { }
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/lpsubosi.h
+++ b/include/ogdf/lib/abacus/lpsubosi.h
@@ -36,6 +36,7 @@
 #include <ogdf/lib/abacus/lpsub.h>
 #include <ogdf/lib/abacus/osiif.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -71,3 +72,4 @@ private:
 };
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/lpvarstat.h
+++ b/include/ogdf/lib/abacus/lpvarstat.h
@@ -31,6 +31,7 @@
 
 #include <ogdf/lib/abacus/abacusroot.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -131,3 +132,4 @@ private:
 };
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/master.h
+++ b/include/ogdf/lib/abacus/master.h
@@ -38,6 +38,7 @@
 
 class OsiSolverInterface;
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -1534,3 +1535,4 @@ inline double Master::upperBound() const
 }
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/nonduplpool.h
+++ b/include/ogdf/lib/abacus/nonduplpool.h
@@ -39,6 +39,7 @@
 #include <ogdf/lib/abacus/sub.h>
 #include <ogdf/lib/abacus/bheap.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 //! Standard pools without constraint duplication.
@@ -182,3 +183,4 @@ private:
 }
 
 #include <ogdf/lib/abacus/nonduplpool.inc>
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/nonduplpool.inc
+++ b/include/ogdf/lib/abacus/nonduplpool.inc
@@ -30,6 +30,7 @@
 
 #include <ogdf/lib/abacus/nonduplpool.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -120,3 +121,4 @@ void NonDuplPool<BaseType, CoType>::hardDeleteConVar(
 }
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/numcon.h
+++ b/include/ogdf/lib/abacus/numcon.h
@@ -35,6 +35,7 @@
 #include <ogdf/lib/abacus/constraint.h>
 
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -115,9 +116,11 @@ private:
 };
 
 }
+#pragma GCC visibility pop
 
 #include <ogdf/lib/abacus/colvar.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 inline double NumCon::coeff(const Variable *v) const
@@ -127,3 +130,4 @@ inline double NumCon::coeff(const Variable *v) const
 }
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/numvar.h
+++ b/include/ogdf/lib/abacus/numvar.h
@@ -31,6 +31,7 @@
 
 #include <ogdf/lib/abacus/variable.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -96,3 +97,4 @@ protected:
 };
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/opensub.h
+++ b/include/ogdf/lib/abacus/opensub.h
@@ -32,6 +32,7 @@
 #include <ogdf/basic/List.h>
 #include <ogdf/lib/abacus/abacusroot.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -121,3 +122,4 @@ private:
 };
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/optsense.h
+++ b/include/ogdf/lib/abacus/optsense.h
@@ -31,6 +31,7 @@
 
 #include <ogdf/lib/abacus/abacusroot.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -104,3 +105,4 @@ private:
 
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/osiif.h
+++ b/include/ogdf/lib/abacus/osiif.h
@@ -39,6 +39,7 @@
 #include <coin/CoinWarmStartBasis.hpp>
 #include <coin/CoinBuild.hpp>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 class LpMasterOsi;
@@ -550,3 +551,4 @@ private:
 };
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/pool.h
+++ b/include/ogdf/lib/abacus/pool.h
@@ -32,6 +32,7 @@
 #include <ogdf/lib/abacus/poolslot.h>
 #include <ogdf/lib/abacus/master.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -195,3 +196,4 @@ protected:
 };
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/poolslot.h
+++ b/include/ogdf/lib/abacus/poolslot.h
@@ -34,6 +34,7 @@
 #include <ogdf/lib/abacus/constraint.h>
 #include <ogdf/lib/abacus/variable.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 class Sub;
@@ -179,3 +180,4 @@ private:
 }
 
 #include <ogdf/lib/abacus/poolslot.inc>
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/poolslot.inc
+++ b/include/ogdf/lib/abacus/poolslot.inc
@@ -32,6 +32,7 @@
 #include <ogdf/lib/abacus/pool.h>
 #include <ogdf/lib/abacus/convar.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 template<class BaseType, class CoType>
@@ -79,3 +80,4 @@ void PoolSlot<BaseType, CoType>::insert(BaseType *convar)
 }
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/poolslotref.h
+++ b/include/ogdf/lib/abacus/poolslotref.h
@@ -34,6 +34,7 @@
 #include <ogdf/lib/abacus/constraint.h>
 #include <ogdf/lib/abacus/variable.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 template<class BaseType, class CoType>
@@ -171,3 +172,4 @@ private:
 }
 
 #include <ogdf/lib/abacus/poolslotref.inc>
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/poolslotref.inc
+++ b/include/ogdf/lib/abacus/poolslotref.inc
@@ -30,6 +30,7 @@
 
 #include <ogdf/lib/abacus/poolslotref.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -68,3 +69,4 @@ void PoolSlotRef<BaseType, CoType>::slot(PoolSlot<BaseType, CoType> *s)
 }
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/ring.h
+++ b/include/ogdf/lib/abacus/ring.h
@@ -32,6 +32,7 @@
 #include <ogdf/lib/abacus/abacusroot.h>
 
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 template <class Type>
@@ -167,3 +168,4 @@ private:
 }
 
 #include <ogdf/lib/abacus/ring.inc>
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/ring.inc
+++ b/include/ogdf/lib/abacus/ring.inc
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -219,3 +220,4 @@ void AbaRing<Type>::realloc(int newSize)
 }
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/row.h
+++ b/include/ogdf/lib/abacus/row.h
@@ -32,6 +32,7 @@
 #include <ogdf/lib/abacus/sparvec.h>
 #include <ogdf/lib/abacus/csense.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -182,3 +183,4 @@ protected:
 
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/rowcon.h
+++ b/include/ogdf/lib/abacus/rowcon.h
@@ -33,6 +33,7 @@
 #include <ogdf/lib/abacus/constraint.h>
 #include <ogdf/lib/abacus/numvar.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -160,3 +161,4 @@ protected:
 };
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/separator.h
+++ b/include/ogdf/lib/abacus/separator.h
@@ -34,6 +34,7 @@
 #include <ogdf/lib/abacus/lpsolution.h>
 #include <ogdf/lib/abacus/nonduplpool.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -200,3 +201,4 @@ private:
 }
 
 #include <ogdf/lib/abacus/separator.inc>
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/separator.inc
+++ b/include/ogdf/lib/abacus/separator.inc
@@ -32,6 +32,7 @@
 #include <ogdf/lib/abacus/constraint.h>
 #include <ogdf/lib/abacus/variable.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -88,3 +89,4 @@ bool Separator<BaseType, CoType>::find(BaseType *cv)
 }
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/setbranchrule.h
+++ b/include/ogdf/lib/abacus/setbranchrule.h
@@ -35,6 +35,7 @@
 #include <ogdf/lib/abacus/branchrule.h>
 #include <ogdf/lib/abacus/fsvarstat.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -124,3 +125,4 @@ private:
 };
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/slackstat.h
+++ b/include/ogdf/lib/abacus/slackstat.h
@@ -31,6 +31,7 @@
 
 #include <ogdf/lib/abacus/abacusroot.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 class AbacusGlobal;
@@ -108,3 +109,4 @@ private:
 };
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/sparvec.h
+++ b/include/ogdf/lib/abacus/sparvec.h
@@ -31,6 +31,7 @@
 
 #include <ogdf/lib/abacus/global.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -284,3 +285,4 @@ protected:
 };
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/srowcon.h
+++ b/include/ogdf/lib/abacus/srowcon.h
@@ -31,6 +31,7 @@
 
 #include <ogdf/lib/abacus/rowcon.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 //! Constraints using row with static variable set.
@@ -144,3 +145,4 @@ public:
 };
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/standardpool.h
+++ b/include/ogdf/lib/abacus/standardpool.h
@@ -32,6 +32,7 @@
 #include <ogdf/basic/SList.h>
 #include <ogdf/lib/abacus/pool.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -212,3 +213,4 @@ private:
 }
 
 #include <ogdf/lib/abacus/standardpool.inc>
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/standardpool.inc
+++ b/include/ogdf/lib/abacus/standardpool.inc
@@ -36,6 +36,7 @@
 #include <ogdf/lib/abacus/sub.h>
 #include <ogdf/lib/abacus/bheap.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 template<class BaseType, class CoType>
@@ -235,3 +236,4 @@ int StandardPool<BaseType, CoType>::separate(
 }
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/sub.h
+++ b/include/ogdf/lib/abacus/sub.h
@@ -36,6 +36,7 @@
 #include <ogdf/basic/Stopwatch.h>
 
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 class LpSub;
@@ -1809,6 +1810,7 @@ private:
 };
 
 }
+#pragma GCC visibility pop
 
 // NOW declaration of sub is complete. its definitions below need full declarations of the below types...
 
@@ -1818,6 +1820,7 @@ private:
 #include <ogdf/lib/abacus/cutbuffer.h>
 #include <ogdf/lib/abacus/lpsub.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 inline int Sub::addBranchingConstraint(PoolSlot<Constraint, Variable> *slot)
@@ -1919,3 +1922,4 @@ inline void Sub::uBound(int i, double u)
 }
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/tailoff.h
+++ b/include/ogdf/lib/abacus/tailoff.h
@@ -32,6 +32,7 @@
 #include <ogdf/lib/abacus/ring.h>
 #include <ogdf/lib/abacus/master.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -162,3 +163,4 @@ protected:
 };
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/valbranchrule.h
+++ b/include/ogdf/lib/abacus/valbranchrule.h
@@ -34,6 +34,7 @@
 
 #include <ogdf/lib/abacus/branchrule.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -106,3 +107,4 @@ private:
 };
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/variable.h
+++ b/include/ogdf/lib/abacus/variable.h
@@ -35,6 +35,7 @@
 #include <ogdf/lib/abacus/vartype.h>
 #include <ogdf/lib/abacus/constraint.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -277,3 +278,4 @@ inline bool Variable::valid(const Sub *sub) const
 
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/abacus/vartype.h
+++ b/include/ogdf/lib/abacus/vartype.h
@@ -31,6 +31,7 @@
 
 #include <ogdf/lib/abacus/abacusroot.h>
 
+#pragma GCC visibility push(default)
 namespace abacus {
 
 
@@ -99,3 +100,4 @@ private:
 };
 
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/mapbox/mapbox_earcut.h
+++ b/include/ogdf/lib/mapbox/mapbox_earcut.h
@@ -24,6 +24,7 @@
 #include <memory>
 #include <vector>
 
+#pragma GCC visibility push(default)
 namespace mapbox {
 
 namespace util {
@@ -789,3 +790,4 @@ std::vector<N> earcut(const Polygon& poly) {
 	return std::move(earcut.indices);
 }
 }
+#pragma GCC visibility pop

--- a/include/ogdf/lib/minisat/core/Solver.h
+++ b/include/ogdf/lib/minisat/core/Solver.h
@@ -27,6 +27,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #include <ogdf/lib/minisat/core/SolverTypes.h>
 
 
+#pragma GCC visibility push(default)
 namespace Minisat {
 namespace Internal {
 
@@ -412,3 +413,4 @@ inline void     Solver::toDimacs     (const char* file, Lit p, Lit q, Lit r){ ve
 //=================================================================================================
 } // namespace Internal
 } // namespace Minisat
+#pragma GCC visibility pop

--- a/include/ogdf/lib/minisat/core/SolverTypes.h
+++ b/include/ogdf/lib/minisat/core/SolverTypes.h
@@ -28,6 +28,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #include <ogdf/lib/minisat/mtl/Map.h>
 #include <ogdf/lib/minisat/mtl/Alloc.h>
 
+#pragma GCC visibility push(default)
 namespace Minisat {
 namespace Internal {
 
@@ -425,3 +426,4 @@ inline void Clause::strengthen(Lit p)
 //=================================================================================================
 } // namespace Internal
 } // namespace Minisat
+#pragma GCC visibility pop

--- a/include/ogdf/lib/minisat/mtl/Alg.h
+++ b/include/ogdf/lib/minisat/mtl/Alg.h
@@ -22,6 +22,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 
 #include <ogdf/lib/minisat/mtl/Vec.h>
 
+#pragma GCC visibility push(default)
 namespace Minisat {
 namespace Internal {
 
@@ -81,3 +82,4 @@ static inline void append(const vec<T>& from, vec<T>& to){ copy(from, to, true);
 //=================================================================================================
 } // namespace Internal
 } // namespace Minisat
+#pragma GCC visibility pop

--- a/include/ogdf/lib/minisat/mtl/Alloc.h
+++ b/include/ogdf/lib/minisat/mtl/Alloc.h
@@ -23,6 +23,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #include <ogdf/lib/minisat/mtl/XAlloc.h>
 #include <ogdf/lib/minisat/mtl/Vec.h>
 
+#pragma GCC visibility push(default)
 namespace Minisat {
 namespace Internal {
 
@@ -136,3 +137,4 @@ RegionAllocator<T>::alloc(int size)
 //=================================================================================================
 } // namespace Internal
 } // namespace Minisat
+#pragma GCC visibility pop

--- a/include/ogdf/lib/minisat/mtl/Heap.h
+++ b/include/ogdf/lib/minisat/mtl/Heap.h
@@ -22,6 +22,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 
 #include <ogdf/lib/minisat/mtl/Vec.h>
 
+#pragma GCC visibility push(default)
 namespace Minisat {
 namespace Internal {
 
@@ -145,3 +146,4 @@ class Heap {
 //=================================================================================================
 } // namespace Internal
 } // namespace Minisat
+#pragma GCC visibility pop

--- a/include/ogdf/lib/minisat/mtl/Map.h
+++ b/include/ogdf/lib/minisat/mtl/Map.h
@@ -22,6 +22,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #include <ogdf/lib/minisat/mtl/IntTypes.h>
 #include <ogdf/lib/minisat/mtl/Vec.h>
 
+#pragma GCC visibility push(default)
 namespace Minisat {
 namespace Internal {
 
@@ -192,3 +193,4 @@ class Map {
 //=================================================================================================
 } // namespace Internal
 } // namespace Minisat
+#pragma GCC visibility pop

--- a/include/ogdf/lib/minisat/mtl/Queue.h
+++ b/include/ogdf/lib/minisat/mtl/Queue.h
@@ -22,6 +22,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 
 #include <ogdf/lib/minisat/mtl/Vec.h>
 
+#pragma GCC visibility push(default)
 namespace Minisat {
 namespace Internal {
 
@@ -68,3 +69,4 @@ public:
 //=================================================================================================
 } // namespace Internal
 } // namespace Minisat
+#pragma GCC visibility pop

--- a/include/ogdf/lib/minisat/mtl/Sort.h
+++ b/include/ogdf/lib/minisat/mtl/Sort.h
@@ -26,6 +26,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 // Some sorting algorithms for vec's
 
 
+#pragma GCC visibility push(default)
 namespace Minisat {
 namespace Internal {
 
@@ -95,3 +96,4 @@ template <class T> void sort(vec<T>& v) {
 //=================================================================================================
 } // namespace Internal
 } // namespace Minisat
+#pragma GCC visibility pop

--- a/include/ogdf/lib/minisat/mtl/Vec.h
+++ b/include/ogdf/lib/minisat/mtl/Vec.h
@@ -26,6 +26,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #include <ogdf/lib/minisat/mtl/IntTypes.h>
 #include <ogdf/lib/minisat/mtl/XAlloc.h>
 
+#pragma GCC visibility push(default)
 namespace Minisat {
 namespace Internal {
 
@@ -129,3 +130,4 @@ void vec<T>::clear(bool dealloc) {
 //=================================================================================================
 } // namespace Internal
 } // namespace Minisat
+#pragma GCC visibility pop

--- a/include/ogdf/lib/minisat/mtl/XAlloc.h
+++ b/include/ogdf/lib/minisat/mtl/XAlloc.h
@@ -22,6 +22,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #include <errno.h>
 #include <stdlib.h>
 
+#pragma GCC visibility push(default)
 namespace Minisat {
 namespace Internal {
 
@@ -41,3 +42,4 @@ static inline void* xrealloc(void *ptr, size_t size)
 //=================================================================================================
 } // namespace Internal
 } // namespace Minisat
+#pragma GCC visibility pop

--- a/include/ogdf/lib/minisat/simp/SimpSolver.h
+++ b/include/ogdf/lib/minisat/simp/SimpSolver.h
@@ -24,6 +24,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #include <ogdf/lib/minisat/core/Solver.h>
 
 
+#pragma GCC visibility push(default)
 namespace Minisat {
 namespace Internal {
 
@@ -198,3 +199,4 @@ inline lbool SimpSolver::solveLimited (const vec<Lit>& assumps, bool do_simp, bo
 //=================================================================================================
 } // namespace Internal
 } // namespace Minisat
+#pragma GCC visibility pop

--- a/include/ogdf/lib/minisat/utils/Options.h
+++ b/include/ogdf/lib/minisat/utils/Options.h
@@ -28,6 +28,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #include <ogdf/lib/minisat/mtl/Vec.h>
 #include <ogdf/lib/minisat/utils/ParseUtils.h>
 
+#pragma GCC visibility push(default)
 namespace Minisat {
 namespace Internal {
 
@@ -112,3 +113,4 @@ class BoolOption
 //=================================================================================================
 } // namespace Internal
 } // namespace Minisat
+#pragma GCC visibility pop

--- a/include/ogdf/lib/minisat/utils/ParseUtils.h
+++ b/include/ogdf/lib/minisat/utils/ParseUtils.h
@@ -25,6 +25,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 
 //#include <ogdf/lib/minisat/win/zlib.h>
 
+#pragma GCC visibility push(default)
 namespace Minisat {
 namespace Internal {
 
@@ -121,3 +122,4 @@ static bool eagerMatch(B& in, const char* str) {
 //=================================================================================================
 } // namespace Internal
 } // namespace Minisat
+#pragma GCC visibility pop

--- a/include/ogdf/lib/pugixml/pugiconfig.h
+++ b/include/ogdf/lib/pugixml/pugiconfig.h
@@ -15,6 +15,8 @@
 
 #include <ogdf/basic/internal/config.h>
 
+#define PUGIXML_API OGDF_EXPORT
+
 // Uncomment this to enable wchar_t mode
 // #define PUGIXML_WCHAR_MODE
 

--- a/include/ogdf/orthogonal/OrthoRep.h
+++ b/include/ogdf/orthogonal/OrthoRep.h
@@ -44,7 +44,7 @@
 
 namespace ogdf {
 
-class OGDF_EXPORT PlanRep;
+class PlanRep;
 
 
 // type for bends (convex or reflex)

--- a/include/ogdf/upward/internal/UpwardPlanaritySingleSource.h
+++ b/include/ogdf/upward/internal/UpwardPlanaritySingleSource.h
@@ -70,7 +70,7 @@ private:
 	//! Maintains constraints set during upward-planarity test on rooting of SPQR-tree
 	class ConstraintRooting;
 	// classes defined and used in UpwardPlanaritySingleSource.cpp
-	class OGDF_EXPORT SkeletonInfo;
+	class SkeletonInfo;
 
 
 	// performs the actual test (and computation of sorted adjacency lists) for

--- a/src/ogdf/geometric/CrossingMinimalPosition.cpp
+++ b/src/ogdf/geometric/CrossingMinimalPosition.cpp
@@ -104,8 +104,8 @@ DPoint CrossingMinimalPosition<FT>::call(GraphAttributes& GA, node v) {
 	return p;
 }
 
-template class CrossingMinimalPosition<double>;
-template class CrossingMinimalPosition<CGAL::Gmpq>;
+template class OGDF_EXPORT_TEMPL_INST CrossingMinimalPosition<double>;
+template class OGDF_EXPORT_TEMPL_INST CrossingMinimalPosition<CGAL::Gmpq>;
 
 }
 #else


### PR DESCRIPTION
On Windows, we already have to annotate all classes and standalone function that we want to use from somewhere else with OGDF_EXPORT. This often led to annoying Windows CI failures for code developed on a Linux machine where OGDF_EXPORT was forgotten. To make all targets more similar in this effect, this PR now makes the behaviour on Unix analogous to that on Windows. See here for the details:
https://gcc.gnu.org/wiki/Visibility
This is the list of symbols [before](https://github.com/user-attachments/files/19397288/ogdf-before.txt) and [after](https://github.com/user-attachments/files/19397287/ogdf-after.txt).
This probably needs some more investigation while they are that different (safe for template instantiations), as anything that now became invisible is probably already invisible on Windows.

