### PR TITLE
MSVC C++ does not properly support the __cplusplus macro

### DIFF
--- a/include/ogdf/basic/internal/config.h
+++ b/include/ogdf/basic/internal/config.h
@@ -62,13 +62,17 @@ using std::to_string;
 #	define OGDF_SYSTEM_OSX
 #endif
 
+#ifdef _MSVC_LANG
+#	define OGDF_CPLUSPLUS _MSVC_LANG
+#else
+#	define OGDF_CPLUSPLUS __cplusplus
+#endif
+
 // C++17 standard
-#if __cplusplus < 201703
+#if OGDF_CPLUSPLUS < 201703L
 
 #	if defined(_MSC_VER)
-#		if _MSC_VER < 1915
-#			error "Compiling OGDF requires C++17 (Visual Studio 2017 15.8) or higher!"
-#		endif
+#		error "Compiling OGDF requires C++17 (Visual Studio 2017 15.8) or higher!"
 
 #	elif defined(__GNUC__)
 #		error "Compiling OGDF requires C++17 (compile with -std=c++17)!"
@@ -81,7 +85,7 @@ using std::to_string;
 
 #ifdef __has_cpp_attribute
 #	define OGDF_HAS_CPP_ATTRIBUTE(x) \
-		(__has_cpp_attribute(x) && __cplusplus >= __has_cpp_attribute(x))
+		(__has_cpp_attribute(x) && OGDF_CPLUSPLUS >= __has_cpp_attribute(x))
 #else
 #	define OGDF_HAS_CPP_ATTRIBUTE(x) 0
 #endif

--- a/src/ogdf/energybased/spring_embedder/SEGV_ForceModel.cpp
+++ b/src/ogdf/energybased/spring_embedder/SEGV_ForceModel.cpp
@@ -32,6 +32,7 @@
 #include <ogdf/basic/Array.h>
 #include <ogdf/basic/Array2D.h>
 #include <ogdf/basic/List.h>
+#include <ogdf/basic/basic.h>
 #include <ogdf/basic/geometry.h>
 #include <ogdf/energybased/SpringEmbedderGridVariant.h>
 #include <ogdf/energybased/spring_embedder/SEGV_ForceModel.h>
@@ -120,7 +121,7 @@ DPoint SpringEmbedderGridVariant::ForceModelFRModRep::computeDisplacement(int j,
 
 // Eades
 DPoint SpringEmbedderGridVariant::ForceModelEades::computeDisplacement(int j, double boxLength) const {
-#if __cplusplus >= 202002L
+#if OGDF_CPLUSPLUS >= 202002L
 	return computeMixedForcesDisplacement(
 			j, boxLength,
 			[=, this](double d, const DPoint& dist) {
@@ -142,7 +143,7 @@ DPoint SpringEmbedderGridVariant::ForceModelEades::computeDisplacement(int j, do
 // Hachul (new method)
 DPoint SpringEmbedderGridVariant::ForceModelHachul::computeDisplacement(int j,
 		double boxLength) const {
-#if __cplusplus >= 202002L
+#if OGDF_CPLUSPLUS >= 202002L
 	return computeMixedForcesDisplacement(
 			j, boxLength,
 			[=, this](double d, const DPoint& dist) {
@@ -164,7 +165,7 @@ DPoint SpringEmbedderGridVariant::ForceModelHachul::computeDisplacement(int j,
 // Gronemann
 DPoint SpringEmbedderGridVariant::ForceModelGronemann::computeDisplacement(int j,
 		double boxLength) const {
-#if __cplusplus >= 202002L
+#if OGDF_CPLUSPLUS >= 202002L
 	return computeMixedForcesDisplacement(
 			j, boxLength,
 			[=, this](double d, const DPoint& dist) {

--- a/test/include/bandit/assertion_frameworks/snowhouse/README.md
+++ b/test/include/bandit/assertion_frameworks/snowhouse/README.md
@@ -546,8 +546,8 @@ The `.clang-format` file allows easy checking and implementation of the
 coding style.
 
 C++ code should comply to C++11.
-Please use `__cplusplus` guards if you want to use language features of
-a certain C++ version.
+Please use `OGDF_CPLUSPLUS` guards (portable way to access `__cplusplus`)
+if you want to use language features of a certain C++ version.
 
 ## Responsibilities
 


### PR DESCRIPTION
In MSVC it always reports 199711L and Microsoft recommends to use _MSVC_LANG (cf. <https://learn.microsoft.com/de-de/cpp/build/reference/zc-cplusplus>).

Introduce `OGDF_CPLUSPLUS` macro to implement portable checks easily.

Updates for Pugixml are in PR #290 .