### PR TITLE
Remove TreeLayout::RootSelectionType::Sink

### DIFF
--- a/include/ogdf/basic/simple_graph_alg.h
+++ b/include/ogdf/basic/simple_graph_alg.h
@@ -927,6 +927,9 @@ inline bool isTree(const Graph& G) {
 /**
  * @ingroup ga-tree
  *
+ * An arborescence is a digraph that has a unique node with indegree 0 (the root)
+ * such that, for any other vertex v, there is exactly one directed walk from r to v.
+ *
  * @param G is the input graph.
  * @param roots is assigned the list of root nodes of the arborescences in the forest.
  * If false is returned, \p roots is undefined.
@@ -937,6 +940,9 @@ OGDF_EXPORT bool isArborescenceForest(const Graph& G, List<node>& roots);
 //! Returns true iff \p G is a forest consisting only of arborescences.
 /**
  * @ingroup ga-tree
+ *
+ * An arborescence is a digraph that has a unique node with indegree 0 (the root)
+ * such that, for any other vertex v, there is exactly one directed walk from r to v.
  *
  * @param G is the input graph.
  * @return true if \p G represents an arborescence forest, false otherwise.
@@ -966,6 +972,9 @@ inline bool isForest(const Graph& G) { return isArborescenceForest(G); }
 /**
  * @ingroup ga-tree
  *
+ * An arborescence is a digraph that has a unique node with indegree 0 (the root)
+ * such that, for any other vertex v, there is exactly one directed walk from r to v.
+ *
  * @param G    is the input graph.
  * @param root is assigned the root node (if true is returned).
  * @return true if \p G represents an arborescence, false otherwise.
@@ -975,6 +984,9 @@ OGDF_EXPORT bool isArborescence(const Graph& G, node& root);
 //! Returns true iff \p G represents an arborescence.
 /**
  * @ingroup ga-tree
+ *
+ * An arborescence is a digraph that has a unique node with indegree 0 (the root)
+ * such that, for any other vertex v, there is exactly one directed walk from r to v.
  *
  * @param G  is the input graph.
  * @return true if \p G represents an arborescence, false otherwise.

--- a/include/ogdf/tree/TreeLayout.h
+++ b/include/ogdf/tree/TreeLayout.h
@@ -83,7 +83,7 @@ class SListPure;
  *   </tr><tr>
  *     <td><i>selectRoot</i><td> #RootSelectionType <td> RootSelectionType::Source
  *     <td>Determines how to select the root of the tree(s). Possible
- *     selection strategies are to take a (unique) source or sink in
+ *     selection strategies are to take a (unique) source in
  *     the graph, or to use the coordinates and to select the topmost
  *     node for top-to-bottom orientation, etc.
  *   </tr>
@@ -100,7 +100,6 @@ public:
 	//! Determines how to select the root of the tree.
 	enum class RootSelectionType {
 		Source, //!< Select a source in the graph.
-		Sink, //!< Select a sink in the graph.
 		ByCoord //!< Use the coordinates, e.g., select the topmost node if orientation is topToBottom.
 	};
 

--- a/src/ogdf/tree/TreeLayout.cpp
+++ b/src/ogdf/tree/TreeLayout.cpp
@@ -381,7 +381,13 @@ void TreeLayout::call(GraphAttributes& AG) {
 		return;
 	}
 
-	OGDF_ASSERT(isArborescenceForest(tree));
+#ifdef OGDF_DEBUG
+	if (m_selectRoot == RootSelectionType::Source) {
+		OGDF_ASSERT(isArborescenceForest(tree));
+	} else {
+		OGDF_ASSERT(isAcyclicUndirected(tree));
+	}
+#endif
 	OGDF_ASSERT(m_siblingDistance > 0);
 	OGDF_ASSERT(m_subtreeDistance > 0);
 	OGDF_ASSERT(m_levelDistance > 0);

--- a/src/ogdf/tree/TreeLayout.cpp
+++ b/src/ogdf/tree/TreeLayout.cpp
@@ -240,10 +240,6 @@ void TreeLayout::setRoot(GraphAttributes& AG, Graph& tree, SListPure<edge>& reve
 					if (x->indeg() == 0) {
 						root = x;
 					}
-				} else if (m_selectRoot == RootSelectionType::Sink) {
-					if (x->outdeg() == 0) {
-						root = x;
-					}
 				} else { // selectByCoordinate
 					root = x;
 				}


### PR DESCRIPTION
It's broken and can be simulated with `G.reverseAllEdges()`, so rather than implementing it, we just remove it.

Close #195 

