### PR TITLE
1-Planarity backtracking

### DIFF
--- a/doc/examples/k-planarity/one-planarity.cpp
+++ b/doc/examples/k-planarity/one-planarity.cpp
@@ -1,0 +1,81 @@
+#include <ogdf/basic/Graph.h>
+#include <ogdf/basic/GraphList.h>
+#include <ogdf/basic/GraphSets.h>
+#include <ogdf/basic/List.h>
+#include <ogdf/basic/Module.h>
+#include <ogdf/basic/basic.h>
+#include <ogdf/basic/extended_graph_alg.h>
+#include <ogdf/basic/graph_generators/deterministic.h>
+#include <ogdf/basic/simple_graph_alg.h>
+#include <ogdf/k-planarity/1-planarity_backtracking/OnePlanarityBacktracking.h>
+#include <ogdf/k-planarity/1-planarity_backtracking/OnePlanarization.h>
+#include <ogdf/k-planarity/1-planarity_backtracking/PartialSolutionFilter.h>
+
+#include <memory>
+#include <set>
+#include <vector>
+
+using namespace ogdf;
+using namespace oneplan_backtracking;
+using ReturnType = Module::ReturnType;
+
+int main() {
+	// Creating a solver that uses at most 1000 threads and extracts up to 1000 Kuratowski-subdivisions in each step
+	OnePlanarityBacktracking solver(1000, 1000);
+
+	Graph K5;
+	completeGraph(K5, 5);
+	// Testing 1-Planarity:
+	OGDF_ASSERT(solver.testOnePlanarity(K5) == ReturnType::Feasible);
+
+	// A corresponding planarization can be obtained as follows:
+	OnePlanarization planarization;
+	solver.testOnePlanarity(K5, &planarization);
+	OGDF_ASSERT(isPlanar(planarization));
+	OGDF_ASSERT(planarization.numberOfNodes() == 6); // 1 additional crossing vertex
+	OGDF_ASSERT(planarization.kiteEdges().size() == 0); // No kite edges in a complete graph
+	OGDF_ASSERT(planarization.numberOfEdges()
+			== 12); // K5 minus 2 edges plus 4 edges incident to crossing vertex
+
+	// kite edges are mapped to nullptr, edges incident to crossing vertices are mapped to the corresponding crossing edge:
+	for (node crossingVertex : planarization.crossingVertices()) {
+		OGDF_ASSERT(crossingVertex->degree() == 4);
+		std::set<edge> originalEdges;
+		for (adjEntry adj : crossingVertex->adjEntries) {
+			originalEdges.insert(planarization.original(adj->theEdge()));
+		}
+		OGDF_ASSERT(originalEdges.size() == 2);
+	}
+
+	planarEmbed(planarization); // Represents a 1-planar embedding of K5
+
+	// Testing IC- or NIC-planarity:
+	OGDF_ASSERT(solver.testICPlanarity(K5) == ReturnType::Feasible);
+	OGDF_ASSERT(solver.testNICPlanarity(K5) == ReturnType::Feasible);
+
+	// No-instances:
+	Graph K7;
+	completeGraph(K7, 7);
+	OGDF_ASSERT(solver.testOnePlanarity(K7) == ReturnType::NoFeasibleSolution);
+
+	// Implementing custom filters:
+	class BipartiteDensityFilter : public PartialSolutionFilter {
+		// Bipartite 1-planar graphs have at most 3n-8 edges. This must also hold for the planarization of a partial solution.
+		bool canCut(OnePlanarization& pl) override {
+			return isBipartite(pl) && pl.numberOfEdges() > 3 * pl.numberOfNodes() - 8;
+		}
+	};
+
+	class MyOneplanSolver : public OnePlanarityBacktracking {
+	public:
+		MyOneplanSolver() : OnePlanarityBacktracking() {
+			m_filters.emplace_back(new BipartiteDensityFilter);
+		}
+	};
+
+	Graph K45;
+	completeBipartiteGraph(K45, 4, 5);
+	MyOneplanSolver mySolver;
+	OGDF_ASSERT(mySolver.testOnePlanarity(K45) == ReturnType::NoFeasibleSolution);
+	OGDF_ASSERT(mySolver.processedNodes() <= 1);
+}

--- a/include/ogdf/k-planarity/1-planarity_backtracking/EdgePairPartition.h
+++ b/include/ogdf/k-planarity/1-planarity_backtracking/EdgePairPartition.h
@@ -1,0 +1,274 @@
+/** \file
+ * \brief Partial solutions for backtracking 1-Planarity.
+ *
+ * \author Matthias Pfretzschner
+ *
+ * \par License:
+ * This file is part of the Open Graph Drawing Framework (OGDF).
+ *
+ * \par
+ * Copyright (C)<br>
+ * See README.md in the OGDF root directory for details.
+ *
+ * \par
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * Version 2 or 3 as published by the Free Software Foundation;
+ * see the file LICENSE.txt included in the packaging of this file
+ * for details.
+ *
+ * \par
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * \par
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, see
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#pragma once
+
+#include <ogdf/basic/Graph.h>
+#include <ogdf/basic/GraphList.h>
+#include <ogdf/basic/GraphSets.h>
+#include <ogdf/basic/basic.h>
+
+#include <list>
+#include <memory>
+#include <set>
+#include <stack>
+#include <vector>
+
+namespace ogdf::oneplan_backtracking {
+
+//! A pair of distinct graph elements, ordered by their index.
+template<typename GraphElementPointer>
+class OrderedPair {
+private:
+	GraphElementPointer m_first, m_second;
+
+public:
+	//! Creates a new pair that consists of \p a and \p b.
+	OrderedPair(GraphElementPointer a, GraphElementPointer b) {
+		OGDF_ASSERT(a && b);
+		OGDF_ASSERT(a->graphOf() == b->graphOf());
+		OGDF_ASSERT(a != b);
+		if (a->index() < b->index()) {
+			m_first = a;
+			m_second = b;
+		} else {
+			m_first = b;
+			m_second = a;
+		}
+	}
+
+	//! Returns the element with smaller index.
+	GraphElementPointer first() const { return m_first; }
+
+	//! Returns the element with larger index.
+	GraphElementPointer second() const { return m_second; }
+
+	//! Returns whether \p el is contained in the pair.
+	bool contains(GraphElementPointer el) const { return m_first == el || m_second == el; }
+
+	bool operator==(const OrderedPair& rhs) const {
+		OGDF_ASSERT(graphOf() == rhs.graphOf());
+		OGDF_ASSERT(m_first->index() <= m_second->index());
+		OGDF_ASSERT(rhs.m_first->index() <= rhs.m_second->index());
+
+		return m_first == rhs.m_first && m_second == rhs.m_second;
+	}
+
+	bool operator!=(const OrderedPair& rhs) const { return !operator==(rhs); }
+
+	bool operator<(const OrderedPair& rhs) const {
+		OGDF_ASSERT(graphOf() == rhs.graphOf());
+		OGDF_ASSERT(m_first->index() <= m_second->index());
+		OGDF_ASSERT(rhs.m_first->index() <= rhs.m_second->index());
+
+		return m_first->index() < rhs.m_first->index()
+				|| ((m_first->index() == rhs.m_first->index())
+						&& (m_second->index() < rhs.m_second->index()));
+	}
+
+#ifdef OGDF_DEBUG
+	const Graph* graphOf() const { return m_first->graphOf(); }
+#endif
+};
+
+using VertexPair = OrderedPair<node>;
+using EdgePair = OrderedPair<edge>;
+
+//! The different modes for 1-Planarity.
+enum class OGDF_EXPORT OneplanMode {
+	Normal, //!< 1-Planarity
+	NIC, //!< 1-Planarity, where two crossed edge pairs may share at most one vertex (NIC-Planarity)
+	IC //!< 1-Planarity, where no two crossed edges may share a vertex (IC-Planarity)
+};
+
+//! A partial solution for a 1-Planarity instance, representing a node in the backtracking tree.
+/**
+ * All independent pairs of the input graph are partitioned into crossing, uncrossable, and free
+ * (i.e., still allowed to cross). Maintains a stack of transactions that can be later undone.
+ */
+class OGDF_EXPORT EdgePairPartition {
+private:
+	struct UndoInformation {
+		std::set<EdgePair> m_crossings;
+		std::set<VertexPair> m_kiteEdges;
+		std::set<EdgePair> m_nonCrossingPairs;
+		std::list<EdgePair> m_todoCrossings;
+		std::unique_ptr<EdgePair> m_previousCrossing = nullptr;
+	};
+
+	OneplanMode m_mode = OneplanMode::Normal;
+	const Graph& m_graph;
+	EdgeSet m_crossedEdges;
+	std::set<VertexPair> m_kiteEdges;
+	std::set<EdgePair> m_crossingEdgePairs;
+	std::set<EdgePair> m_freeEdgePairs;
+
+	std::stack<UndoInformation> m_undoInformation;
+
+public:
+	//! Creates a new EdgePairPartition, where all pairs of independent edges are crossable.
+	/**
+	 * @param g The input graph.
+	 * @param m The kind of 1-Planarity represented
+	 */
+	explicit EdgePairPartition(const Graph& g, OneplanMode m = OneplanMode::Normal)
+		: m_mode(m), m_graph(g), m_crossedEdges(m_graph) {
+		for (edge e1 : m_graph.edges) {
+			for (edge e2 : m_graph.edges) {
+				if (!e1->isAdjacent(e2)) {
+					m_freeEdgePairs.emplace(e1, e2);
+				}
+			}
+		}
+	}
+
+	//! Creates a new EdgePairPartition as a copy of \p other, but does not copy its transaction stack.
+	EdgePairPartition(const EdgePairPartition& other)
+		: m_mode(other.m_mode)
+		, m_graph(other.m_graph)
+		, m_crossedEdges(other.m_crossedEdges)
+		, m_kiteEdges(other.m_kiteEdges)
+		, m_crossingEdgePairs(other.m_crossingEdgePairs)
+		, m_freeEdgePairs(other.m_freeEdgePairs) { }
+
+	//! Returns the associated graph.
+	const Graph& graph() const { return m_graph; }
+
+	//! Returns the set of kite edges.
+	const std::set<VertexPair>& kiteEdges() const { return m_kiteEdges; }
+
+	//! Returns the set of all crossed edge pairs.
+	const std::set<EdgePair>& crossingEdgePairs() const { return m_crossingEdgePairs; }
+
+	//! Starts a new transaction that can later be undone.
+	void startTransaction() { m_undoInformation.emplace(); }
+
+	//! Starts a new transaction and associates an exhaustive set of crossings that will be branched over.
+	void startTransaction(std::vector<EdgePair>& todoCrossings) {
+		UndoInformation& ui = m_undoInformation.emplace();
+		ui.m_todoCrossings.assign(todoCrossings.begin(), todoCrossings.end());
+	}
+
+	//! Reverts the previous transaction.
+	void undoTransaction();
+
+	//! Returns whether there are crossings that should be branched over.
+	bool hasTodoCrossing() {
+		if (m_undoInformation.empty()) {
+			return false;
+		}
+		return !m_undoInformation.top().m_todoCrossings.empty();
+	}
+
+	//! Removes and returns the next stored crossing that should be considered.
+	EdgePair getNextTodoCrossing() {
+		OGDF_ASSERT(hasTodoCrossing());
+		EdgePair ep = m_undoInformation.top().m_todoCrossings.front();
+		m_undoInformation.top().m_todoCrossings.pop_front();
+		m_undoInformation.top().m_previousCrossing = std::make_unique<EdgePair>(ep);
+		return ep;
+	}
+
+	//! Crosses \p pair and computes the corresponding kite edges.
+	void crossEdgePair(const EdgePair& pair);
+
+	//! Marks \p pair as non-crossing.
+	void setNonCrossing(const EdgePair& pair) {
+		if (m_freeEdgePairs.count(pair) > 0) {
+			m_freeEdgePairs.erase(pair);
+			m_undoInformation.top().m_nonCrossingPairs.insert(pair);
+		}
+	}
+
+	//! Returns whether \p pair is still allowed to cross.
+	bool isFree(const EdgePair& pair) const {
+		OGDF_ASSERT(pair.graphOf() == &m_graph);
+		if (m_crossedEdges.contains(pair.first()) || m_crossedEdges.contains(pair.second())) {
+			return false;
+		}
+		if (m_kiteEdges.count({pair.first()->source(), pair.first()->target()}) > 0
+				|| m_kiteEdges.count({pair.second()->source(), pair.second()->target()}) > 0) {
+			return false;
+		}
+		return m_freeEdgePairs.count(pair) > 0;
+	}
+
+	//! Returns whether there exists an edge that \p e may cross.
+	bool isFree(edge e) const {
+		if (m_kiteEdges.count({e->source(), e->target()}) > 0 || m_crossedEdges.contains(e)) {
+			return false;
+		}
+		for (EdgePair ep : m_freeEdgePairs) {
+			if (ep.contains(e)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	//! Returns whether \p e is part of a crossing.
+	bool isCrossed(edge e) const {
+		for (EdgePair ep : m_crossingEdgePairs) {
+			if (ep.contains(e)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	//! Returns an edge between \p a and \p b, or null
+	static edge getEdgeBetween(node a, node b) {
+		for (adjEntry adj : a->adjEntries) {
+			if (adj->twinNode() == b) {
+				return adj->theEdge();
+			}
+		}
+		return nullptr;
+	}
+
+private:
+	void computeKiteEdges(const EdgePair& crossedPair);
+
+	void addKiteEdge(edge e) {
+		OGDF_ASSERT(e->graphOf() == &m_graph);
+		if (!m_crossedEdges.contains(e)) {
+			addKiteEdge({e->source(), e->target()});
+		}
+	}
+
+	void addKiteEdge(const VertexPair& vp) {
+		if (m_kiteEdges.count(vp) == 0) {
+			m_kiteEdges.insert(vp);
+			m_undoInformation.top().m_kiteEdges.insert(vp);
+		}
+	}
+};
+}

--- a/include/ogdf/k-planarity/1-planarity_backtracking/OnePlanarityBacktracking.h
+++ b/include/ogdf/k-planarity/1-planarity_backtracking/OnePlanarityBacktracking.h
@@ -1,0 +1,201 @@
+/** \file
+ * \brief The main class of the 1-Planarity backtracker.
+ *
+ * \author Matthias Pfretzschner
+ *
+ * \par License:
+ * This file is part of the Open Graph Drawing Framework (OGDF).
+ *
+ * \par
+ * Copyright (C)<br>
+ * See README.md in the OGDF root directory for details.
+ *
+ * \par
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * Version 2 or 3 as published by the Free Software Foundation;
+ * see the file LICENSE.txt included in the packaging of this file
+ * for details.
+ *
+ * \par
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * \par
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, see
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#pragma once
+
+#include <ogdf/basic/Module.h>
+#include <ogdf/basic/Timeouter.h>
+#include <ogdf/basic/basic.h>
+#include <ogdf/k-planarity/1-planarity_backtracking/EdgePairPartition.h>
+#include <ogdf/k-planarity/1-planarity_backtracking/OnePlanarization.h> // IWYU pragma: keep
+
+#include <list>
+#include <memory>
+#include <stack>
+#include <vector>
+
+namespace ogdf {
+class Graph;
+} // namespace ogdf
+
+namespace ogdf::oneplan_backtracking {
+class PartialSolutionFilter;
+
+//! A backtracking implementation for the 1-Planarity problem.
+/**
+ * This solver finds edge pairs to branch over using Kuratowski-Subdivisions of the graph and uses
+ * filters to reject non-realizable partial solutions early to shrink the search space.
+ * Moreover, it explores the search space using multiple depth-first searches running alternatingly
+ * to increase the likelihood of finding solutions with few crossings early.
+ */
+class OGDF_EXPORT OnePlanarityBacktracking : public Timeouter {
+private:
+	//! A class representing one depth-first search in the backtracking tree.
+	class DFSThread {
+	public:
+		//! The current partial solution considered by the DFSThread.
+		EdgePairPartition m_epp;
+
+		//! The associated solver.
+		OnePlanarityBacktracking* m_solver;
+
+		//! The DFS-stack. True indicates that new branches should be computed, false means that
+		//! the changes in the partial solution should be reverted.
+		std::stack<bool> m_branchStack;
+
+		//! Creates a new DFS-thread associated with \p s that starts with a copy of \p x.
+		DFSThread(EdgePairPartition& x, OnePlanarityBacktracking* s) : m_epp(x), m_solver(s) {
+			m_branchStack.push(true);
+		}
+
+		//! Creates a new DFS-thread associated with \p s and initializes it with a new
+		//! \ref EdgePairPartition for \p G with mode \p mode.
+		DFSThread(const Graph& G, OneplanMode mode, OnePlanarityBacktracking* s)
+			: m_epp(G, mode), m_solver(s) {
+			m_branchStack.push(true);
+		}
+
+		//! Executes one step of the DFS and returns true if a solution was found.
+		bool nextStep();
+
+		//! Returns whether the DFS-thread has terminated.
+		bool finished() const { return m_branchStack.empty(); }
+
+		//! Computes the children of the current node in the search tree using Kuratowski-subdivisions.
+		/**
+		 *  If the maximum number of DFS-threads has not been reached, the children will be moved to
+		 *  new DFS-threads.
+		 *  @return true if a solution was found, false otherwise.
+		 */
+		bool branch();
+
+		//! Proceeds to the next child if there are any left, otherwise reverts the changes to the partial solution.
+		void cleanUp(DFSThread& thread);
+	};
+
+	//! Classification of partial solutions in the search tree.
+	enum class NodeStatus {
+		CNT, //!< Unknown whether partial solution is realizable or not.
+		CUT, //!< Partial solution is not realizable and can be rejected.
+		SOL //!< Partial solution is a solution.
+	};
+
+	std::list<DFSThread> m_threads;
+	std::vector<std::unique_ptr<PartialSolutionFilter>> m_filters;
+
+	int m_maxThreads;
+	int m_maxExtractedKuratowskis;
+	int m_processedNodes = 0;
+
+public:
+	//! Creates a new solver.
+	/**
+	 * @param maxThreads The maximum number of DFS-threads that are executed alternatingly.
+	 * A higher number may help find solutions with few crossings faster, but comes at a cost of
+	 * increased memory consumption.
+	 * @param maxKuratowskis The maximum number of Kuratowski-Subdivisions that are taken into
+	 * consideration when branching. A higher number may shrink the search space, but increases the
+	 * time spent at each node in the search tree.
+	 */
+	explicit OnePlanarityBacktracking(int maxThreads = 1000, int maxKuratowskis = 1000);
+
+	~OnePlanarityBacktracking();
+
+	OnePlanarityBacktracking(const OnePlanarityBacktracking&) = delete;
+
+	OnePlanarityBacktracking& operator=(const OnePlanarityBacktracking&) = delete;
+
+	//! Tests whether \p G is 1-planar.
+	/**
+	 * A graph is 1-planar if it admits a drawing with at most one crossing per edge.
+	 *
+	 * @param G is the input graph.
+	 * @param out is assigned a solution, if one is found.
+	 * @return \ref Module::ReturnType::TimeoutInfeasible if a \ref timeLimit() was specified and
+	 * exceeded. Otherwise returns \ref Module::ReturnType::Feasible if \p G is 1-planar and
+	 * \ref Module::ReturnType::NoFeasibleSolution if it is not.
+	 *
+	 * \remark For better performance, first decompose the graph into its biconnected components.
+	 */
+	Module::ReturnType testOnePlanarity(const Graph& G, OnePlanarization* out = nullptr) {
+		return test(OneplanMode::Normal, G, out);
+	}
+
+	//! Tests whether \p G is IC-Planar.
+	/**
+	 * A graph is IC-Planar if it admits a drawing with at most one crossing per edge and no two
+	 * crossed edges may share an endpoint.
+	 *
+	 *
+	 * @param G is the input graph.
+	 * @param out is assigned a solution, if one is found.
+	 * @return \ref Module::ReturnType::TimeoutInfeasible if a \ref timeLimit() was specified and
+	 * exceeded. Otherwise returns \ref Module::ReturnType::Feasible if \p G is IC-planar and
+	 * \ref Module::ReturnType::NoFeasibleSolution if it is not.
+	 *
+	 * \remark In contrast to 1-Planarity and NIC-Planarity, a graph is not necessarily IC-planar if
+	 * and only if its biconnected components are.
+	 */
+	Module::ReturnType testICPlanarity(const Graph& G, OnePlanarization* out = nullptr) {
+		return test(OneplanMode::IC, G, out);
+	}
+
+	//! Tests whether \p G is NIC-Planar.
+	/**
+	 * A graph is NIC-Planar if it admits a drawing with at most one crossing per edge and two
+	 * pairs of crossed edges may have at most one common endpoint.
+	 *
+	 * @param G is the input graph.
+	 * @param out is assigned a solution, if one is found.
+	 * @return \ref Module::ReturnType::TimeoutInfeasible if a \ref timeLimit() was specified and
+	 * exceeded. Otherwise returns \ref Module::ReturnType::Feasible if \p G is NIC-planar and
+	 * \ref Module::ReturnType::NoFeasibleSolution if it is not.
+	 *
+	 * \remark For better performance, first decompose the graph into its biconnected components.
+	 */
+	Module::ReturnType testNICPlanarity(const Graph& G, OnePlanarization* out = nullptr) {
+		return test(OneplanMode::NIC, G, out);
+	}
+
+	//! Returns the number of search tree nodes that were processed in the previous run.
+	int processedNodes() const { return m_processedNodes; }
+
+private:
+	//! Runs he backtracking on \p G and writes the solution to \p out.
+	Module::ReturnType test(OneplanMode mode, const Graph& G, OnePlanarization* out = nullptr);
+
+	//! Determines whether a partial solution is a solution, non-realizable, or the search must continue.
+	virtual NodeStatus verifyNode(EdgePairPartition* epp);
+
+	//! Creates a new DFS-thread for \p epp if there is space, otherwise pushes it to \p t.
+	virtual void push(DFSThread* t, EdgePairPartition* epp);
+};
+}

--- a/include/ogdf/k-planarity/1-planarity_backtracking/OnePlanarityBacktracking.h
+++ b/include/ogdf/k-planarity/1-planarity_backtracking/OnePlanarityBacktracking.h
@@ -114,7 +114,6 @@ private:
 	};
 
 	std::list<DFSThread> m_threads;
-	std::vector<std::unique_ptr<PartialSolutionFilter>> m_filters;
 
 	int m_maxThreads;
 	int m_maxExtractedKuratowskis;
@@ -132,7 +131,7 @@ public:
 	 */
 	explicit OnePlanarityBacktracking(int maxThreads = 1000, int maxKuratowskis = 1000);
 
-	~OnePlanarityBacktracking();
+	virtual ~OnePlanarityBacktracking();
 
 	OnePlanarityBacktracking(const OnePlanarityBacktracking&) = delete;
 
@@ -193,14 +192,17 @@ public:
 	//! Returns the number of search tree nodes that were processed in the previous run.
 	int processedNodes() const { return m_processedNodes; }
 
+protected:
+	std::vector<std::unique_ptr<PartialSolutionFilter>> m_filters;
+
 private:
 	//! Runs the backtracking on \p G and writes the solution to \p out.
 	Module::ReturnType test(OneplanMode mode, const Graph& G, OnePlanarization* out = nullptr);
 
 	//! Determines whether a partial solution is a solution, non-realizable, or the search must continue.
-	virtual NodeStatus verifyNode(EdgePairPartition* epp);
+	NodeStatus verifyNode(EdgePairPartition* epp);
 
 	//! Creates a new DFS-thread for \p epp if there is space, otherwise pushes it to \p t.
-	virtual void push(DFSThread* t, EdgePairPartition* epp);
+	void push(DFSThread* t, EdgePairPartition* epp);
 };
 }

--- a/include/ogdf/k-planarity/1-planarity_backtracking/OnePlanarityBacktracking.h
+++ b/include/ogdf/k-planarity/1-planarity_backtracking/OnePlanarityBacktracking.h
@@ -51,8 +51,13 @@ class PartialSolutionFilter;
 
 //! A backtracking implementation for the 1-Planarity problem.
 /**
- * This solver finds edge pairs to branch over using Kuratowski-Subdivisions of the graph and uses
- * filters to reject non-realizable partial solutions early to shrink the search space.
+ * Implements the best configuration of the backtracking procedure for 1-Planarity evaluated in:
+ * \remark Simon D. Fink, Miriam Münch, Matthias Pfretzschner and Ignaz Rutter. Heuristics for Exact
+ * 1-Planarity Testing. To appear in the Proc. of the 33rd International Symposium on Graph Drawing
+ * and Network Visualization, GD 2025, LIPIcs, Volume 357, 2025.
+ *
+ * This solver finds edge pairs to branch over by extracting multiple Kuratowski-Subdivisions of the
+ * graph and uses filters to reject non-realizable partial solutions early to shrink the search space.
  * Moreover, it explores the search space using multiple depth-first searches running alternatingly
  * to increase the likelihood of finding solutions with few crossings early.
  */
@@ -189,7 +194,7 @@ public:
 	int processedNodes() const { return m_processedNodes; }
 
 private:
-	//! Runs he backtracking on \p G and writes the solution to \p out.
+	//! Runs the backtracking on \p G and writes the solution to \p out.
 	Module::ReturnType test(OneplanMode mode, const Graph& G, OnePlanarization* out = nullptr);
 
 	//! Determines whether a partial solution is a solution, non-realizable, or the search must continue.

--- a/include/ogdf/k-planarity/1-planarity_backtracking/OnePlanarization.h
+++ b/include/ogdf/k-planarity/1-planarity_backtracking/OnePlanarization.h
@@ -1,0 +1,110 @@
+/** \file
+ * \brief Declaration of the OnePlanarization class.
+ *
+ * \author Matthias Pfretzschner
+ *
+ * \par License:
+ * This file is part of the Open Graph Drawing Framework (OGDF).
+ *
+ * \par
+ * Copyright (C)<br>
+ * See README.md in the OGDF root directory for details.
+ *
+ * \par
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * Version 2 or 3 as published by the Free Software Foundation;
+ * see the file LICENSE.txt included in the packaging of this file
+ * for details.
+ *
+ * \par
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * \par
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, see
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#pragma once
+
+#include <ogdf/basic/Graph.h>
+#include <ogdf/basic/GraphCopy.h>
+#include <ogdf/basic/GraphSets.h>
+#include <ogdf/basic/List.h>
+#include <ogdf/basic/basic.h>
+#include <ogdf/basic/extended_graph_alg.h>
+
+namespace ogdf::oneplan_backtracking {
+class EdgePairPartition;
+
+//! The graph corresponding to a partial solution for the 1-Planarity problem.
+/**
+ * Represents the graph corresponding to a \ref EdgePairPartition using a \ref GraphCopy of the
+ * original input graph. Crossed edge pairs are replaced with crossing vertices and kite edges
+ * around crossing vertices are inserted. If this graph is planar, it represents a solution for
+ * the 1-Planarity problem.
+ */
+class OGDF_EXPORT OnePlanarization : public GraphCopy {
+private:
+	const EdgePairPartition* m_epp = nullptr;
+	NodeSet m_saturatedVertices; // vertices that are incident to an uncrossable edge
+	NodeSet m_crossingVertices;
+	EdgeSet m_kiteEdges; // uncrossable
+	EdgeSet m_crossingEdges; // edges incident to crossing vertices (uncrossable)
+	EdgeSet m_freeEdges; // edges that still have at least one other edge they are allowed to cross
+	EdgeSet m_remainingEdges; // uncrossable edges that are not kite edges or crossing edges
+
+public:
+	OnePlanarization() = default;
+
+	//! Associates the graph with \p ep and computes the planarization
+	explicit OnePlanarization(const EdgePairPartition* ep) { init(ep); }
+
+	//! Re-initializes the graph with \p ep.
+	void init(const EdgePairPartition* ep);
+
+	//! Returns the associated \ref EdgePairPartition.
+	const EdgePairPartition* getEdgePairPartition() const { return m_epp; }
+
+	//! Returns true if the graph is planar and thus represents a solution.
+	bool isPlanar() const { return ogdf::isPlanar(*this); }
+
+	//! Returns the set of all crossing vertices in the graph.
+	const NodeSet& crossingVertices() const { return m_crossingVertices; }
+
+	//! Returns the set of all kite edges in the graph.
+	/**
+	 *	Kite edges are non-edges of the original graph between the endpoints of crossed edge pairs.
+	 *	Note that these edges are not associated with edges of the original graph.
+	 */
+	const EdgeSet& kiteEdges() const { return m_kiteEdges; }
+
+	//! Returns the set of all edges that are incident to a crossing vertex.
+	/**
+	 * The four edges incident to each crossing vertex are associated with the two corresponding
+	 * edges of the original graph.
+	 */
+	const EdgeSet& crossingEdges() const { return m_crossingEdges; }
+
+	//! Returns the set of all edges that may still cross some other edge.
+	const EdgeSet& freeEdges() const { return m_freeEdges; }
+
+	//! Returns the set of all uncrossable edges that are neither crossing edges nor kite edges.
+	const EdgeSet& remainingEdges() const { return m_remainingEdges; }
+
+	//! Computes the subgraph induced by uncrossable edges.
+	void getSaturatedSubgraph(GraphCopy& cp) const {
+		cp.init(*reinterpret_cast<const Graph*>(this));
+		for (edge e : m_freeEdges) {
+			cp.delEdge(cp.copy(e));
+		}
+	}
+
+private:
+	using GraphCopy::init;
+};
+}

--- a/include/ogdf/k-planarity/1-planarity_backtracking/PartialSolutionFilter.h
+++ b/include/ogdf/k-planarity/1-planarity_backtracking/PartialSolutionFilter.h
@@ -1,0 +1,115 @@
+/** \file
+ * \brief Filters for partial solutions in backtracking for the 1-Planarity problem.
+ *
+ * \author Matthias Pfretzschner
+ *
+ * \par License:
+ * This file is part of the Open Graph Drawing Framework (OGDF).
+ *
+ * \par
+ * Copyright (C)<br>
+ * See README.md in the OGDF root directory for details.
+ *
+ * \par
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * Version 2 or 3 as published by the Free Software Foundation;
+ * see the file LICENSE.txt included in the packaging of this file
+ * for details.
+ *
+ * \par
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * \par
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, see
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#pragma once
+
+#include <ogdf/basic/Graph.h>
+#include <ogdf/basic/GraphCopy.h>
+#include <ogdf/basic/GraphSets.h>
+#include <ogdf/basic/List.h>
+#include <ogdf/basic/basic.h>
+#include <ogdf/basic/extended_graph_alg.h>
+#include <ogdf/k-planarity/1-planarity_backtracking/OnePlanarization.h>
+
+namespace ogdf::oneplan_backtracking {
+
+//! Interface of filters for partial solutions for 1-Planarity
+/**
+ *	A filter takes as input a partial solution representing a node in the backtracking tree and
+ *	rejects if it detects that the partial solution cannot be extended to a solution.
+ */
+class OGDF_EXPORT PartialSolutionFilter {
+public:
+	//! Returns true if the partial solution represented by \p pl can be classified as non-realizable, false otherwise.
+	virtual bool canCut(OnePlanarization& pl) = 0;
+
+	virtual ~PartialSolutionFilter() = default;
+};
+
+//! Rejects partial solutions for 1-Planarity if the crossable edges violate the density for 1-Planarity.
+class OGDF_EXPORT FreeEdgesDensityFilter : public PartialSolutionFilter {
+public:
+	//! Returns true if the subgraph of \p induced by its free edges violates the density for 1-Planarity, false otherwise.
+	bool canCut(OnePlanarization& pl) override {
+		ogdf::NodeSet seenVertices(pl);
+		for (ogdf::edge e : pl.freeEdges()) {
+			seenVertices.insert(e->target());
+			seenVertices.insert(e->source());
+		}
+
+		return pl.freeEdges().size() > 4 * seenVertices.size() - 8;
+	}
+};
+
+//! Rejects partial solutions for 1-Planarity if they are too dense.
+class OGDF_EXPORT PlanarizationDensityFilter : public PartialSolutionFilter {
+public:
+	//! Returns true if the subgraph of \p pl induced by its free edges violates the density formula for 1-Planarity, false otherwise.
+	bool canCut(OnePlanarization& pl) override {
+		return pl.numberOfEdges() > 4 * pl.numberOfNodes() - 8;
+	}
+};
+
+//! Rejects partial solutions for 1-Planarity if the uncrossable edges induce a non-planar graph.
+class OGDF_EXPORT SaturatedSubgraphPlanarityFilter : public PartialSolutionFilter {
+	//! Returns true if the subgraph of \p pl induced by its uncrossable edges is non-planar, false otherwise.
+	bool canCut(OnePlanarization& pl) override {
+		ogdf::GraphCopy saturatedSubgraph;
+		pl.getSaturatedSubgraph(saturatedSubgraph);
+		return !isPlanar(saturatedSubgraph);
+	}
+};
+
+//! Rejects partial solutions for 1-Planarity if a separating cycle with too few crossable edges is found.
+/**
+ * For every pair (e, f) of crossed edges in a given partial solution, this filter searches a cycle c
+ * containing e and tests whether the maximum number of edge-disjoint paths between the endpoints of f
+ * that are vertex-disjoint from c exceeds the number of crossable edges contained in c.
+ * If this is the case, the partial solution is not realizable and is rejected.
+ */
+class OGDF_EXPORT SeparatingCycleFilter : public PartialSolutionFilter {
+public:
+	//! Returns true if \p pl can be rejected due to a found separating cycle, false otherwise.
+	bool canCut(OnePlanarization& pl) override;
+
+private:
+	bool test(OnePlanarization& pl, ogdf::node crossingVertex, ogdf::NodePair cyclePair,
+			ogdf::NodePair otherPair);
+
+	//! Searches for a path between \p cyclePair that is disjoint from \p otherPair.
+	static int minFreeEdgeCycle(const OnePlanarization& pl, node crossingVertex,
+			NodePair& cyclePair, NodePair& otherPair, EdgeSet& cycleEdges, NodeSet& cycleNodes);
+
+	//! Contracts all edges of \p cp that cannot cross any edge of the cycle.
+	static void contractUncrossableEdges(const OnePlanarization& pl, GraphCopy& cp,
+			const EdgeSet& cycleEdges, const NodeSet& cycleNodes, node& v1, node& v2);
+};
+}

--- a/src/ogdf/k-planarity/1-planarity_backtracking/EdgePairPartition.cpp
+++ b/src/ogdf/k-planarity/1-planarity_backtracking/EdgePairPartition.cpp
@@ -1,0 +1,188 @@
+/** \file
+ * \brief Implementation of EdgePairPartition methods.
+ *
+ * \author Matthias Pfretzschner
+ *
+ * \par License:
+ * This file is part of the Open Graph Drawing Framework (OGDF).
+ *
+ * \par
+ * Copyright (C)<br>
+ * See README.md in the OGDF root directory for details.
+ *
+ * \par
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * Version 2 or 3 as published by the Free Software Foundation;
+ * see the file LICENSE.txt included in the packaging of this file
+ * for details.
+ *
+ * \par
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * \par
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, see
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#include <ogdf/basic/Graph.h>
+#include <ogdf/basic/GraphList.h>
+#include <ogdf/basic/GraphSets.h>
+#include <ogdf/basic/basic.h>
+#include <ogdf/k-planarity/1-planarity_backtracking/EdgePairPartition.h>
+
+#include <deque>
+#include <initializer_list>
+#include <list>
+#include <memory>
+#include <set>
+#include <stack>
+#include <vector>
+
+using namespace std;
+using namespace ogdf;
+using namespace oneplan_backtracking;
+
+void EdgePairPartition::undoTransaction() {
+	for (const EdgePair& ep : m_undoInformation.top().m_crossings) {
+		m_freeEdgePairs.insert(ep);
+		m_crossingEdgePairs.erase(ep);
+		m_crossedEdges.remove(ep.first());
+		m_crossedEdges.remove(ep.second());
+	}
+
+	for (const VertexPair& vp : m_undoInformation.top().m_kiteEdges) {
+		m_kiteEdges.erase(vp);
+	}
+
+	for (const EdgePair& ep : m_undoInformation.top().m_nonCrossingPairs) {
+		m_freeEdgePairs.insert(ep);
+	}
+	m_undoInformation.pop();
+
+	if (!m_undoInformation.empty() && !m_undoInformation.top().m_todoCrossings.empty()
+			&& m_undoInformation.top().m_previousCrossing) {
+		setNonCrossing(*m_undoInformation.top().m_previousCrossing);
+	}
+}
+
+void EdgePairPartition::crossEdgePair(const EdgePair& pair) {
+	OGDF_ASSERT(m_freeEdgePairs.count(pair) > 0);
+	OGDF_ASSERT(!m_crossedEdges.contains(pair.first()));
+	OGDF_ASSERT(!m_crossedEdges.contains(pair.second()));
+	OGDF_ASSERT(m_kiteEdges.count({pair.first()->source(), pair.first()->target()}) == 0);
+	OGDF_ASSERT(m_kiteEdges.count({pair.second()->source(), pair.second()->target()}) == 0);
+	m_freeEdgePairs.erase(pair);
+	m_crossingEdgePairs.insert(pair);
+	m_crossedEdges.insert(pair.first());
+	m_crossedEdges.insert(pair.second());
+	m_undoInformation.top().m_crossings.insert(pair);
+	if (m_mode == OneplanMode::NIC) {
+		vector<node> nl = {pair.first()->source(), pair.first()->target(), pair.second()->source(),
+				pair.second()->target()};
+		set<VertexPair> distinctPairs;
+		for (node v1 : nl) {
+			for (node v2 : nl) {
+				if (v1 != v2) {
+					distinctPairs.insert({v1, v2});
+				}
+			}
+		}
+		for (const VertexPair& vp : distinctPairs) {
+			for (adjEntry adj1 : vp.first()->adjEntries) {
+				for (adjEntry adj2 : vp.second()->adjEntries) {
+					if (adj1->theEdge() == adj2->theEdge()) {
+						continue;
+					}
+					EdgePair ep = {adj1->theEdge(), adj2->theEdge()};
+					if (isFree(ep)) {
+						setNonCrossing(ep);
+					}
+				}
+			}
+		}
+	} else if (m_mode == OneplanMode::IC) {
+		vector<node> nl = {pair.first()->source(), pair.first()->target(), pair.second()->source(),
+				pair.second()->target()};
+		for (node v : nl) {
+			for (adjEntry adj : v->adjEntries) {
+				if (isFree(adj->theEdge())) {
+					addKiteEdge(adj->theEdge());
+				}
+			}
+		}
+	}
+	computeKiteEdges(pair);
+
+#ifdef OGDF_DEBUG
+	for (edge e : m_graph.edges) {
+		int nCrossings = 0;
+		for (edge e2 : m_graph.edges) {
+			if (e == e2) {
+				continue;
+			}
+			if (m_crossingEdgePairs.count({e, e2}) > 0) {
+				++nCrossings;
+			}
+		}
+		OGDF_ASSERT(nCrossings <= 1);
+	}
+#endif
+}
+
+void EdgePairPartition::computeKiteEdges(const EdgePair& crossedPair) {
+	VertexPair p1(crossedPair.first()->source(), crossedPair.second()->source()),
+			p2(crossedPair.first()->source(), crossedPair.second()->target()),
+			p3(crossedPair.first()->target(), crossedPair.second()->source()),
+			p4(crossedPair.first()->target(), crossedPair.second()->target());
+
+	for (VertexPair p : {p1, p2, p3, p4}) {
+		ogdf::edge e = getEdgeBetween(p.first(), p.second());
+		if (e) {
+			addKiteEdge(e);
+		} else {
+			addKiteEdge(p);
+		}
+
+		// degree-2 paths between the endpoints can alo be realized without crossings -> mark as uncrossable
+		std::stack<ogdf::node> dfsStack({p.first()});
+		ogdf::NodeArray<bool> visited(m_graph, false);
+		visited[p.first()] = true;
+
+		std::vector<ogdf::edge> pathEnds;
+		while (!dfsStack.empty()) {
+			ogdf::node n = dfsStack.top();
+			dfsStack.pop();
+
+			visited[n] = true;
+			if (n != p.first() && n->degree() != 2) {
+				continue;
+			}
+			for (ogdf::adjEntry adj : n->adjEntries) {
+				ogdf::node t = adj->twinNode();
+				if (t == p.second()) {
+					pathEnds.push_back(adj->theEdge());
+				} else if (!visited[t]) {
+					dfsStack.push(t);
+				}
+				visited[t] = true;
+			}
+		}
+
+		for (ogdf::edge s : pathEnds) {
+			addKiteEdge(s);
+			ogdf::node n = s->opposite(p.second());
+			while (n != p.first()) {
+				OGDF_ASSERT(n->degree() == 2);
+				s = n->firstAdj()->theEdge() == s ? n->lastAdj()->theEdge()
+												  : n->firstAdj()->theEdge();
+				addKiteEdge(s);
+				n = s->opposite(n);
+			}
+		}
+	}
+}

--- a/src/ogdf/k-planarity/1-planarity_backtracking/OnePlanarityBacktracking.cpp
+++ b/src/ogdf/k-planarity/1-planarity_backtracking/OnePlanarityBacktracking.cpp
@@ -1,0 +1,314 @@
+/** \file
+ * \brief Implementation of OnePlanarityBacktracking methods.
+ *
+ * \author Matthias Pfretzschner
+ *
+ * \par License:
+ * This file is part of the Open Graph Drawing Framework (OGDF).
+ *
+ * \par
+ * Copyright (C)<br>
+ * See README.md in the OGDF root directory for details.
+ *
+ * \par
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * Version 2 or 3 as published by the Free Software Foundation;
+ * see the file LICENSE.txt included in the packaging of this file
+ * for details.
+ *
+ * \par
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * \par
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, see
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#include <ogdf/basic/Graph.h>
+#include <ogdf/basic/GraphCopy.h>
+#include <ogdf/basic/GraphList.h>
+#include <ogdf/basic/Module.h>
+#include <ogdf/basic/SList.h>
+#include <ogdf/basic/Stopwatch.h>
+#include <ogdf/basic/basic.h>
+#include <ogdf/basic/simple_graph_alg.h>
+#include <ogdf/k-planarity/1-planarity_backtracking/EdgePairPartition.h>
+#include <ogdf/k-planarity/1-planarity_backtracking/OnePlanarityBacktracking.h>
+#include <ogdf/k-planarity/1-planarity_backtracking/OnePlanarization.h>
+#include <ogdf/k-planarity/1-planarity_backtracking/PartialSolutionFilter.h>
+#include <ogdf/planarity/BoyerMyrvold.h>
+#include <ogdf/planarity/ExtractKuratowskis.h>
+
+#include <algorithm>
+#include <climits>
+#include <deque>
+#include <list>
+#include <map>
+#include <memory>
+#include <set>
+#include <stack>
+#include <vector>
+
+using namespace std;
+using namespace ogdf;
+using namespace ogdf::oneplan_backtracking;
+
+bool OnePlanarityBacktracking::DFSThread::nextStep() {
+	bool toBranch = m_branchStack.top();
+	m_branchStack.pop();
+	if (toBranch) {
+		return branch();
+	} else {
+		cleanUp(*this);
+	}
+
+	return false;
+}
+
+void OnePlanarityBacktracking::DFSThread::cleanUp(DFSThread& thread) {
+	EdgePairPartition& epp = thread.m_epp;
+
+	if (epp.hasTodoCrossing()) {
+		EdgePair ep = epp.getNextTodoCrossing();
+		epp.startTransaction();
+		epp.crossEdgePair(ep);
+		thread.m_branchStack.push(false);
+		m_solver->push(&thread, &epp);
+	} else {
+		epp.undoTransaction();
+	}
+}
+
+//! Computes all crossable edge pairs of a given Kuratowski-subdivision.
+void extractCrossableKuratowskiEdgePairs(OnePlanarization& p, EdgePairPartition& epp,
+		KuratowskiWrapper& kuratowski, vector<EdgePair>& out) {
+	Graph::HiddenEdgeSet hiddenEdges(p);
+	vector<edge> edgeListCopy;
+	for (edge e : p.edges) {
+		edgeListCopy.push_back(e);
+	}
+	for (edge e : edgeListCopy) {
+		hiddenEdges.hide(e);
+	}
+	for (edge e : kuratowski.edgeList) {
+		hiddenEdges.restore(e);
+	}
+
+	GraphCopy minor(*reinterpret_cast<Graph*>(&p));
+
+	EdgeArray<edge> rep(p, nullptr);
+	rep[p.firstEdge()] = minor.copy(p.firstEdge());
+	stack<adjEntry> stk {{p.firstEdge()->adjSource()}};
+
+	while (!stk.empty()) {
+		adjEntry adj = stk.top();
+		stk.pop();
+		node n = adj->twinNode();
+
+		if (n->degree() == 2) {
+			adjEntry nextAdj = n->firstAdj()->twin() == adj ? n->lastAdj() : n->firstAdj();
+			rep[nextAdj->theEdge()] = rep[adj->theEdge()];
+			stk.push(nextAdj);
+		} else {
+			for (adjEntry nextAdj : n->adjEntries) {
+				if (nextAdj->twin() == adj || rep[nextAdj->theEdge()] != nullptr) {
+					continue;
+				}
+				rep[nextAdj->theEdge()] = minor.copy(nextAdj->theEdge());
+				stk.push(nextAdj);
+			}
+		}
+	}
+	for (edge e : p.edges) {
+		if (rep[e] != minor.copy(e)) {
+			minor.contract(minor.copy(e));
+		}
+	}
+	OGDF_ASSERT(minor.numberOfEdges() == 10 || minor.numberOfEdges() == 9);
+	for (edge e : kuratowski.edgeList) {
+		OGDF_ASSERT(rep[e]);
+	}
+
+	hiddenEdges.restore();
+
+	out.clear();
+	for (edge e1 : kuratowski.edgeList) {
+		for (edge e2 : kuratowski.edgeList) {
+			if (e1 == e2) {
+				break;
+			}
+			if (rep[e1] == rep[e2] || rep[e1]->isAdjacent(rep[e2])) {
+				continue;
+			}
+			edge m1 = p.original(e1);
+			edge m2 = p.original(e2);
+			if (m1 == m2 || !m1 || !m2) {
+				continue;
+			}
+			EdgePair pa(m1, m2);
+			if (epp.isFree(pa)) {
+				out.push_back(pa);
+			}
+		}
+	}
+}
+
+/**
+ * Either writes a set of edge pairs that need to be crossed to \p forcedCrossings or outputs an
+ * exhaustive set of edge pairs that can be branched over to \p childPairs.
+ */
+bool computeBranches(EdgePairPartition* epp, int nKuratowskis, vector<EdgePair>& childPairs,
+		set<EdgePair>& forcedCrossings) {
+	OnePlanarization p(epp);
+	SList<KuratowskiWrapper> output;
+	BoyerMyrvold bm;
+	bm.planarEmbed(p, output, nKuratowskis);
+
+	map<EdgePair, int> pairs;
+	vector<EdgePair> minKuratowskiPairs;
+	int minKuratowskiPairSize = INT_MAX;
+
+	forcedCrossings.clear();
+	childPairs.clear();
+	for (auto& kuratowski : output) {
+		vector<EdgePair> out;
+		extractCrossableKuratowskiEdgePairs(p, *epp, kuratowski, out);
+		if (out.empty()) {
+			return false;
+		}
+		if (out.size() == 1) { // only one crossable edge pair -> must be crossed
+			forcedCrossings.insert(out.front());
+		} else {
+			for (auto& ep : out) {
+				pairs[ep]++;
+			}
+			if ((int)out.size() < minKuratowskiPairSize) {
+				minKuratowskiPairSize = out.size();
+				std::swap(out, minKuratowskiPairs);
+			}
+		}
+	}
+	if (forcedCrossings.empty()) {
+		OGDF_ASSERT(minKuratowskiPairs.size() > 1);
+		std::swap(minKuratowskiPairs, childPairs);
+		std::sort(childPairs.begin(), // Order pairs by the number of their occurrences in subdivisions.
+				childPairs.end(), [&](auto& a, auto& b) { return pairs[a] > pairs[b]; });
+	}
+	return true;
+}
+
+bool OnePlanarityBacktracking::DFSThread::branch() {
+	auto res = m_solver->verifyNode(&m_epp);
+	if (res == NodeStatus::SOL) {
+		return true;
+	} else if (res == NodeStatus::CUT) {
+		return false;
+	}
+
+	vector<EdgePair> childPairs;
+	set<EdgePair> forcedCrossings;
+	if (!computeBranches(&m_epp, m_solver->m_maxExtractedKuratowskis, childPairs, forcedCrossings)) {
+		return false;
+	}
+
+	if (!forcedCrossings.empty()) { // apply forced crossings and push
+		m_epp.startTransaction();
+		for (auto forcedCrossing : forcedCrossings) {
+			OGDF_ASSERT(!OnePlanarization(&m_epp).isPlanar());
+			if (!m_epp.isFree(forcedCrossing)) {
+				m_epp.undoTransaction();
+				return false;
+			}
+			m_epp.crossEdgePair(forcedCrossing);
+		}
+		m_solver->push(this, &m_epp);
+	} else {
+		m_epp.startTransaction(childPairs); // store edge pairs corresponding to children
+		m_branchStack.push(false); // mark on stack
+		EdgePair ep = m_epp.getNextTodoCrossing();
+		m_epp.startTransaction();
+		m_epp.crossEdgePair(ep); // cross first edge pair and push
+		m_solver->push(this, &m_epp);
+	}
+	return false;
+}
+
+Module::ReturnType OnePlanarityBacktracking::test(oneplan_backtracking::OneplanMode mode,
+		const Graph& G, OnePlanarization* out) {
+	OGDF_ASSERT(isSimple(G));
+	m_processedNodes = 0;
+	m_threads.clear();
+	if (G.numberOfNodes() > 6 && G.numberOfEdges() > 4 * G.numberOfNodes() - 8) {
+		return Module::ReturnType::NoFeasibleSolution;
+	}
+
+	StopwatchWallClock timer;
+	timer.start();
+	m_threads.emplace_back(G, mode, this);
+
+	while (!m_threads.empty()) {
+		for (auto it = m_threads.begin(); it != m_threads.end();) {
+			if (m_timeLimit >= 0 && timer.milliSeconds() / 1000.0 > m_timeLimit) {
+				return Module::ReturnType::TimeoutInfeasible;
+			}
+
+			DFSThread& t = *it;
+			bool solutionFound = t.nextStep();
+			if (solutionFound) {
+				if (out != nullptr) {
+					out->init(&t.m_epp);
+					OGDF_ASSERT(out->isPlanar());
+				}
+				return Module::ReturnType::Feasible;
+			}
+
+			if (t.finished()) {
+				it = m_threads.erase(it);
+			} else {
+				++it;
+			}
+		}
+	}
+	return Module::ReturnType::NoFeasibleSolution;
+}
+
+void OnePlanarityBacktracking::push(OnePlanarityBacktracking::DFSThread* t, EdgePairPartition* epp) {
+	t->m_branchStack.push(false);
+	if ((int)m_threads.size() < m_maxThreads) {
+		m_threads.emplace_back(*epp, this);
+	} else {
+		t->m_branchStack.push(true);
+	}
+}
+
+OnePlanarityBacktracking::NodeStatus OnePlanarityBacktracking::verifyNode(EdgePairPartition* epp) {
+	m_processedNodes++;
+	OnePlanarization pl(epp);
+	if (pl.isPlanar()) {
+		return NodeStatus::SOL;
+	}
+
+	for (auto& f : m_filters) {
+		if (f->canCut(pl)) {
+			return NodeStatus::CUT;
+		}
+	}
+	OGDF_ASSERT(!OnePlanarization(epp).isPlanar());
+
+	return NodeStatus::CNT;
+}
+
+OnePlanarityBacktracking::OnePlanarityBacktracking(int maxThreads, int maxKuratowskis)
+	: m_maxThreads(maxThreads), m_maxExtractedKuratowskis(maxKuratowskis) {
+	m_filters.emplace_back(new PlanarizationDensityFilter);
+	m_filters.emplace_back(new SaturatedSubgraphPlanarityFilter);
+	m_filters.emplace_back(new FreeEdgesDensityFilter);
+	m_filters.emplace_back(new SeparatingCycleFilter);
+}
+
+OnePlanarityBacktracking::~OnePlanarityBacktracking() = default;

--- a/src/ogdf/k-planarity/1-planarity_backtracking/OnePlanarization.cpp
+++ b/src/ogdf/k-planarity/1-planarity_backtracking/OnePlanarization.cpp
@@ -1,0 +1,103 @@
+/** \file
+ * \brief Implementation of OnePlanarization methods.
+ *
+ * \author Matthias Pfretzschner
+ *
+ * \par License:
+ * This file is part of the Open Graph Drawing Framework (OGDF).
+ *
+ * \par
+ * Copyright (C)<br>
+ * See README.md in the OGDF root directory for details.
+ *
+ * \par
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * Version 2 or 3 as published by the Free Software Foundation;
+ * see the file LICENSE.txt included in the packaging of this file
+ * for details.
+ *
+ * \par
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * \par
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, see
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#include <ogdf/basic/Graph.h>
+#include <ogdf/basic/GraphCopy.h>
+#include <ogdf/basic/GraphList.h>
+#include <ogdf/basic/GraphSets.h>
+#include <ogdf/basic/List.h>
+#include <ogdf/basic/basic.h>
+#include <ogdf/k-planarity/1-planarity_backtracking/EdgePairPartition.h>
+#include <ogdf/k-planarity/1-planarity_backtracking/OnePlanarization.h>
+
+#include <set>
+
+using namespace ogdf;
+using namespace oneplan_backtracking;
+
+void OnePlanarization::init(const EdgePairPartition* ep) {
+	m_epp = ep;
+	GraphCopy::init(m_epp->graph());
+	m_saturatedVertices.init(*this);
+	m_crossingVertices.init(*this);
+	m_crossingEdges.init(*this);
+	m_kiteEdges.init(*this);
+	m_freeEdges.init(*this);
+	m_remainingEdges.init(*this);
+
+	for (const EdgePair& crossPair : m_epp->crossingEdgePairs()) {
+		edge c1 = copy(crossPair.second());
+		node crossingVertex = insertCrossing(c1, copy(crossPair.first()), true)->source();
+		m_crossingVertices.insert(crossingVertex);
+		for (adjEntry adj : crossingVertex->adjEntries) {
+			OGDF_ASSERT(original(adj->theEdge()) == crossPair.first()
+					|| original(adj->theEdge()) == crossPair.second());
+			m_crossingEdges.insert(adj->theEdge());
+		}
+	}
+
+	for (const VertexPair& vp : m_epp->kiteEdges()) {
+		edge e = EdgePairPartition::getEdgeBetween(vp.first(), vp.second());
+		if (e == nullptr) {
+			m_kiteEdges.insert(newEdge(copy(vp.first()), copy(vp.second())));
+		}
+	}
+
+	for (edge e : m_epp->graph().edges) {
+		if (m_epp->isFree(e)) {
+			m_freeEdges.insert(copy(e));
+		} else if (!m_epp->isCrossed(e)) {
+			m_remainingEdges.insert(copy(e));
+		}
+	}
+
+	for (edge e : edges) {
+		if (!m_freeEdges.isMember(e)) {
+			m_saturatedVertices.insert(e->source());
+			m_saturatedVertices.insert(e->target());
+		}
+	}
+
+#ifdef OGDF_DEBUG
+	OGDF_ASSERT(numberOfEdges()
+			== m_crossingEdges.size() + m_kiteEdges.size() + m_freeEdges.size()
+					+ m_remainingEdges.size());
+	OGDF_ASSERT(m_crossingVertices.size() == (int)m_epp->crossingEdgePairs().size());
+	OGDF_ASSERT(numberOfEdges()
+			== m_epp->graph().numberOfEdges() + 2 * m_crossingVertices.size() + m_kiteEdges.size());
+	OGDF_ASSERT(numberOfNodes() == m_epp->graph().numberOfNodes() + m_crossingVertices.size());
+	for (node cv : m_crossingVertices) {
+		for (adjEntry adj : cv->adjEntries) {
+			OGDF_ASSERT(m_crossingEdges.isMember(adj->theEdge()));
+		}
+	}
+#endif
+}

--- a/src/ogdf/k-planarity/1-planarity_backtracking/PartialSolutionFilter.cpp
+++ b/src/ogdf/k-planarity/1-planarity_backtracking/PartialSolutionFilter.cpp
@@ -1,0 +1,223 @@
+/** \file
+ * \brief Implementation of SeparatingCycleFilter methods.
+ *
+ * \author Matthias Pfretzschner
+ *
+ * \par License:
+ * This file is part of the Open Graph Drawing Framework (OGDF).
+ *
+ * \par
+ * Copyright (C)<br>
+ * See README.md in the OGDF root directory for details.
+ *
+ * \par
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * Version 2 or 3 as published by the Free Software Foundation;
+ * see the file LICENSE.txt included in the packaging of this file
+ * for details.
+ *
+ * \par
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * \par
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, see
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#include <ogdf/basic/Graph.h>
+#include <ogdf/basic/GraphCopy.h>
+#include <ogdf/basic/GraphList.h>
+#include <ogdf/basic/GraphSets.h>
+#include <ogdf/basic/List.h>
+#include <ogdf/basic/basic.h>
+#include <ogdf/graphalg/MinSTCutMaxFlow.h>
+#include <ogdf/k-planarity/1-planarity_backtracking/EdgePairPartition.h>
+#include <ogdf/k-planarity/1-planarity_backtracking/OnePlanarization.h>
+#include <ogdf/k-planarity/1-planarity_backtracking/PartialSolutionFilter.h>
+
+#include <climits>
+#include <deque>
+#include <iterator>
+#include <unordered_set>
+#include <vector>
+
+using namespace ogdf;
+using namespace oneplan_backtracking;
+using namespace std;
+
+bool SeparatingCycleFilter::canCut(OnePlanarization& pl) {
+	for (node cv : pl.crossingVertices()) {
+		OGDF_ASSERT(cv->degree() == 4);
+
+		// Find endpoints of the crossed edges corresponding to cv
+		unordered_set<edge> crossedEdges;
+		for (adjEntry adj : cv->adjEntries) {
+			crossedEdges.insert(pl.original(adj->theEdge()));
+		}
+		OGDF_ASSERT(crossedEdges.size() == 2);
+		NodePair p1 = {pl.copy((*crossedEdges.begin())->source()),
+				pl.copy((*crossedEdges.begin())->target())};
+		NodePair p2 = {pl.copy((*std::next(crossedEdges.begin()))->source()),
+				pl.copy((*std::next(crossedEdges.begin()))->target())};
+
+		if (test(pl, cv, p1, p2) || test(pl, cv, p2, p1)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool SeparatingCycleFilter::test(OnePlanarization& pl, node crossingVertex, NodePair cyclePair,
+		NodePair otherPair) {
+	Graph::HiddenEdgeSet hes(pl);
+	List<adjEntry> adjCopy;
+	crossingVertex->allAdjEntries(adjCopy);
+	for (adjEntry adj : adjCopy) {
+		hes.hide(adj->theEdge());
+	}
+
+	EdgeSet cycleEdges;
+	NodeSet cycleNodes;
+	int minCycleLength =
+			minFreeEdgeCycle(pl, crossingVertex, cyclePair, otherPair, cycleEdges, cycleNodes);
+	// As long as there is a cycle c containing cyclePair, test c and subsequently hide it.
+	while (minCycleLength < INT_MAX) {
+		for (edge e : cycleEdges) {
+			hes.hide(e);
+		}
+
+		GraphCopy cp(*reinterpret_cast<Graph*>(&pl));
+		node v1 = cp.copy(otherPair.source);
+		node v2 = cp.copy(otherPair.target);
+
+		// Contract all edges that cannot cross any edge of the cycle
+		contractUncrossableEdges(pl, cp, cycleEdges, cycleNodes, v1, v2);
+
+		if (v1 == v2) {
+			return true;
+		}
+		for (node n : cycleNodes) {
+			cp.delNode(cp.copy(n));
+		}
+
+		// Test whether the maximum number of edge-disjoint paths between otherPair is greater than minCycleLength
+		MinSTCutMaxFlow<int> minCutAlg;
+		List<edge> res;
+		EdgeArray<int> edgeCosts(cp, 1);
+		minCutAlg.call(cp, v1, v2, res);
+		if (res.size() > minCycleLength) {
+			return true;
+		}
+
+		minCycleLength =
+				minFreeEdgeCycle(pl, crossingVertex, cyclePair, otherPair, cycleEdges, cycleNodes);
+	}
+	return false;
+}
+
+void SeparatingCycleFilter::contractUncrossableEdges(const OnePlanarization& pl, GraphCopy& cp,
+		const EdgeSet& cycleEdges, const NodeSet& cycleNodes, node& v1, node& v2) {
+	vector<edge> contractableEdges;
+	for (edge e : pl.edges) {
+		bool crossableWithCycle = false;
+		if (pl.freeEdges().isMember(e)) {
+			if (cycleEdges.isMember(e)) {
+				continue;
+			}
+			for (edge cycEdge : cycleEdges) {
+				edge origCycEdge = pl.original(cycEdge);
+				edge origE = pl.original(e);
+				if (origCycEdge != nullptr
+						&& pl.getEdgePairPartition()->isFree({origE, origCycEdge})) {
+					crossableWithCycle = true;
+					break;
+				}
+			}
+		}
+		if (!crossableWithCycle) {
+			contractableEdges.push_back(e);
+		}
+	}
+
+	for (edge e : contractableEdges) {
+		edge eCopy = cp.copy(e);
+		OGDF_ASSERT(eCopy->source()->degree() > 0 && eCopy->target()->degree() > 0);
+		if (cycleNodes.isMember(e->source()) || cycleNodes.isMember(e->target())) {
+			continue;
+		}
+
+		if (eCopy->target() == v1 || eCopy->target() == v2) {
+			cp.reverseEdge(eCopy);
+		}
+
+		if (eCopy->source() != eCopy->target()) {
+			if (eCopy->target() == v1) {
+				v1 = eCopy->source();
+			}
+			if (eCopy->target() == v2) {
+				v2 = eCopy->source();
+			}
+			cp.contract(eCopy, true);
+		}
+	}
+}
+
+int SeparatingCycleFilter::minFreeEdgeCycle(const OnePlanarization& pl, node crossingVertex,
+		NodePair& cyclePair, NodePair& otherPair, EdgeSet& cycleEdges, NodeSet& cycleNodes) {
+	cycleEdges.init(pl);
+	cycleNodes.init(pl);
+	node start = cyclePair.source;
+	node target = cyclePair.target;
+	deque<node> q {start};
+	NodeArray<adjEntry> parent(pl, nullptr);
+	NodeArray<int> dist(pl, INT_MAX - 1);
+	dist[start] = 0;
+
+	while (!q.empty()) { // 0-1 BFS
+		node next = q.front();
+		q.pop_front();
+		if (next == target) {
+			break;
+		}
+
+		for (adjEntry adj : next->adjEntries) {
+			node neigh = adj->twinNode();
+			OGDF_ASSERT(neigh != crossingVertex);
+			if (neigh == otherPair.source || neigh == otherPair.target) {
+				continue;
+			}
+			int edgeWeight = pl.freeEdges().isMember(adj->theEdge());
+			if (dist[next] + edgeWeight < dist[neigh]) {
+				dist[neigh] = dist[next] + edgeWeight;
+				parent[neigh] = adj->twin();
+				if (edgeWeight == 1) {
+					q.push_back(neigh);
+				} else {
+					q.push_front(neigh);
+				}
+			}
+		}
+	}
+
+	if (parent[target] == nullptr) {
+		return INT_MAX;
+	}
+
+	OGDF_ASSERT(dist[target] < INT_MAX - 1);
+	node cur = parent[target]->twinNode();
+	cycleEdges.insert(parent[target]->theEdge());
+	cycleNodes.insert(start);
+	cycleNodes.insert(target);
+	while (cur != start) {
+		cycleEdges.insert(parent[cur]->theEdge());
+		cycleNodes.insert(cur);
+		cur = parent[cur]->twinNode();
+	}
+
+	return dist[target];
+}

--- a/test/resources/north/g.10.27.gml
+++ b/test/resources/north/g.10.27.gml
@@ -1,0 +1,150 @@
+Creator "ogdf::GraphIO::writeGML"
+graph
+[
+	directed	1
+	node
+	[
+		id	0
+	]
+	node
+	[
+		id	1
+	]
+	node
+	[
+		id	2
+	]
+	node
+	[
+		id	3
+	]
+	node
+	[
+		id	4
+	]
+	node
+	[
+		id	5
+	]
+	node
+	[
+		id	6
+	]
+	node
+	[
+		id	7
+	]
+	node
+	[
+		id	8
+	]
+	node
+	[
+		id	9
+	]
+	edge
+	[
+		source	0
+		target	1
+	]
+	edge
+	[
+		source	0
+		target	2
+	]
+	edge
+	[
+		source	1
+		target	2
+	]
+	edge
+	[
+		source	1
+		target	3
+	]
+	edge
+	[
+		source	1
+		target	4
+	]
+	edge
+	[
+		source	1
+		target	5
+	]
+	edge
+	[
+		source	1
+		target	6
+	]
+	edge
+	[
+		source	1
+		target	7
+	]
+	edge
+	[
+		source	2
+		target	3
+	]
+	edge
+	[
+		source	2
+		target	4
+	]
+	edge
+	[
+		source	2
+		target	5
+	]
+	edge
+	[
+		source	2
+		target	6
+	]
+	edge
+	[
+		source	2
+		target	7
+	]
+	edge
+	[
+		source	3
+		target	8
+	]
+	edge
+	[
+		source	8
+		target	4
+	]
+	edge
+	[
+		source	8
+		target	5
+	]
+	edge
+	[
+		source	8
+		target	7
+	]
+	edge
+	[
+		source	4
+		target	5
+	]
+	edge
+	[
+		source	4
+		target	6
+	]
+	edge
+	[
+		source	5
+		target	6
+	]
+	edge
+	[
+		source	7
+		target	9
+	]
+]

--- a/test/resources/north/g.13.94.gml
+++ b/test/resources/north/g.13.94.gml
@@ -1,0 +1,217 @@
+Creator "ogdf::GraphIO::writeGML"
+graph
+[
+	directed	1
+	node
+	[
+		id	0
+	]
+	node
+	[
+		id	1
+	]
+	node
+	[
+		id	2
+	]
+	node
+	[
+		id	3
+	]
+	node
+	[
+		id	4
+	]
+	node
+	[
+		id	5
+	]
+	node
+	[
+		id	6
+	]
+	node
+	[
+		id	7
+	]
+	node
+	[
+		id	8
+	]
+	node
+	[
+		id	9
+	]
+	node
+	[
+		id	10
+	]
+	node
+	[
+		id	11
+	]
+	node
+	[
+		id	12
+	]
+	edge
+	[
+		source	0
+		target	1
+	]
+	edge
+	[
+		source	0
+		target	2
+	]
+	edge
+	[
+		source	0
+		target	3
+	]
+	edge
+	[
+		source	0
+		target	4
+	]
+	edge
+	[
+		source	0
+		target	5
+	]
+	edge
+	[
+		source	0
+		target	6
+	]
+	edge
+	[
+		source	0
+		target	7
+	]
+	edge
+	[
+		source	0
+		target	8
+	]
+	edge
+	[
+		source	0
+		target	9
+	]
+	edge
+	[
+		source	0
+		target	10
+	]
+	edge
+	[
+		source	0
+		target	11
+	]
+	edge
+	[
+		source	0
+		target	12
+	]
+	edge
+	[
+		source	1
+		target	3
+	]
+	edge
+	[
+		source	1
+		target	9
+	]
+	edge
+	[
+		source	3
+		target	4
+	]
+	edge
+	[
+		source	4
+		target	10
+	]
+	edge
+	[
+		source	7
+		target	3
+	]
+	edge
+	[
+		source	7
+		target	5
+	]
+	edge
+	[
+		source	7
+		target	10
+	]
+	edge
+	[
+		source	5
+		target	4
+	]
+	edge
+	[
+		source	5
+		target	11
+	]
+	edge
+	[
+		source	9
+		target	4
+	]
+	edge
+	[
+		source	9
+		target	5
+	]
+	edge
+	[
+		source	9
+		target	8
+	]
+	edge
+	[
+		source	9
+		target	10
+	]
+	edge
+	[
+		source	8
+		target	7
+	]
+	edge
+	[
+		source	6
+		target	4
+	]
+	edge
+	[
+		source	6
+		target	9
+	]
+	edge
+	[
+		source	6
+		target	12
+	]
+	edge
+	[
+		source	2
+		target	1
+	]
+	edge
+	[
+		source	2
+		target	3
+	]
+	edge
+	[
+		source	2
+		target	6
+	]
+]

--- a/test/resources/north/g.18.1.gml
+++ b/test/resources/north/g.18.1.gml
@@ -1,0 +1,242 @@
+Creator "ogdf::GraphIO::writeGML"
+graph
+[
+	directed	1
+	node
+	[
+		id	0
+	]
+	node
+	[
+		id	1
+	]
+	node
+	[
+		id	2
+	]
+	node
+	[
+		id	3
+	]
+	node
+	[
+		id	4
+	]
+	node
+	[
+		id	5
+	]
+	node
+	[
+		id	6
+	]
+	node
+	[
+		id	7
+	]
+	node
+	[
+		id	8
+	]
+	node
+	[
+		id	9
+	]
+	node
+	[
+		id	10
+	]
+	node
+	[
+		id	11
+	]
+	node
+	[
+		id	12
+	]
+	node
+	[
+		id	13
+	]
+	node
+	[
+		id	14
+	]
+	node
+	[
+		id	15
+	]
+	node
+	[
+		id	16
+	]
+	node
+	[
+		id	17
+	]
+	edge
+	[
+		source	0
+		target	1
+	]
+	edge
+	[
+		source	0
+		target	2
+	]
+	edge
+	[
+		source	0
+		target	8
+	]
+	edge
+	[
+		source	0
+		target	11
+	]
+	edge
+	[
+		source	1
+		target	4
+	]
+	edge
+	[
+		source	1
+		target	7
+	]
+	edge
+	[
+		source	1
+		target	8
+	]
+	edge
+	[
+		source	1
+		target	12
+	]
+	edge
+	[
+		source	4
+		target	3
+	]
+	edge
+	[
+		source	4
+		target	6
+	]
+	edge
+	[
+		source	4
+		target	7
+	]
+	edge
+	[
+		source	4
+		target	8
+	]
+	edge
+	[
+		source	4
+		target	13
+	]
+	edge
+	[
+		source	3
+		target	5
+	]
+	edge
+	[
+		source	5
+		target	10
+	]
+	edge
+	[
+		source	5
+		target	14
+	]
+	edge
+	[
+		source	10
+		target	8
+	]
+	edge
+	[
+		source	10
+		target	11
+	]
+	edge
+	[
+		source	8
+		target	9
+	]
+	edge
+	[
+		source	9
+		target	12
+	]
+	edge
+	[
+		source	12
+		target	13
+	]
+	edge
+	[
+		source	15
+		target	12
+	]
+	edge
+	[
+		source	15
+		target	16
+	]
+	edge
+	[
+		source	16
+		target	8
+	]
+	edge
+	[
+		source	7
+		target	6
+	]
+	edge
+	[
+		source	7
+		target	15
+	]
+	edge
+	[
+		source	7
+		target	17
+	]
+	edge
+	[
+		source	6
+		target	3
+	]
+	edge
+	[
+		source	6
+		target	5
+	]
+	edge
+	[
+		source	6
+		target	9
+	]
+	edge
+	[
+		source	17
+		target	6
+	]
+	edge
+	[
+		source	14
+		target	10
+	]
+	edge
+	[
+		source	2
+		target	3
+	]
+]

--- a/test/resources/north/g.23.108.gml
+++ b/test/resources/north/g.23.108.gml
@@ -1,0 +1,262 @@
+Creator "ogdf::GraphIO::writeGML"
+graph
+[
+	directed	1
+	node
+	[
+		id	0
+	]
+	node
+	[
+		id	1
+	]
+	node
+	[
+		id	2
+	]
+	node
+	[
+		id	3
+	]
+	node
+	[
+		id	4
+	]
+	node
+	[
+		id	5
+	]
+	node
+	[
+		id	6
+	]
+	node
+	[
+		id	7
+	]
+	node
+	[
+		id	8
+	]
+	node
+	[
+		id	9
+	]
+	node
+	[
+		id	10
+	]
+	node
+	[
+		id	11
+	]
+	node
+	[
+		id	12
+	]
+	node
+	[
+		id	13
+	]
+	node
+	[
+		id	14
+	]
+	node
+	[
+		id	15
+	]
+	node
+	[
+		id	16
+	]
+	node
+	[
+		id	17
+	]
+	node
+	[
+		id	18
+	]
+	node
+	[
+		id	19
+	]
+	node
+	[
+		id	20
+	]
+	node
+	[
+		id	21
+	]
+	node
+	[
+		id	22
+	]
+	edge
+	[
+		source	0
+		target	1
+	]
+	edge
+	[
+		source	0
+		target	2
+	]
+	edge
+	[
+		source	0
+		target	3
+	]
+	edge
+	[
+		source	0
+		target	4
+	]
+	edge
+	[
+		source	0
+		target	5
+	]
+	edge
+	[
+		source	0
+		target	6
+	]
+	edge
+	[
+		source	1
+		target	7
+	]
+	edge
+	[
+		source	7
+		target	9
+	]
+	edge
+	[
+		source	7
+		target	10
+	]
+	edge
+	[
+		source	9
+		target	3
+	]
+	edge
+	[
+		source	3
+		target	12
+	]
+	edge
+	[
+		source	12
+		target	10
+	]
+	edge
+	[
+		source	12
+		target	13
+	]
+	edge
+	[
+		source	10
+		target	14
+	]
+	edge
+	[
+		source	14
+		target	13
+	]
+	edge
+	[
+		source	14
+		target	15
+	]
+	edge
+	[
+		source	13
+		target	16
+	]
+	edge
+	[
+		source	13
+		target	17
+	]
+	edge
+	[
+		source	13
+		target	18
+	]
+	edge
+	[
+		source	16
+		target	19
+	]
+	edge
+	[
+		source	19
+		target	20
+	]
+	edge
+	[
+		source	20
+		target	22
+	]
+	edge
+	[
+		source	21
+		target	22
+	]
+	edge
+	[
+		source	17
+		target	21
+	]
+	edge
+	[
+		source	18
+		target	21
+	]
+	edge
+	[
+		source	15
+		target	20
+	]
+	edge
+	[
+		source	6
+		target	19
+	]
+	edge
+	[
+		source	11
+		target	16
+	]
+	edge
+	[
+		source	8
+		target	9
+	]
+	edge
+	[
+		source	8
+		target	11
+	]
+	edge
+	[
+		source	2
+		target	8
+	]
+	edge
+	[
+		source	5
+		target	14
+	]
+	edge
+	[
+		source	4
+		target	12
+	]
+]

--- a/test/src/k-planarity/1-planarity_backtracking/oneplan-backtracking.cpp
+++ b/test/src/k-planarity/1-planarity_backtracking/oneplan-backtracking.cpp
@@ -1,0 +1,141 @@
+/** \file
+ * \brief Tests for OnePlanarityBacktracking.
+ *
+ * \author Matthias Pfretzschner
+ *
+ * \par License:
+ * This file is part of the Open Graph Drawing Framework (OGDF).
+ *
+ * \par
+ * Copyright (C)<br>
+ * See README.md in the OGDF root directory for details.
+ *
+ * \par
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * Version 2 or 3 as published by the Free Software Foundation;
+ * see the file LICENSE.txt included in the packaging of this file
+ * for details.
+ *
+ * \par
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * \par
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, see
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#include <ogdf/basic/Graph.h>
+#include <ogdf/basic/GraphSets.h>
+#include <ogdf/basic/List.h>
+#include <ogdf/basic/Module.h>
+#include <ogdf/basic/graph_generators/deterministic.h>
+#include <ogdf/k-planarity/1-planarity_backtracking/EdgePairPartition.h>
+#include <ogdf/k-planarity/1-planarity_backtracking/OnePlanarityBacktracking.h>
+#include <ogdf/k-planarity/1-planarity_backtracking/OnePlanarization.h>
+
+#include <functional>
+#include <set>
+#include <string>
+#include <vector>
+
+#include <graphs.h>
+#include <resources.h>
+
+#include <testing.h>
+
+using namespace oneplan_backtracking;
+
+void testGraph(const Graph& G, OneplanMode mode, bool yesInstance) {
+	OnePlanarityBacktracking solver;
+	OnePlanarization opl;
+	Module::ReturnType res;
+	switch (mode) {
+	case OneplanMode::IC:
+		res = solver.testICPlanarity(G, &opl);
+		break;
+	case OneplanMode::NIC:
+		res = solver.testNICPlanarity(G, &opl);
+		break;
+	case OneplanMode::Normal:
+	default:
+		res = solver.testOnePlanarity(G, &opl);
+		break;
+	}
+
+	if (yesInstance) {
+		AssertThat(res, Equals(Module::ReturnType::Feasible));
+		AssertThat(opl.isPlanar(), IsTrue());
+		AssertThat(opl.numberOfNodes(), Equals(G.numberOfNodes() + opl.crossingVertices().size()));
+
+		EdgeSet mappedEdges(G);
+		for (edge e : opl.crossingEdges()) {
+			AssertThat(opl.original(e), !IsNull());
+			mappedEdges.insert(opl.original(e));
+		}
+		for (edge e : opl.freeEdges()) {
+			AssertThat(opl.original(e), !IsNull());
+			mappedEdges.insert(opl.original(e));
+		}
+
+		for (edge e : opl.kiteEdges()) {
+			AssertThat(opl.original(e), IsNull());
+		}
+
+		for (edge e : opl.remainingEdges()) {
+			AssertThat(opl.original(e), !IsNull());
+			mappedEdges.insert(opl.original(e));
+		}
+		AssertThat(mappedEdges.size(), Equals(G.numberOfEdges()));
+	} else {
+		AssertThat(res, Equals(Module::ReturnType::NoFeasibleSolution));
+	}
+}
+
+go_bandit([]() {
+	describe("1-Planarity test", []() {
+		it("works for planar graphs", []() {
+			forEachGraphItWorks({GraphProperty::planar, GraphProperty::simple}, [&](Graph& G) {
+				testGraph(G, OneplanMode::Normal, true);
+				testGraph(G, OneplanMode::NIC, true);
+				testGraph(G, OneplanMode::IC, true);
+			});
+		});
+		it("works for trivially non-planar graphs", []() {
+			Graph G;
+			completeGraph(G, 10);
+			testGraph(G, OneplanMode::Normal, false);
+			testGraph(G, OneplanMode::NIC, false);
+			testGraph(G, OneplanMode::IC, false);
+		});
+
+		for_each_graph_it("works", {"north/g.41.26.gml", "north/g.73.8.gml", "north/g.18.1.gml"},
+				[&](Graph& G) {
+					testGraph(G, OneplanMode::Normal, true);
+					testGraph(G, OneplanMode::NIC, true);
+					testGraph(G, OneplanMode::IC, false);
+				});
+
+		for_each_graph_it("works", {"north/g.13.94.gml"}, [&](Graph& G) {
+			testGraph(G, OneplanMode::Normal, false);
+			testGraph(G, OneplanMode::NIC, false);
+			testGraph(G, OneplanMode::IC, false);
+		});
+
+		for_each_graph_it("works", {"north/g.23.108.gml"}, [&](Graph& G) {
+			testGraph(G, OneplanMode::Normal, true);
+			testGraph(G, OneplanMode::NIC, true);
+			testGraph(G, OneplanMode::IC, true);
+		});
+
+		for_each_graph_it("works", {"north/g.10.27.gml"}, [&](Graph& G) {
+			testGraph(G, OneplanMode::Normal, true);
+			testGraph(G, OneplanMode::NIC, false);
+			testGraph(G, OneplanMode::IC, false);
+		});
+	});
+});

--- a/test/src/k-planarity/1-planarity_backtracking/oneplan-backtracking.cpp
+++ b/test/src/k-planarity/1-planarity_backtracking/oneplan-backtracking.cpp
@@ -137,5 +137,12 @@ go_bandit([]() {
 			testGraph(G, OneplanMode::NIC, false);
 			testGraph(G, OneplanMode::IC, false);
 		});
+
+		for_each_graph_it("works with fewer threads", {"north/g.10.27.gml"}, [&](Graph& G) {
+			OnePlanarityBacktracking solver(1);
+			AssertThat(solver.testOnePlanarity(G), Equals(Module::ReturnType::Feasible));
+			AssertThat(solver.testNICPlanarity(G), Equals(Module::ReturnType::NoFeasibleSolution));
+			AssertThat(solver.testICPlanarity(G), Equals(Module::ReturnType::NoFeasibleSolution));
+		});
 	});
 });


### PR DESCRIPTION
Implementation of the backtracking procedure for 1-Planarity introduced in 

> Simon D. Fink, Miriam Münch, Matthias Pfretzschner, and Ignaz Rutter. Heuristics for Exact 1-Planarity Testing, GD 2025 (to appear, pre-proceedings available [here](https://submission.dagstuhl.de/collections/nRkgFYuBzJ4EhEkOGRZd/preliminary-proceedings))

This implementation finds edge pairs to branch over using Kuratowski-Subdivisions of the graph and uses filters to reject non-realizable partial solutions early to shrink the search space. Moreover, it explores the search space using multiple depth-first searches running alternatingly to increase the likelihood of finding solutions with few crossings early.

Also supports testing for IC-Planarity and NIC-Planarity.