### PR TITLE
Fix build with Gurobi as solver

### DIFF
--- a/include/coin/OsiGrbSolverInterface.hpp
+++ b/include/coin/OsiGrbSolverInterface.hpp
@@ -17,6 +17,7 @@
 
 #include <string>
 #include "OsiSolverInterface.hpp"
+#include "CoinPackedMatrix.hpp"
 
 typedef struct _GRBmodel GRBmodel;
 typedef struct _GRBenv GRBenv;


### PR DESCRIPTION
When compiling with `-DCOIN_SOLVER=GRB` , I was getting `incomplete type` errors in lots of files. I fixed this by adding an `#include` that was already present in `OsiClpSolverInterface.hpp` but missing in `OsiGrbSolverInterface.hpp`. I'm not sure this is the best fix but it works.