### PR TITLE
Fix MSVC warning C4670: 'exception' : this base class is inaccessible

### DIFF
--- a/include/ogdf/basic/exceptions.h
+++ b/include/ogdf/basic/exceptions.h
@@ -163,7 +163,7 @@ enum class LibraryNotSupportedCode {
 /**
  * @ingroup exceptions
  */
-class OGDF_EXPORT Exception : std::exception {
+class OGDF_EXPORT Exception : public std::exception {
 private:
 	const char* m_file; //!< Source file where exception occurred.
 	int m_line; //!< Line number where exception occurred.


### PR DESCRIPTION
I statically link ogdf in TortoiseGit and get this warning.